### PR TITLE
feat: WhatsApp-like notification to emoji modal functionality

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -1,188 +1,152 @@
 package com.datainfers.zync
 
-import android.util.Log
-import android.widget.Toast
-import android.os.Bundle
+import android.Manifest
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.app.PendingIntent
+import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
-import com.datainfers.zync.QuickActionReceiver
 
 class MainActivity: FlutterActivity() {
-    private lateinit var methodChannel: MethodChannel
-    
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        Log.d("ZYNC", "onCreate llamado - inicializando MethodChannel...")
-        
-        // Manejar intent inicial si viene desde notificación
-        handleQuickStatusIntent(intent)
-        
-        // Procesar intent inicial si viene desde notificación
-        if (intent.getBooleanExtra("show_quick_modal", false)) {
-            Log.d("ZYNC", "show_quick_modal detectado en onCreate")
-            Toast.makeText(this, "Modal desde onCreate", Toast.LENGTH_SHORT).show()
-        }
-    }
-    
-    override fun provideFlutterEngine(context: Context): FlutterEngine? {
-        val engine = super.provideFlutterEngine(context) ?: FlutterEngine(context)
-        io.flutter.embedding.engine.FlutterEngineCache.getInstance().put("my_engine_id", engine)
-        return engine
-    }
-    private val CHANNEL = "zync/notification"
-    private val NOTIFICATION_ID = 12346
+    private val CHANNEL = "mini_emoji/notification"
+    private val NOTIFICATION_ID = 12345
+    private val NOTIFICATION_PERMISSION_REQUEST_CODE = 100
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-        Log.d("ZYNC", "Configurando Flutter Engine y MethodChannel...")
         
-        // Inicializar MethodChannel aquí donde SÍ se ejecuta
-        methodChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
-        Log.d("ZYNC", "MethodChannel creado como propiedad de clase")
-        methodChannel.setMethodCallHandler { call, result ->
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
-                "hideCustomNotification" -> {
-                    hideCustomNotification()
-                    result.success(null)
+                "requestNotificationPermission" -> {
+                    requestNotificationPermission()
+                    result.success("Permisos solicitados")
                 }
-                "updateNotificationWithActions" -> {
-                    val actions = call.argument<List<Map<String, String>>>("actions")
-                    if (actions != null) {
-                        updateNotificationWithActions(actions)
+                "showNotification" -> {
+                    if (hasNotificationPermission()) {
+                        showPersistentNotification()
+                        result.success("Notificación mostrada")
+                    } else {
+                        result.error("NO_PERMISSION", "Permisos de notificación requeridos", null)
                     }
-                    result.success(null)
                 }
                 else -> result.notImplemented()
             }
         }
     }
-
-    // Solo una función onNewIntent, combinando ambas lógicas
+    
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        Log.d("ZYNC", "onNewIntent recibido")
-        Toast.makeText(this, "onNewIntent recibido", Toast.LENGTH_SHORT).show()
-        
-        // IMPORTANTE: Establecer el nuevo intent como el intent actual
         setIntent(intent)
-        
-        // Debug: Imprimir todos los extras del intent
-        Log.d("ZYNC", "Intent extras: " + intent.extras?.toString())
-        val hasModalExtra = intent.getBooleanExtra("show_quick_modal", false)
-        val hasFlutterForegroundExtra = intent.getStringExtra("intentData") == "onNotificationPressed"
-        
-        Log.d("ZYNC", "show_quick_modal extra value: $hasModalExtra")
-        Log.d("ZYNC", "FlutterForegroundTask extra detected: $hasFlutterForegroundExtra")
-        
-        handleQuickStatusIntent(intent)
-        
-        // Tratar AMBOS casos como modal request
-        if (hasModalExtra || hasFlutterForegroundExtra) {
-            Log.d("ZYNC", "Modal solicitado (nativo o FlutterForegroundTask), enviando a Flutter")
-            Toast.makeText(this, "Modal detectado!", Toast.LENGTH_SHORT).show()
-            
-            // Usar Handler para asegurar que Flutter esté listo
-            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
-                Log.d("ZYNC", "Enviando showQuickStatusModal a Flutter (con delay)")
-                Log.d("ZYNC", "Verificando si methodChannel está inicializado...")
-                
-                try {
-                    if (::methodChannel.isInitialized) {
-                        Log.d("ZYNC", "MethodChannel está inicializado, enviando método...")
-                        methodChannel.invokeMethod("showQuickStatusModal", null)
-                        Log.d("ZYNC", "Método enviado exitosamente")
-                    } else {
-                        Log.e("ZYNC", "ERROR: methodChannel NO está inicializado")
-                    }
-                } catch (e: Exception) {
-                    Log.e("ZYNC", "Error enviando a MethodChannel: $e")
-                }
-            }, 200) // 200ms delay
-        } else {
-            Log.d("ZYNC", "NO se detectó solicitud de modal")
-            Toast.makeText(this, "NO solicitud de modal", Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    private fun handleQuickStatusIntent(intent: Intent) {
-        val action = intent.getStringExtra("quick_status_action")
-        if (action != null) {
-            // Enviar a Flutter por MethodChannel
-            val engine = io.flutter.embedding.engine.FlutterEngineCache.getInstance().get("my_engine_id")
-            if (engine != null) {
-                MethodChannel(engine.dartExecutor.binaryMessenger, CHANNEL)
-                    .invokeMethod("onQuickStatusSelected", action)
-            } else {
-                // fallback si engine no está cacheado
-                MethodChannel(flutterEngine?.dartExecutor?.binaryMessenger ?: return, CHANNEL)
-                    .invokeMethod("onQuickStatusSelected", action)
+        if (intent.getBooleanExtra("open_emoji_modal", false)) {
+            // Enviar a Flutter para abrir modal
+            flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
+                val channel = MethodChannel(messenger, CHANNEL)
+                channel.invokeMethod("showEmojiModal", null)
             }
         }
     }
 
+    private fun hasNotificationPermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            // En versiones anteriores a Android 13, los permisos se otorgan automáticamente
+            true
+        }
+    }
 
+    private fun requestNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (!hasNotificationPermission()) {
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                    NOTIFICATION_PERMISSION_REQUEST_CODE
+                )
+            }
+        }
+    }
 
