### PR TITLE
fix: eliminate double notification icon and add battery optimization exemption

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
         android:label="zync_app"

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -7,10 +7,13 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.PowerManager
+import android.provider.Settings
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
@@ -389,6 +392,20 @@ class MainActivity: FlutterActivity() {
                     KeepAliveService.stop(this)
                     NotificationManagerCompat.from(this).cancelAll()
                     isSilentModeActive = false
+                    result.success(true)
+                }
+                "checkBatteryOptimization" -> {
+                    val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+                    val isIgnoring = pm.isIgnoringBatteryOptimizations(packageName)
+                    Log.d(TAG, "🔋 [SILENT] Battery optimization ignorada: $isIgnoring")
+                    result.success(isIgnoring)
+                }
+                "requestBatteryOptimization" -> {
+                    val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                        data = Uri.parse("package:$packageName")
+                    }
+                    startActivity(intent)
+                    Log.d(TAG, "🔋 [SILENT] Solicitando exención de optimización de batería")
                     result.success(true)
                 }
                 else -> result.notImplemented()

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -99,6 +99,37 @@ class SilentFunctionalityCoordinator {
       return;
     }
 
+    // Verificar exención de optimización de batería (necesaria en Samsung OEM para
+    // que "Borrar todo" no descarte la notificación del foreground service).
+    final isExempt =
+        await _channel.invokeMethod<bool>('checkBatteryOptimization') ?? false;
+    if (!context.mounted) return;
+
+    if (!isExempt) {
+      await _channel.invokeMethod('requestBatteryOptimization');
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Row(
+            children: [
+              Icon(Icons.battery_saver, color: Colors.white),
+              SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Acepta la solicitud y toca el botón nuevamente para activar el Modo Silencio.',
+                  style: TextStyle(fontSize: 13),
+                ),
+              ),
+            ],
+          ),
+          backgroundColor: Colors.blueGrey,
+          duration: Duration(seconds: 5),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      return; // El usuario acepta en el diálogo del sistema y vuelve a tocar
+    }
+
     try {
       await _channel.invokeMethod('activate');
     } catch (e) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,6 @@ import 'package:zync_app/core/utils/performance_tracker.dart'; // PERFORMANCE TR
 import 'package:zync_app/core/services/session_cache_service.dart'; // FASE 2B: Session Cache (fallback)
 import 'package:zync_app/core/services/native_state_bridge.dart'; // FASE 3: Native State (primario) (fallback)
 import 'package:zync_app/core/services/silent_functionality_coordinator.dart'; // Point 2: Silent Functionality
-import 'package:zync_app/notifications/notification_service.dart'; // Point 2: Notification Service
 import 'package:zync_app/core/services/status_service.dart'; // Para actualizar estado desde native
 import 'package:zync_app/core/services/emoji_service.dart'; // Para cargar emojis desde Firebase
 import 'package:zync_app/core/services/emoji_cache_service.dart'; // Para sincronizar emojis a cache nativo
@@ -232,15 +231,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
       print('[App Resume] ✅ Usuario pertenece al círculo: ${userCircle.name}');
 
-      final hasPermission = await NotificationService.hasPermission();
-
-      if (hasPermission) {
-        print('[App Resume] ✅ Permisos CONCEDIDOS - Activando notificación persistente...');
-        await NotificationService.showQuickActionNotification();
-        print('[App Resume] ✅ Notificación persistente activada');
-      } else {
-        print('[App Resume] ⚠️ Permisos DENEGADOS - notificación no disponible');
-      }
+      // Nota: la notificación persistente es gestionada exclusivamente por
+      // KeepAliveService (Kotlin) al activar el Modo Silencio. No se crea aquí.
     } catch (e) {
       print('[App Resume] ❌ Error verificando permisos: $e');
     }


### PR DESCRIPTION
## Summary

- **Fix A — doble ícono:** `_checkPermissionsOnResume()` en `main.dart` llamaba `showQuickActionNotification()` en cada resume del app, creando la notificación #12345 (`emoji_channel`) de forma independiente al Modo Silencio. Al reactivar Silent Mode, `KeepAliveService` creaba #12346 — resultado: 2 íconos idénticos. Se elimina la llamada y el import de `NotificationService` que quedó sin uso.

- **Fix B — Samsung "Borrar todo":** Samsung One UI descarta notificaciones de foreground services si la app no está eximida de optimización de batería. Se agrega el permiso `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` al manifest y dos métodos en el canal `zync/keep_alive` (`checkBatteryOptimization`, `requestBatteryOptimization`). `activateSilentMode()` verifica la exención antes de activar: si no está eximida, abre el diálogo del sistema y muestra un SnackBar explicativo. En el segundo toque, la app ya está eximida y la activación procede normalmente.

## Test plan

- [ ] **Doble ícono:** activar Silent Mode → borrar todo → relanzar app → activar de nuevo → debe aparecer **un solo** ícono en la barra
- [ ] **Samsung "Borrar todo" (primera vez):** activar Silent Mode en instalación fresca → diálogo del sistema de batería debe aparecer → SnackBar debe ser visible → no se activa aún → aceptar en diálogo → tocar botón nuevamente → Silent Mode activa → notificación persiste ante "Borrar todo"
- [ ] **Samsung "Borrar todo" (segunda vez):** ya eximida → activar directamente sin diálogo → notificación persiste
- [ ] El flujo de logout explícito no debe verse afectado

## Notas

- El permiso `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` no es un permiso de riesgo — solo permite mostrar el diálogo del sistema. No requiere aprobación de Play Store.
- La exención de batería persiste entre sesiones una vez que el usuario la otorga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)