### PR TITLE
debug: diagnostic logs for Silent Mode race condition

### DIFF
--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -52,18 +52,21 @@ class SilentFunctionalityCoordinator {
     // Un login siempre cancela cualquier logout previo en el mismo proceso.
     _isManualLogoutInProgress = false;
 
+    debugPrint('[SilentCoordinator][DBG] activateAfterLogin — initialized=$_isInitialized');
     if (!_isInitialized) return;
 
     try {
       final userCircle = await CircleService().getUserCircle();
+      debugPrint('[SilentCoordinator][DBG] getUserCircle → ${userCircle != null ? "circle=${userCircle.name}" : "NULL (sin círculo)"}');
       if (userCircle == null) {
         _userHasCircle = false;
         return;
       }
       _userHasCircle = true;
       await StatusService.clearOfflineStatus();
+      debugPrint('[SilentCoordinator][DBG] clearOfflineStatus → OK');
     } catch (e) {
-      debugPrint('[SilentCoordinator] ❌ Error en activateAfterLogin: $e');
+      debugPrint('[SilentCoordinator][DBG] activateAfterLogin EXCEPCIÓN: $e');
     }
   }
 
@@ -87,11 +90,13 @@ class SilentFunctionalityCoordinator {
   /// Activa el Modo Silencio. Requiere permiso de notificaciones y círculo activo.
   /// Kotlin maneja el resto: notificación, KeepAlive y moveTaskToBack.
   static Future<void> activateSilentMode(BuildContext context) async {
+    debugPrint('[SilentCoordinator][DBG] activateSilentMode → logout=$_isManualLogoutInProgress, circle=$_userHasCircle, mounted=${context.mounted}');
     if (_isManualLogoutInProgress) return;
     if (!_userHasCircle) return;
     if (!context.mounted) return;
 
     final hasPermission = await NotificationService.requestPermissions();
+    debugPrint('[SilentCoordinator][DBG] requestPermissions → $hasPermission');
     if (!context.mounted) return;
 
     if (!hasPermission) {
@@ -100,9 +105,11 @@ class SilentFunctionalityCoordinator {
     }
 
     try {
+      debugPrint('[SilentCoordinator][DBG] invokeMethod activate →');
       await _channel.invokeMethod('activate');
+      debugPrint('[SilentCoordinator][DBG] activate → OK');
     } catch (e) {
-      debugPrint('[SilentCoordinator] ❌ Error activando Modo Silencio: $e');
+      debugPrint('[SilentCoordinator][DBG] activate EXCEPCIÓN: $e');
     }
   }
 


### PR DESCRIPTION
## Propósito

Rama de diagnóstico temporal. **No mergear a main.**

Agrega 9 líneas de log estratégico en `SilentFunctionalityCoordinator` para confirmar o descartar la hipótesis de race condition:

- `activateSilentMode`: imprime el estado de los 3 guards antes de ejecutar (`logout`, `circle`, `mounted`) + resultado de `requestPermissions` + resultado de `activate`
- `activateAfterLogin`: imprime `_isInitialized` al entrar + resultado de `getUserCircle` + confirmación de `clearOfflineStatus` + cualquier excepción

## Cómo leer los logs

Filtrar logcat con el tag `[DBG]`:
```
adb logcat | grep "SilentCoordinator\]\[DBG\]"
```

## Escenarios a reproducir

1. **Warm state:** app abierta → tap "Modo Silencio" → leer guards
2. **Post-logout:** cerrar sesión → re-login → tap "Modo Silencio" → leer guards + activateAfterLogin

## Próximo paso

Una vez obtenidos los logs, eliminar esta rama y aplicar el fix puntual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)