### PR TITLE
fix(geofencing): smallest radius zone wins when zones overlap

### DIFF
--- a/lib/features/geofencing/services/geofencing_service.dart
+++ b/lib/features/geofencing/services/geofencing_service.dart
@@ -108,14 +108,13 @@ class GeofencingService {
         return;
       }
 
-      // Verificar en qué zona está el usuario
-      Zone? detectedZone;
-      for (final zone in zones) {
-        if (zone.containsLocation(latitude, longitude)) {
-          detectedZone = zone;
-          break; // Solo consideramos la primera zona donde está
-        }
-      }
+      // Verificar en qué zona está el usuario.
+      // Si hay zonas solapadas, gana la de menor radio (más específica).
+      final containingZones = zones
+          .where((z) => z.containsLocation(latitude, longitude))
+          .toList()
+        ..sort((a, b) => a.radiusMeters.compareTo(b.radiusMeters));
+      final detectedZone = containingZones.isNotEmpty ? containingZones.first : null;
 
       // Detectar cambios de zona
       await _detectZoneTransition(


### PR DESCRIPTION
## Summary
- Corrige comportamiento no determinístico cuando el usuario está dentro de múltiples zonas solapadas
- **Antes:** se tomaba la primera zona en el orden de la lista de Firestore (sin garantía de orden)
- **Después:** se ordenan las zonas por radio ascendente y gana la más específica (menor radio)

## Ejemplo
- 🏠 Casa (200m) solapada con 🏫 Colegio (300m) → antes: resultado aleatorio → ahora: siempre gana 🏠 Casa

## Archivos modificados
- `lib/features/geofencing/services/geofencing_service.dart` — método `_onLocationUpdate` (7 líneas)

## Test plan
- [ ] Con una sola zona: comportamiento idéntico al anterior ✅
- [ ] Con dos zonas solapadas: siempre gana la de menor radio
- [ ] Verificar con el simulador debug (ZonesPage → 🐛)

🤖 Generated with [Claude Code](https://claude.com/claude-code)