-    private fun updateNotificationWithActions(actions: List<Map<String, String>>) {
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        when (requestCode) {
+            NOTIFICATION_PERMISSION_REQUEST_CODE -> {
+                if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    // Permisos otorgados, podemos mostrar notificaciones
+                    showPersistentNotification()
+                } else {
+                    // Permisos denegados
+                    println("❌ Permisos de notificación denegados")
+                }
+            }
+        }
+    }
+
+    private fun showPersistentNotification() {
         createNotificationChannel()
-        // Intent para lanzar MainActivity con un extra especial
-        val mainIntent = Intent(this, MainActivity::class.java)
-        mainIntent.putExtra("show_quick_modal", true)
-        mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-        Log.d("ZYNC", "Intent para PendingIntent: extras=" + mainIntent.extras?.toString())
         
-        // CAMBIAMOS requestCode para forzar actualización del PendingIntent
-        val mainPendingIntent = PendingIntent.getActivity(
-            this, System.currentTimeMillis().toInt(), mainIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("open_emoji_modal", true)
+        }
+        
+        val pendingIntent = PendingIntent.getActivity(
+            this, 
+            0, 
+            intent, 
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val builder = NotificationCompat.Builder(this, "zync_quick_status_channel")
-            .setContentTitle("Zync Activo")
-            .setContentText("Toca para abrir Zync y enviar estado rápido")
-            .setSmallIcon(R.drawable.ic_transparent) // Asegúrate de tener este recurso
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setContentIntent(mainPendingIntent)
+        val notification = NotificationCompat.Builder(this, "emoji_channel")
+            .setContentTitle("🎯 Mini Emoji App")
+            .setContentText("Toca para abrir modal de emojis")
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
             .setAutoCancel(false)
             .setOngoing(true)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
 
-        // NO agregamos acciones de emojis - solo modal
-        NotificationManagerCompat.from(this).notify(NOTIFICATION_ID, builder.build())
-        Log.d("ZYNC", "Notificación creada con requestCode dinámico")
-    }
-
-    // Utilidad para evitar notificaciones duplicadas
-    private fun isNotificationActive(notificationId: Int): Boolean {
-        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val activeNotifications = notificationManager.activeNotifications
-            return activeNotifications.any { it.id == notificationId }
+        try {
+            NotificationManagerCompat.from(this).notify(NOTIFICATION_ID, notification)
+            println("✅ Notificación creada exitosamente")
+        } catch (e: SecurityException) {
+            println("❌ Error de permisos al crear notificación: ${e.message}")
         }
-        return false
-    }
-
-    private fun hideCustomNotification() {
-        NotificationManagerCompat.from(this).cancel(NOTIFICATION_ID)
     }
 
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                "zync_quick_status_channel",
-                "Zync Quick Actions",
-                NotificationManager.IMPORTANCE_LOW
+                "emoji_channel",
+                "Mini Emoji Notifications",
+                NotificationManager.IMPORTANCE_DEFAULT
             ).apply {
-                description = "Servicio de Zync para acciones rápidas."
+                description = "Notificaciones para abrir modal de emojis"
+                enableLights(true)
+                enableVibration(false)
+                setShowBadge(true)
             }
             val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.createNotificationChannel(channel)
