### PR TITLE
fix: Silent Mode activates immediately, battery opt requested non-blocking

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -382,6 +382,16 @@ class MainActivity: FlutterActivity() {
             when (call.method) {
                 "activate" -> {
                     Log.d(TAG, "🌙 [SILENT] Activando Modo Silencio")
+                    // Exención de batería: se solicita una sola vez, sin bloquear la activación.
+                    // El diálogo del sistema aparece mientras la app ya se está minimizando.
+                    val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
+                    if (!pm.isIgnoringBatteryOptimizations(packageName)) {
+                        Log.d(TAG, "🔋 [SILENT] Primera vez — solicitando exención de batería")
+                        val batteryIntent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                            data = Uri.parse("package:$packageName")
+                        }
+                        startActivity(batteryIntent)
+                    }
                     KeepAliveService.start(this)
                     isSilentModeActive = true
                     moveTaskToBack(true)

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -99,37 +99,6 @@ class SilentFunctionalityCoordinator {
       return;
     }
 
-    // Verificar exención de optimización de batería (necesaria en Samsung OEM para
-    // que "Borrar todo" no descarte la notificación del foreground service).
-    final isExempt =
-        await _channel.invokeMethod<bool>('checkBatteryOptimization') ?? false;
-    if (!context.mounted) return;
-
-    if (!isExempt) {
-      await _channel.invokeMethod('requestBatteryOptimization');
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Row(
-            children: [
-              Icon(Icons.battery_saver, color: Colors.white),
-              SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  'Acepta la solicitud y toca el botón nuevamente para activar el Modo Silencio.',
-                  style: TextStyle(fontSize: 13),
-                ),
-              ),
-            ],
-          ),
-          backgroundColor: Colors.blueGrey,
-          duration: Duration(seconds: 5),
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
-      return; // El usuario acepta en el diálogo del sistema y vuelve a tocar
-    }
-
     try {
       await _channel.invokeMethod('activate');
     } catch (e) {


### PR DESCRIPTION
## Summary

Corrige el error de diseño introducido en PR #82 donde la exención de batería bloqueaba la activación del Modo Silencio.

La lógica de batería se mueve completamente a Kotlin dentro del handler `activate`:
- Si la app no tiene exención de batería → el diálogo del sistema se abre **mientras la app ya se está minimizando**. Silent Mode queda activo independientemente de si el usuario acepta o cancela el diálogo.
- Desde la segunda activación en adelante: ningún diálogo, ningún paso adicional. Un tap → app se minimiza → ícono en la barra.

`SilentFunctionalityCoordinator` vuelve al estado de PR #80: verificar permisos de notificación → llamar `activate` → fin. Sin lógica de batería en Dart.

## Flujo resultante para el usuario

**Primera vez:** tap → permiso de notificaciones (Android 13+, inevitable) → activación inmediata → diálogo de batería aparece en segundo plano → usuario puede aceptar o ignorar

**Desde la segunda vez:** tap → activa. Sin diálogos.

## Test plan

- [ ] Primera activación en instalación fresca: Silent Mode activa inmediatamente, diálogo de batería aparece mientras la app se minimiza
- [ ] Segunda activación: tap único, sin diálogos
- [ ] Samsung "Borrar todo" (con exención concedida): notificación permanece
- [ ] Logout explícito desde Settings: funciona normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)