### PR TITLE
fix: resolve Silent Mode bugs — permissions, KeepAlive stop, mutex removal

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -74,24 +74,9 @@ class EmojiDialogActivity : Activity() {
         super.onCreate(savedInstanceState)
         Log.d(TAG, "⚡ [NATIVE] Abriendo dialog nativo de emojis...")
 
-        // Mutex: si el modal Flutter ya está abierto, no mostrar el nativo encima.
-        // Staleness check: si el flag lleva más de 30s en estado 1, el proceso fue
-        // matado con el modal abierto y SharedPreferences quedó con flag=1 en disco.
-        // En ese caso se considera stale y se resetea para no bloquear el modal nativo.
-        val sharedPrefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
-        val isFlutterModalOpen = sharedPrefs.getInt("flutter.zync_modal_open", 0) == 1
-        if (isFlutterModalOpen) {
-            val flagTs = sharedPrefs.getLong("flutter.zync_modal_open_ts", 0L)
-            val ageMs = System.currentTimeMillis() - flagTs
-            if (ageMs > 30_000L) {
-                Log.d(TAG, "⚠️ [NATIVE] Flag zync_modal_open stale (${ageMs}ms) — reseteando y abriendo modal")
-                sharedPrefs.edit().putInt("flutter.zync_modal_open", 0).apply()
-            } else {
-                Log.d(TAG, "⚠️ [NATIVE] Modal Flutter ya está abierto (age=${ageMs}ms) — cerrando activity nativa")
-                finish()
-                return
-            }
-        }
+        // 🌙 SILENT MODE: El mutex zync_modal_open fue eliminado.
+        // Con el diseño mutuamente excluyente (app abierta ↔ Silent Mode activo),
+        // no puede haber dos modales simultáneos — la race condition desaparece de raíz.
 
         emojis = loadEmojisFromCache()
         configuredZoneTypes = loadConfiguredZoneTypes()

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -526,7 +526,10 @@ class MainActivity: FlutterActivity() {
         when (requestCode) {
             NOTIFICATION_PERMISSION_REQUEST_CODE -> {
                 if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    showPersistentNotification()
+                    // 🌙 SILENT MODE: Permiso otorgado — la notificación y KeepAlive
+                    // se activan SOLO desde el botón "Modo Silencio" en Flutter,
+                    // no automáticamente aquí.
+                    Log.d(TAG, "✅ Permisos de notificación otorgados — esperando activación explícita del usuario")
                 } else {
                     Log.w(TAG, "Permisos de notificación denegados")
                 }

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart'; // Point 21: Para MethodChannel
-import 'package:shared_preferences/shared_preferences.dart';
 import '../../notifications/notification_service.dart';
 import '../../quick_actions/quick_actions_service.dart';
 import '../../widgets/notification_status_selector.dart'; // CAMBIADO: Usar modal de notificaciones
@@ -29,13 +28,6 @@ class SilentFunctionalityCoordinator {
     }
 
     try {
-      // Reset del mutex cross-platform: garantiza que zync_modal_open=0 al arrancar.
-      // Sin este reset, si la app fue cerrada mientras StatusSelectorOverlay estaba
-      // abierto, el flag queda en 1 y EmojiDialogActivity se cierra inmediatamente
-      // en cada arranque posterior, rompiendo el modo silencioso.
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setInt('zync_modal_open', 0);
-
       // 1. Inicializar servicios existentes (sin romper nada)
       print('[SilentCoordinator] 🔧 Inicializando servicios base...');
 
@@ -122,17 +114,12 @@ class SilentFunctionalityCoordinator {
       // T5.6: Limpiar estado offline al reconectarse
       await StatusService.clearOfflineStatus();
 
-      final hasPermission = await NotificationService.requestPermissions();
+      // 🌙 SILENT MODE: No solicitar permisos aquí. Los permisos se piden al momento
+      // en que el usuario toca el botón "Modo Silencio" (activateSilentMode).
+      // Esto evita que el dialog de permisos aparezca sin acción explícita del usuario.
 
-      if (hasPermission) {
-        print('[SilentCoordinator] ✅ Permisos de notificación otorgados');
-        print('[SilentCoordinator] 🌙 Modo Silencio disponible — se activa con botón explícito');
-        // 🌙 SILENT MODE: No mostrar notificación automáticamente.
-        // La notificación solo aparece cuando el usuario toca "Modo Silencio".
-      } else {
-        print('[SilentCoordinator] ⚠️ Permisos de notificación denegados');
-        print('[SilentCoordinator] 💡 Point 2: El modal se mostrará después de navegar a HomePage');
-      }
+
+      print('[SilentCoordinator] 🌙 Modo Silencio disponible — se activa con botón explícito');
     } catch (e) {
       print('[SilentCoordinator] ❌ Error en activateAfterLogin: $e');
     }
@@ -418,7 +405,11 @@ class SilentFunctionalityCoordinator {
     if (!_userHasCircle) return;
     if (!context.mounted) return;
 
-    final hasPermission = await NotificationService.hasPermission();
+    // Fix 2b: Solicitar permisos en el momento que el usuario toca el botón.
+    // Si ya los tiene → continúa. Si no → Android muestra el dialog nativo.
+    // Si los deniega → muestra info. Esto garantiza que notificación y KeepAlive
+    // solo arrancan cuando el usuario actúa intencionalmente.
+    final hasPermission = await NotificationService.requestPermissions();
     if (!context.mounted) return;
 
     if (!hasPermission) {
@@ -439,10 +430,20 @@ class SilentFunctionalityCoordinator {
     }
   }
 
-  /// Desactiva el Modo Silencio: cancela la notificación y limpia el estado.
+  /// Desactiva el Modo Silencio: cancela la notificación, limpia el estado
+  /// y detiene KeepAlive en el lado nativo.
   /// Se llama automáticamente cuando el usuario reabre la app.
   static Future<void> deactivateSilentMode() async {
     _isSilentModeActive = false;
+    // Fix 2c: Detener KeepAlive vía Kotlin antes de cancelar la notificación.
+    // Sin esto, el foreground service sigue corriendo aunque la notificación desaparezca.
+    try {
+      const keepAliveChannel = MethodChannel('zync/keep_alive');
+      await keepAliveChannel.invokeMethod('stop');
+      print('[SilentCoordinator] 🔴 KeepAlive detenido al desactivar Modo Silencio');
+    } catch (e) {
+      print('[SilentCoordinator] ⚠️ Error deteniendo KeepAlive en deactivateSilentMode: $e');
+    }
     await NotificationService.cancelQuickActionNotification();
     print('[SilentCoordinator] 🌙 Modo Silencio desactivado');
   }

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -857,6 +857,66 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
     }
   }
 
+  /// Muestra dialog de confirmación antes de activar Modo Silencio.
+  /// Fondo negro, borde menta, letras blancas — coherente con el resto del diseño.
+  Future<void> _confirmAndActivateSilentMode(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.75),
+      barrierDismissible: true,
+      builder: (dialogContext) {
+        return Dialog(
+          backgroundColor: Colors.black,
+          insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+            side: BorderSide(color: const Color(0xFF1CE4B3).withValues(alpha: 0.4), width: 1),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Activar Modo Silencio',
+                  style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white),
+                ),
+                const SizedBox(height: 12),
+                const Text(
+                  'La app se minimizará y quedará activa en segundo plano. '
+                  'Podrás cambiar tu estado desde la notificación persistente.',
+                  style: TextStyle(fontSize: 14, color: Color(0xCCFFFFFF)),
+                ),
+                const SizedBox(height: 18),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.of(dialogContext).pop(false),
+                      style: TextButton.styleFrom(foregroundColor: Colors.white70),
+                      child: const Text('Cancelar'),
+                    ),
+                    const SizedBox(width: 8),
+                    TextButton(
+                      onPressed: () => Navigator.of(dialogContext).pop(true),
+                      style: TextButton.styleFrom(foregroundColor: Color(0xFF1CE4B3)),
+                      child: const Text('Activar', style: TextStyle(fontWeight: FontWeight.bold)),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+
+    if (confirmed == true && context.mounted) {
+      SilentFunctionalityCoordinator.activateSilentMode(context);
+    }
+  }
+
   /// Construye el botón del footer
   Widget _buildFooterButton(BuildContext context) {
     return SafeArea(
@@ -871,9 +931,10 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                 key: const Key('btn_silent_mode'),
                 onPressed: _isUpdatingStatus
                     ? null
-                    : () => SilentFunctionalityCoordinator.activateSilentMode(context),
+                    : () => _confirmAndActivateSilentMode(context),
                 style: OutlinedButton.styleFrom(
                   foregroundColor: _AppColors.accent,
+                  backgroundColor: Colors.black,
                   side: const BorderSide(color: _AppColors.accent),
                   padding: const EdgeInsets.symmetric(vertical: 16),
                   shape: RoundedRectangleBorder(

--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../core/models/user_status.dart';
 import '../core/services/status_service.dart';
 
@@ -48,7 +47,6 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
   @override
   void initState() {
     super.initState();
-    _setModalOpenFlag(true);
     _setupAnimations();
     _loadStatusGrid(); // Cargar grid de forma asíncrona
     // CRÍTICO: NO iniciar animación hasta que el grid esté cargado
@@ -206,20 +204,9 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
 
   @override
   void dispose() {
-    _setModalOpenFlag(false);
     _sosTimer?.cancel();
     _animationController.dispose();
     super.dispose();
-  }
-
-  Future<void> _setModalOpenFlag(bool isOpen) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt('zync_modal_open', isOpen ? 1 : 0);
-    if (isOpen) {
-      // Timestamp para que EmojiDialogActivity pueda detectar flags stale
-      // (proceso matado con modal abierto → flag queda en 1 en disco)
-      await prefs.setInt('zync_modal_open_ts', DateTime.now().millisecondsSinceEpoch);
-    }
   }
 
   void _startSosHold() {


### PR DESCRIPTION
## Summary

- **Fix A (Bug B):** `onRequestPermissionsResult()` en `MainActivity.kt` ya no llama `showPersistentNotification()` — la notificación nunca aparece sin acción del usuario
- **Fix B (Bug A+B):** `activateAfterLogin()` ya no pide permisos; `activateSilentMode()` usa `requestPermissions()` en lugar de `hasPermission()` — el dialog nativo de Android aparece solo cuando el usuario toca el botón
- **Fix C:** `deactivateSilentMode()` detiene KeepAlive vía Kotlin antes de cancelar la notificación — el foreground service se limpia correctamente al volver a la app
- **UX:** Dialog de confirmación (fondo negro, borde menta) antes de activar Modo Silencio
- **UX:** Botón "Modo Silencio" con fondo negro explícito
- **Mutex eliminado:** `zync_modal_open` removido de `status_selector_overlay.dart`, `EmojiDialogActivity.kt` e `initializeServices()` — la race condition es arquitectónicamente imposible con el diseño mutuamente excluyente (app abierta ↔ Silent Mode activo)

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `MainActivity.kt` | Fix A: quitar `showPersistentNotification()` de `onRequestPermissionsResult()` |
| `silent_functionality_coordinator.dart` | Fix B + C: permisos solo en botón, `deactivateSilentMode()` detiene KeepAlive, reset mutex eliminado |
| `in_circle_view.dart` | Dialog confirmación + fondo negro en botón |
| `status_selector_overlay.dart` | Eliminar `_setModalOpenFlag()` completo |
| `EmojiDialogActivity.kt` | Eliminar bloque mutex/staleness check de `onCreate()` |

## Test plan

- [ ] Login → verificar que **no** aparece dialog de permisos ni notificación automáticamente
- [ ] Tocar "Modo Silencio" sin permisos → Android muestra dialog nativo → otorgar → notificación aparece + app se minimiza
- [ ] Tocar "Modo Silencio" sin permisos → denegar → SnackBar informativo (sin crash)
- [ ] Tocar "Modo Silencio" con permisos → dialog de confirmación aparece → Cancelar → nada pasa
- [ ] Tocar "Modo Silencio" con permisos → dialog → Activar → notificación + minimización + KeepAlive corriendo
- [ ] Maximizar app con Silent Mode activo → KeepAlive se detiene + notificación desaparece
- [ ] Tocar notificación → `EmojiDialogActivity` abre sin problemas (sin mutex bloqueando)
- [ ] Cold start → `EmojiDialogActivity` abre normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)