+            println("✅ Canal de notificación creado")
         }
     }
 }

--- a/lib/core/widgets/emoji_modal.dart
+++ b/lib/core/widgets/emoji_modal.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:zync_app/features/circle/domain/entities/user_status.dart';
+import 'package:zync_app/features/circle/domain/usecases/send_user_status.dart';
+import 'package:zync_app/features/auth/presentation/provider/auth_provider.dart';
+import 'package:zync_app/features/auth/presentation/provider/auth_state.dart';
+import 'package:zync_app/features/circle/presentation/provider/circle_provider.dart';
+import 'package:zync_app/features/circle/presentation/provider/circle_state.dart';
+import 'package:zync_app/core/di/injection_container.dart' as di;
+
+class EmojiModal extends ConsumerStatefulWidget {
+  const EmojiModal({super.key});
+
+  @override
+  ConsumerState<EmojiModal> createState() => _EmojiModalState();
+}
+
+class _EmojiModalState extends ConsumerState<EmojiModal> {
+  bool _showCheck = false;
+  bool _isSending = false;
+
+  // Mapear emojis del modal con StatusType existentes
+  final List<StatusType> emojis = const [
+    StatusType.fine,     // 😊 Feliz -> Bien
+    StatusType.sad,      // 😢 Triste
+    StatusType.worried,  // 😡 -> Preocupado (más cercano a enojado)
+    StatusType.thinking, // 🤔 Pensativo
+    StatusType.sos,      // 🆘 SOS
+    StatusType.busy,     // 🔥 Ocupado
+  ];
+
+  Future<void> _onStatusTap(StatusType status) async {
+    final authState = ref.read(authProvider);
+    final circleState = ref.read(circleProvider);
+    
+    final userId = authState is Authenticated ? authState.user.uid : null;
+    String? circleId;
+    if (circleState is CircleLoaded) {
+      circleId = circleState.circle.id;
+    }
+
+    if (userId != null && circleId != null && !_isSending) {
+      setState(() => _isSending = true);
+      try {
+        final sendUserStatus = di.sl<SendUserStatus>();
+        await sendUserStatus(SendUserStatusParams(
+          circleId: circleId,
+          statusType: status,
+        ));
+        setState(() => _showCheck = true);
+        await Future.delayed(const Duration(milliseconds: 900));
+        if (mounted) Navigator.of(context).pop();
+      } catch (e) {
+        // Si hay error, mostrar mensaje pero cerrar modal
+        if (mounted) {
+          Navigator.of(context).pop();
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('❌ Error: $e'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    } else {
+      if (mounted) Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 350, maxHeight: 400),
+        padding: const EdgeInsets.all(20.0),
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            AnimatedOpacity(
+              opacity: _showCheck ? 0.0 : 1.0,
+              duration: const Duration(milliseconds: 250),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text(
+                    '🎯 ¡FUNCIONÓ! Modal desde notificación',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.green),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 20),
+                  Flexible(
+                    child: GridView.builder(
+                      shrinkWrap: true,
+                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3,
+                        crossAxisSpacing: 12,
+                        mainAxisSpacing: 12,
+                        childAspectRatio: 1,
+                      ),
+                      itemCount: emojis.length,
+                      itemBuilder: (context, index) {
+                        final emoji = emojis[index];
+                        return GestureDetector(
+                          onTap: () => _onStatusTap(emoji),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.grey[100],
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: Colors.grey[300]!),
+                            ),
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  emoji.emoji,
+                                  style: const TextStyle(fontSize: 24),
+                                ),
+                                const SizedBox(height: 4),
+                                Flexible(
+                                  child: Text(
+                                    emoji.description,
+                                    style: const TextStyle(fontSize: 10),
+                                    textAlign: TextAlign.center,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Cerrar'),
+                  ),
+                ],
+              ),
+            ),
+            AnimatedScale(
+              scale: _showCheck ? 1.0 : 0.7,
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.easeOutBack,
+              child: AnimatedOpacity(
+                opacity: _showCheck ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 250),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.green[100],
+                    shape: BoxShape.circle,
+                  ),
+                  padding: const EdgeInsets.all(24),
+                  child: Icon(Icons.check_circle_rounded, color: Colors.green[700], size: 56),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/circle/presentation/pages/home_page.dart
+++ b/lib/features/circle/presentation/pages/home_page.dart
@@ -12,6 +12,7 @@ import 'package:zync_app/features/circle/presentation/provider/circle_state.dart
 import 'package:zync_app/features/circle/presentation/pages/quick_status_selector_page.dart';
 import 'package:zync_app/features/circle/presentation/widgets/in_circle_view.dart';
 import 'package:zync_app/features/circle/presentation/widgets/no_circle_view.dart';
+import 'package:zync_app/main.dart';
 
 // --- CAMBIO 1: Convertir a ConsumerStatefulWidget para tener acceso a initState ---
 class HomePage extends ConsumerStatefulWidget {
@@ -35,6 +36,15 @@ class _HomePageState extends ConsumerState<HomePage> {
     final status = await Permission.notification.request();
     if (status.isGranted) {
       log('Notification permission has been granted.');
+      
+      // 🎯 AUTOMATIZAR: Crear notificación emoji automáticamente
+      try {
+        await EmojiNotificationService.requestNotificationPermission();
+        await EmojiNotificationService.showNotification();
+        log('✅ Notificación emoji creada automáticamente');
+      } catch (e) {
+        log('❌ Error creando notificación emoji: $e');
+      }
     } else {
       log('Notification permission has been denied.');
     }

--- a/lib/features/circle/presentation/pages/quick_status_selector_page.dart
+++ b/lib/features/circle/presentation/pages/quick_status_selector_page.dart
@@ -10,7 +10,7 @@ import 'package:zync_app/core/di/injection_container.dart' as di;
 
 
 class QuickStatusSelectorPage extends ConsumerWidget {
-  const QuickStatusSelectorPage({Key? key}) : super(key: key);
+  const QuickStatusSelectorPage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/features/circle/presentation/widgets/quick_status_send_dialog.dart
+++ b/lib/features/circle/presentation/widgets/quick_status_send_dialog.dart
@@ -7,7 +7,7 @@ class QuickStatusSendDialog extends StatefulWidget {
   final StatusType statusType;
   final String userId;
   final String circleId;
-  const QuickStatusSendDialog({Key? key, required this.statusType, required this.userId, required this.circleId}) : super(key: key);
+  const QuickStatusSendDialog({super.key, required this.statusType, required this.userId, required this.circleId});
   @override
   State<QuickStatusSendDialog> createState() => _QuickStatusSendDialogState();
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:zync_app/features/circle/presentation/pages/home_page.dart';
 import 'package:zync_app/features/circle/services/quick_status_service.dart';
 // import 'package:zync_app/features/circle/presentation/widgets/quick_status_send_dialog.dart';
 import 'package:zync_app/features/circle/presentation/pages/quick_status_selector_page.dart';
+import 'package:zync_app/core/widgets/emoji_modal.dart';
 // import 'package:zync_app/features/circle/domain/entities/user_status.dart';
 // import 'package:zync_app/features/circle/presentation/provider/circle_provider.dart';
 // import 'package:zync_app/features/circle/presentation/provider/circle_state.dart';
@@ -62,6 +63,7 @@ void _setupMethodChannelEarly() {
   }
   
   final MethodChannel channel = MethodChannel('zync/notification');
+  final MethodChannel emojiChannel = MethodChannel('mini_emoji/notification');
   print('🔥🔥🔥 [FLUTTER] MethodChannel configurado TEMPRANO en main()');
   _methodChannelConfigured = true;
   
@@ -71,6 +73,7 @@ void _setupMethodChannelEarly() {
     channel.invokeMethod('showQuickStatusModal', {});
   });
   
+  // Handler para el canal original de ZYNC
   channel.setMethodCallHandler((call) async {
     print('🔥🔥🔥 [FLUTTER] MethodChannel call recibido: ${call.method}');
     print('🔥🔥🔥 [FLUTTER] Arguments: ${call.arguments}');
@@ -91,6 +94,31 @@ void _setupMethodChannelEarly() {
           );
         } else {
           print('🔥🔥🔥 [FLUTTER] ERROR: Context es null, no se puede navegar');
+        }
+      });
+    }
+  });
+  
+  // Handler para el canal del mini_emoji_app
+  emojiChannel.setMethodCallHandler((call) async {
+    print('🎯 [EMOJI] MethodChannel call recibido: ${call.method}');
+    
+    if (call.method == 'showEmojiModal') {
+      print('🎯 [EMOJI] ¡showEmojiModal llamado desde Android!');
+      
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final context = rootNavigatorKey.currentContext;
+        if (context != null) {
+          print('🎯 [EMOJI] Context encontrado, mostrando EmojiModal');
+          showDialog(
+            context: context,
+            barrierDismissible: false,
+            builder: (BuildContext context) {
+              return const EmojiModal();
+            },
+          );
+        } else {
+          print('🎯 [EMOJI] ERROR: Context es null, no se puede mostrar modal');
         }
       });
     }
@@ -119,6 +147,29 @@ class MyApp extends ConsumerWidget {
         ),
       },
     );
