### PR TITLE
fix: Silent Mode notification persistence + cold-start auth retry

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -16,10 +16,10 @@ class KeepAliveService : Service() {
     
     companion object {
         private const val TAG = "KeepAliveService"
-        // Usar el mismo canal e ID que la notificación persistente de MainActivity
-        // para que SOLO exista una notificación visible
-        private const val CHANNEL_ID = "emoji_channel"
-        private const val NOTIFICATION_ID = 12345
+        // Canal propio del Modo Silencio — IMPORTANCE_HIGH evita que Samsung lo descarte
+        // con "Borrar todo". Canal nuevo (_v2) para forzar recreación con la nueva importance.
+        private const val CHANNEL_ID = "zync_silent_mode_v2"
+        private const val NOTIFICATION_ID = 12346
         
         fun start(context: Context) {
             Log.d(TAG, "🟢 Iniciando servicio keep-alive")
@@ -92,11 +92,13 @@ class KeepAliveService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
-                "Zync en segundo plano",
-                NotificationManager.IMPORTANCE_DEFAULT
+                "Modo Silencio",
+                NotificationManager.IMPORTANCE_HIGH
             ).apply {
-                description = "Mantiene Zync listo para usarse"
+                description = "Activo mientras el Modo Silencio está encendido"
                 setShowBadge(false)
+                enableVibration(false)
+                setSound(null, null)
             }
             
             val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -123,7 +125,7 @@ class KeepAliveService : Service() {
             .setContentText("Toca para cambiar tu estado") // Point 21: Texto claro
             .setSmallIcon(android.R.drawable.ic_dialog_info) // Usar icono genérico por ahora
             .setContentIntent(pendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setOngoing(true) // No se puede deslizar para cerrar
             .setShowWhen(false)
             .build()

--- a/lib/features/auth/presentation/provider/auth_provider.dart
+++ b/lib/features/auth/presentation/provider/auth_provider.dart
@@ -15,6 +15,8 @@ class AuthNotifier extends StateNotifier<AuthState> {
   final AuthService _authService; // 🔥 SIMPLIFICADO: Un solo servicio
   StreamSubscription? _authSubscription;
 
+  bool _getUserRetryInProgress = false;
+
   AuthNotifier({
     required firebase.FirebaseAuth firebaseAuth,
     required AuthService authService,
@@ -56,13 +58,25 @@ class AuthNotifier extends StateNotifier<AuthState> {
           }
         } catch (e) {
           log("[AuthNotifier] [STREAM] getCurrentUser FAILURE: $e");
-          state = AuthError("No pudimos cargar tus datos. Intenta de nuevo.");
-          Future.delayed(const Duration(seconds: 2), () {
-            if (!mounted) return;
-            if (state is AuthError) {
-              state = Unauthenticated();
-            }
-          });
+          if (_getUserRetryInProgress) {
+            // Ya se reintentó — red no disponible, ceder el paso al login
+            log("[AuthNotifier] [STREAM] Reintento fallido. Yendo a Unauthenticated.");
+            _getUserRetryInProgress = false;
+            state = AuthError("No pudimos cargar tus datos. Verifica tu conexión.");
+            Future.delayed(const Duration(seconds: 2), () {
+              if (!mounted) return;
+              if (state is AuthError) state = Unauthenticated();
+            });
+          } else {
+            // Primer fallo — puede ser error de red transitorio en cold start
+            _getUserRetryInProgress = true;
+            log("[AuthNotifier] [STREAM] Reintentando en 5s (posible cold-start)...");
+            state = AuthLoading();
+            Future.delayed(const Duration(seconds: 5), () {
+              if (!mounted) return;
+              if (state is AuthLoading) _onAuthStateChanged(firebaseUser);
+            });
+          }
         }
       } else {
         // Si el stream emite null tras la inicialización, avanzar a Unauthenticated


### PR DESCRIPTION
## Summary

- **T4.8** — `KeepAliveService` now uses a dedicated channel `zync_silent_mode_v2` with `IMPORTANCE_HIGH` + `PRIORITY_HIGH`. Samsung OEM's "Borrar todo" cannot dismiss `IMPORTANCE_HIGH` ongoing notifications. Vibration and sound explicitly disabled so the higher importance doesn't generate alerts. Notification ID changed to `12346` to avoid collision with the `emoji_channel` persistent notification.
- **Cold-start logout cascade** — `AuthNotifier` now retries `getCurrentUser()` once (after 5s) before going to `Unauthenticated`. Firestore is often transiently unreachable during cold start; the previous code treated any network failure as a real logout, which also reset `_userHasCircle = false` and broke T4.3.

## Test plan

- [ ] Activate Silent Mode → app goes to background → open notification tray → tap "Borrar todo" → notification must **not** be dismissed (T4.8)
- [ ] With Silent Mode active: kill app process completely (via Android task manager or ADB) → reopen → app should restore session without showing the login screen
- [ ] Explicit logout via Settings → must still navigate to login screen normally
- [ ] T4.3: after cold start, Silent Mode button must remain functional (circle check passes)

## Notes

- Devices with the old `emoji_channel` channel already created at `IMPORTANCE_DEFAULT` are unaffected — KeepAliveService now uses a different channel ID so the new importance is applied on first run. No uninstall required.
- The "Desconectado" flash on reopen is a separate race condition (Firestore renders before `clearOfflineStatus()` runs) — deferred to post-MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)