### PR TITLE
feat: explicit Silent Mode button — KeepAlive only on user intent

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -140,19 +140,9 @@ class MainActivity: FlutterActivity() {
             return
         }
         
-        // Point 2 FIX: Solo iniciar keep-alive si hay un usuario autenticado
-        if (currentUserId == null) {
-            Log.d(TAG, "⚠️ [NATIVO] No hay usuario autenticado - NO iniciando KeepAliveService")
-            return
-        }
+        // 🌙 SILENT MODE: KeepAlive solo arranca vía botón explícito "Modo Silencio"
+        // (no en cada minimización — ver handler 'activateSilentMode' en keep_alive channel)
 
-        // 🚀 FASE 1: Iniciar keep-alive NATIVO (no esperar a Flutter)
-        if (!isKeepAliveRunning) {
-            Log.d(TAG, "🟢 [NATIVO] Iniciando keep-alive service desde onPause() para usuario: $currentUserId")
-            KeepAliveService.start(this)
-            isKeepAliveRunning = true
-        }
-        
         // 🚀 FASE 1: Guardar estado NATIVO inmediatamente
         currentUserId?.let { userId ->
             Log.d(TAG, "💾 [NATIVO] Guardando estado: $userId")
@@ -215,14 +205,9 @@ class MainActivity: FlutterActivity() {
             Log.w(TAG, "⚠️ [BROADCAST] Error desregistrando receiver: ${e.message}")
         }
         
-        // Point 21 FASE 1: SIEMPRE mantener keep-alive activo
-        // El logout manual se manejará desde Flutter (Settings)
-        // NOTA: En Android 12+ esto puede fallar silenciosamente, y está bien
-        if (!isKeepAliveRunning) {
-            Log.d(TAG, "⚠️ [NATIVO] Keep-alive no estaba corriendo - intentando iniciar desde onDestroy()")
-            KeepAliveService.start(this)
-            // NO marcar isKeepAliveRunning = true porque puede haber fallado
-        }
+        // 🌙 SILENT MODE: KeepAlive NO se reactiva en onDestroy()
+        // Si estaba corriendo (Silent Mode activo), se limpia en onResume()
+        Log.d(TAG, "🔴 [NATIVO] onDestroy — isKeepAliveRunning=$isKeepAliveRunning")
     }
     
     // 🚀 FASE 1.5: Interceptar back gesture para MINIMIZAR en vez de CERRAR