+  }
+}
+
+// Funciones utilitarias para la funcionalidad del emoji modal
+class EmojiNotificationService {
+  static const MethodChannel _channel = MethodChannel('mini_emoji/notification');
+
+  static Future<void> requestNotificationPermission() async {
+    try {
+      await _channel.invokeMethod('requestNotificationPermission');
+      print('✅ Permisos de notificación solicitados');
+    } on PlatformException catch (e) {
+      print('❌ Error solicitando permisos: ${e.message}');
+    }
+  }
+
+  static Future<void> showNotification() async {
+    try {
+      await _channel.invokeMethod('showNotification');
+      print('✅ Notificación mostrada');
+    } on PlatformException catch (e) {
+      print('❌ Error mostrando notificación: ${e.message}');
+    }
   }
 }
 


### PR DESCRIPTION
🎯 CORE FUNCTIONALITY:
- Persistent notification that opens emoji modal when tapped
- Modal automatically updates user status in Firestore
- Works always, even with app open (WhatsApp-like behavior)

📱 ANDROID CHANGES (MainActivity.kt):
- Complete rewrite with working mini_emoji_app logic
- MethodChannel 'mini_emoji/notification' for Flutter-Android communication
- Persistent notification with PendingIntent to modal
- Full Android 13+ permissions handling (POST_NOTIFICATIONS)
- onNewIntent() redirects notification taps to Flutter

🎨 FLUTTER CHANGES:
- EmojiModal: ConsumerStatefulWidget with Firestore integration
- main.dart: Dual MethodChannel (zync + mini_emoji) with modal navigation
- HomePage: Full automation - creates notification on app start
- StatusType mapping: Modal emojis map to existing DB states

✨ AUTOMATION:
- App opens: Permissions → Automatic emoji notification
- Tap notification: Instant emoji modal
- Select emoji: Update Firestore → Success animation → Close modal

📊 DATABASE INTEGRATION:
- SendUserStatus usecase for status updates
- StatusType enum: fine, sad, worried, thinking, sos, busy
- Riverpod provider system for reactive state management

🚀 RESULT:
- Complete WhatsApp-like experience working
- Notification→Modal→Database seamless flow
- No manual buttons - fully automated in initState()

Replicates mini_emoji_app success integrated with ZYNC architecture.