### PR TITLE
fix: block only configured zone type in manual status selection

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -126,10 +126,12 @@ class StatusService {
         throw Exception('Usuario no está en ningún círculo');
       }
 
-      final zonesConfigured = await _hasZonesConfigured(circleId);
-      if (zonesConfigured && _blockedZoneStatusIds.contains(newStatus.id)) {
-        log('[StatusService] 🚫 Bloqueado: selección manual de zona (${newStatus.id}) con zonas configuradas');
-        return StatusUpdateResult.error(_zoneManualSelectionNotAllowedError);
+      if (_blockedZoneStatusIds.contains(newStatus.id)) {
+        final isThisZoneConfigured = await _isSpecificZoneTypeConfigured(circleId, newStatus.id);
+        if (isThisZoneConfigured) {
+          log('[StatusService] 🚫 Bloqueado: zona ${newStatus.id} está configurada como zona de geofencing');
+          return StatusUpdateResult.error(_zoneManualSelectionNotAllowedError);
+        }
       }
 
       // Leer el estado actual del usuario para verificar si estaba en una zona
@@ -238,13 +240,18 @@ class StatusService {
     }
   }
 
-  static Future<bool> _hasZonesConfigured(String circleId) async {
+  static Future<bool> _isSpecificZoneTypeConfigured(String circleId, String zoneType) async {
     try {
-      final snapshot =
-          await FirebaseFirestore.instance.collection('circles').doc(circleId).collection('zones').limit(1).get();
+      final snapshot = await FirebaseFirestore.instance
+          .collection('circles')
+          .doc(circleId)
+          .collection('zones')
+          .where('type', isEqualTo: zoneType)
+          .limit(1)
+          .get();
       return snapshot.docs.isNotEmpty;
     } catch (e) {
-      log('[StatusService] ⚠️ Error verificando zonas configuradas: $e');
+      log('[StatusService] ⚠️ Error verificando zona $zoneType: $e');
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- `_hasZonesConfigured()` bloqueaba todos los estados de ubicación (home, school, university, work) si existía **cualquier** zona configurada en el círculo
- Reemplazado por `_isSpecificZoneTypeConfigured()` que consulta Firestore filtrando por el `type` exacto del estado seleccionado
- Ahora solo se bloquea el botón cuya zona fue configurada en Geofencing; los demás permanecen seleccionables

## Test plan
- [ ] Con zona `home` configurada: 🏠 Casa bloqueado, 🏫 Colegio / 🎓 Universidad / 🏢 Trabajo seleccionables
- [ ] Con zona `university` configurada: 🎓 Universidad bloqueada, el resto seleccionable
- [ ] Sin zonas configuradas: los 4 botones de ubicación seleccionables
- [ ] Verificar que el modal de advertencia solo aparece al tocar un botón cuya zona sí está configurada

🤖 Generated with [Claude Code](https://claude.com/claude-code)