### PR TITLE
fix: revert BugA KeepAlive skip and add stale mutex detection

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -74,13 +74,23 @@ class EmojiDialogActivity : Activity() {
         super.onCreate(savedInstanceState)
         Log.d(TAG, "⚡ [NATIVE] Abriendo dialog nativo de emojis...")
 
-        // Mutex: si el modal Flutter ya está abierto, no mostrar el nativo encima
+        // Mutex: si el modal Flutter ya está abierto, no mostrar el nativo encima.
+        // Staleness check: si el flag lleva más de 30s en estado 1, el proceso fue
+        // matado con el modal abierto y SharedPreferences quedó con flag=1 en disco.
+        // En ese caso se considera stale y se resetea para no bloquear el modal nativo.
         val sharedPrefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
         val isFlutterModalOpen = sharedPrefs.getInt("flutter.zync_modal_open", 0) == 1
         if (isFlutterModalOpen) {
-            Log.d(TAG, "⚠️ [NATIVE] Modal Flutter ya está abierto — cerrando activity nativa")
-            finish()
-            return
+            val flagTs = sharedPrefs.getLong("flutter.zync_modal_open_ts", 0L)
+            val ageMs = System.currentTimeMillis() - flagTs
+            if (ageMs > 30_000L) {
+                Log.d(TAG, "⚠️ [NATIVE] Flag zync_modal_open stale (${ageMs}ms) — reseteando y abriendo modal")
+                sharedPrefs.edit().putInt("flutter.zync_modal_open", 0).apply()
+            } else {
+                Log.d(TAG, "⚠️ [NATIVE] Modal Flutter ya está abierto (age=${ageMs}ms) — cerrando activity nativa")
+                finish()
+                return
+            }
         }
 
         emojis = loadEmojisFromCache()

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -146,17 +146,6 @@ class MainActivity: FlutterActivity() {
             return
         }
 
-        // Bug A FIX: No iniciar KeepAliveService si hay un modal Flutter abierto.
-        // EmojiDialogActivity.finish() dispara onPause()/onResume() en MainActivity,
-        // lo que causaría un ciclo que reactiva la Firestore stream y muestra el emoji
-        // de zona guardado (📍) aunque el mutex rechazó la apertura del modal.
-        val flutterPrefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
-        val isModalOpen = flutterPrefs.getInt("flutter.zync_modal_open", 0)
-        if (isModalOpen == 1) {
-            Log.d(TAG, "⚠️ [NATIVO] Modal Flutter abierto (zync_modal_open=1) — NO iniciando KeepAliveService")
-            return
-        }
-
         // 🚀 FASE 1: Iniciar keep-alive NATIVO (no esperar a Flutter)
         if (!isKeepAliveRunning) {
             Log.d(TAG, "🟢 [NATIVO] Iniciando keep-alive service desde onPause() para usuario: $currentUserId")

--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -215,6 +215,11 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
   Future<void> _setModalOpenFlag(bool isOpen) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('zync_modal_open', isOpen ? 1 : 0);
+    if (isOpen) {
+      // Timestamp para que EmojiDialogActivity pueda detectar flags stale
+      // (proceso matado con modal abierto → flag queda en 1 en disco)
+      await prefs.setInt('zync_modal_open_ts', DateTime.now().millisecondsSinceEpoch);
+    }
   }
 
   void _startSosHold() {


### PR DESCRIPTION
## Problema
PR #71 introdujo regresiones más graves que el bug original:

1. **App muestra splash al minimizar/maximizar** — Bug A saltaba `KeepAliveService.start()` cuando `zync_modal_open=1`. Sin KeepAlive, Android mataba el proceso y Flutter arrancaba desde cero.
2. **Modal de la barra no aparece** — Race condition: proceso matado con modal abierto → flag queda en `1` en disco → `EmojiDialogActivity` lee `1` y hace `finish()` antes de que Flutter pueda resetear el flag.

## Cambios

### `MainActivity.kt` — Revertir Bug A
Se elimina el bloque que chequeaba `zync_modal_open` en `onPause()`. KeepAlive corre siempre que hay usuario autenticado y no hay logout en progreso.

### `status_selector_overlay.dart` — Timestamp del flag
Al escribir `zync_modal_open=1`, se guarda también `zync_modal_open_ts` con el timestamp actual en milliseconds.

### `EmojiDialogActivity.kt` — Staleness check
Antes de rechazar por mutex, se evalúa la antigüedad del flag. Si lleva más de 30 segundos en estado `1`, se considera stale (proceso fue matado con modal abierto) → se resetea y el modal nativo se abre normalmente.

## Test plan
- [ ] Minimizar app → maximizar: NO debe mostrar splash screen
- [ ] Tocar notificación persistente → modal debe abrirse correctamente
- [ ] T4.12: abrir modal del Círculo → intentar abrir modal nativo → debe ser rechazado (menos de 30s)
- [ ] Flujo SOS en ambos modales sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)