@@ -419,6 +404,14 @@ class MainActivity: FlutterActivity() {
                     Log.d(TAG, "🔴 Flutter solicita detener keep-alive service (LOGOUT MANUAL)")
                     KeepAliveService.stop(this)
                     isKeepAliveRunning = false
+                    result.success(true)
+                }
+                "activateSilentMode" -> {
+                    Log.d(TAG, "🌙 [SILENT] Flutter solicita activar Modo Silencio")
+                    KeepAliveService.start(this)
+                    isKeepAliveRunning = true
+                    // Minimizar la app al background (igual que onBackPressed)
+                    moveTaskToBack(true)
                     result.success(true)
                 }
                 "setManualLogoutFlag" -> {

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -15,6 +15,7 @@ class SilentFunctionalityCoordinator {
   static BuildContext? _context;
   static bool _isManualLogoutInProgress = false; // Point 1.1: Bandera para evitar reactivación
   static bool _userHasCircle = false; // True solo cuando activateAfterLogin confirmó círculo activo
+  static bool _isSilentModeActive = false; // True cuando el usuario activó explícitamente Modo Silencio
 
   /// Inicializa SOLO los servicios base (sin BuildContext)
   /// Se debe llamar en main() ANTES de runApp()
@@ -113,9 +114,9 @@ class SilentFunctionalityCoordinator {
 
       if (hasPermission) {
         print('[SilentCoordinator] ✅ Permisos de notificación otorgados');
-        print('[SilentCoordinator] Mostrando notificación persistente...');
-        await NotificationService.showQuickActionNotification();
-        print('[SilentCoordinator] ✅ Funcionalidad silenciosa ACTIVADA');
+        print('[SilentCoordinator] 🌙 Modo Silencio disponible — se activa con botón explícito');
+        // 🌙 SILENT MODE: No mostrar notificación automáticamente.
+        // La notificación solo aparece cuando el usuario toca "Modo Silencio".
 
         // Point 1.1: Resetear bandera de logout manual (usuario hizo login exitoso)
         _isManualLogoutInProgress = false;
@@ -194,13 +195,13 @@ class SilentFunctionalityCoordinator {
       final hasPermission = await NotificationService.hasPermission();
 
       if (hasPermission) {
-        print('[SilentCoordinator] ✅ Usuario habilitó notificaciones - mostrando notificación');
-        await NotificationService.showQuickActionNotification();
-
+        print('[SilentCoordinator] ✅ Usuario habilitó notificaciones');
+        // 🌙 SILENT MODE: No mostrar notificación automáticamente.
+        // El usuario debe tocar "Modo Silencio" para activarla.
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
-              content: Text('✅ Notificaciones habilitadas - Cambio rápido disponible'),
+              content: Text('✅ Notificaciones habilitadas — usa "Modo Silencio" para activarlas'),
               backgroundColor: Colors.green,
               duration: Duration(seconds: 3),
             ),
@@ -397,15 +398,55 @@ class SilentFunctionalityCoordinator {
     if (!_userHasCircle) return;
     if (!context.mounted) return;
 
-    final hasPermission = await NotificationService.hasPermission();
+    // 🌙 SILENT MODE: Si el usuario vuelve a la app con Silent Mode activo, desactivarlo.
+    if (_isSilentModeActive) {
+      await deactivateSilentMode();
+      return;
+    }
 
+    // Verificar permisos para mostrar aviso si están denegados (sin auto-activar notificación).
+    final hasPermission = await NotificationService.hasPermission();
+    if (!context.mounted) return;
+    if (!hasPermission) {
+      _showNotificationsDisabledInfo(context);
+    }
+  }
+
+  /// Activa el Modo Silencio de forma explícita (botón en la UI).
+  /// Muestra la notificación persistente, inicia KeepAlive y minimiza la app.
+  /// Solo funciona si el usuario pertenece a un círculo y tiene permisos.
+  static Future<void> activateSilentMode(BuildContext context) async {
+    if (_isManualLogoutInProgress) return;
+    if (!_userHasCircle) return;
+    if (!context.mounted) return;
+
+    final hasPermission = await NotificationService.hasPermission();
     if (!context.mounted) return;
 
     if (!hasPermission) {
       _showNotificationsDisabledInfo(context);
-    } else {
-      await NotificationService.showQuickActionNotification();
+      return;
     }
+
+    _isSilentModeActive = true;
+    await NotificationService.showQuickActionNotification();
+
+    try {
+      const keepAliveChannel = MethodChannel('zync/keep_alive');
+      await keepAliveChannel.invokeMethod('activateSilentMode');
+    } catch (e) {
+      print('[SilentCoordinator] ❌ Error activando Modo Silencio nativo: $e');
+      _isSilentModeActive = false;
+      await NotificationService.cancelQuickActionNotification();
+    }
+  }
+
+  /// Desactiva el Modo Silencio: cancela la notificación y limpia el estado.
+  /// Se llama automáticamente cuando el usuario reabre la app.
+  static Future<void> deactivateSilentMode() async {
+    _isSilentModeActive = false;
+    await NotificationService.cancelQuickActionNotification();
+    print('[SilentCoordinator] 🌙 Modo Silencio desactivado');
   }
 
   /// Limpia recursos cuando la app se cierra

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -14,6 +14,7 @@ import '../../../../core/widgets/emoji_modal.dart';
 import '../../../../core/services/gps_service.dart';
 import '../../../../core/services/status_service.dart';
 import '../../../../core/services/emoji_service.dart';
+import '../../../../core/services/silent_functionality_coordinator.dart';
 import '../../../settings/presentation/pages/settings_page.dart';
 import '../../../../core/models/user_status.dart';
 import '../../../geofencing/services/geofencing_service.dart'; // Servicio de geofencing
@@ -861,36 +862,68 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: ElevatedButton(
-          key: const Key('btn_change_status'),
-          onPressed: _isUpdatingStatus ? null : () => _quickStatusUpdate(),
-          style: ElevatedButton.styleFrom(
-            backgroundColor: _AppColors.accent,
-            foregroundColor: _AppColors.background,
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12.0),
-            ),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              if (_isUpdatingStatus)
-                const SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    valueColor: AlwaysStoppedAnimation<Color>(Colors.black54),
+        child: Row(
+          children: [
+            // Botón secundario: Modo Silencio
+            Expanded(
+              flex: 3,
+              child: OutlinedButton.icon(
+                key: const Key('btn_silent_mode'),
+                onPressed: _isUpdatingStatus
+                    ? null
+                    : () => SilentFunctionalityCoordinator.activateSilentMode(context),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: _AppColors.accent,
+                  side: const BorderSide(color: _AppColors.accent),
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12.0),
                   ),
-                )
-              else
-                const Icon(Icons.check_circle),
-              const SizedBox(width: 8),
-              Text(_isUpdatingStatus ? 'Actualizando...' : 'OK'),
-            ],
-          ),
+                ),
+                icon: const Icon(Icons.bedtime_outlined, size: 18),
+                label: const Text(
+                  'Modo Silencio',
+                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            // Botón primario: OK / Actualizar estado
+            Expanded(
+              flex: 2,
+              child: ElevatedButton(
+                key: const Key('btn_change_status'),
+                onPressed: _isUpdatingStatus ? null : () => _quickStatusUpdate(),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _AppColors.accent,
+                  foregroundColor: _AppColors.background,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (_isUpdatingStatus)
+                      const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(Colors.black54),
+                        ),
+                      )
+                    else
+                      const Icon(Icons.check_circle),
+                    const SizedBox(width: 8),
+                    Text(_isUpdatingStatus ? '...' : 'OK'),
+                  ],
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary

- **Modo Silencio** ahora es una acción explícita del usuario (botón en la pantalla del círculo) en lugar de activarse automáticamente en cada minimización
- El botón muestra la notificación persistente con emojis rápidos e inicia KeepAlive, luego minimiza la app con `moveTaskToBack(true)`
- Swipe/back gesture sigue minimizando la app pero **ya no arranca KeepAlive** — elimina la raíz de los ciclos de Bug A
- Al regresar a la app mientras Silent Mode está activo, la notificación se cancela y KeepAlive se detiene automáticamente

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `MainActivity.kt` | Removido auto-KeepAlive de `onPause()` y `onDestroy()`; nuevo handler `activateSilentMode` en canal `keep_alive` |
| `silent_functionality_coordinator.dart` | Nuevos métodos `activateSilentMode()` y `deactivateSilentMode()`; removida auto-notificación de `activateAfterLogin()` y `onAppResumed()` |
| `in_circle_view.dart` | Botón `Modo Silencio` (OutlinedButton) junto al botón `OK` en el footer |

## Test plan

- [ ] Presionar "Modo Silencio" → app se minimiza + notificación aparece en barra
- [ ] Tocar emoji en notificación → estado enviado sin abrir la app
- [ ] Abrir la app desde notificación o directamente → notificación desaparece
- [ ] Swipe hacia arriba sin presionar el botón → app se minimiza, sin notificación, sin KeepAlive
- [ ] Botón solo visible cuando el usuario está en un círculo

🤖 Generated with [Claude Code](https://claude.com/claude-code)