### PR TITLE
fix: sync SilentCoordinator state on app resume (#85)

### DIFF
--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -52,18 +52,21 @@ class SilentFunctionalityCoordinator {
     // Un login siempre cancela cualquier logout previo en el mismo proceso.
     _isManualLogoutInProgress = false;
 
+    debugPrint('[SilentCoordinator][DBG] activateAfterLogin — initialized=$_isInitialized');
     if (!_isInitialized) return;
 
     try {
       final userCircle = await CircleService().getUserCircle();
+      debugPrint('[SilentCoordinator][DBG] getUserCircle → ${userCircle != null ? "circle=${userCircle.name}" : "NULL (sin círculo)"}');
       if (userCircle == null) {
         _userHasCircle = false;
         return;
       }
       _userHasCircle = true;
       await StatusService.clearOfflineStatus();
+      debugPrint('[SilentCoordinator][DBG] clearOfflineStatus → OK');
     } catch (e) {
-      debugPrint('[SilentCoordinator] ❌ Error en activateAfterLogin: $e');
+      debugPrint('[SilentCoordinator][DBG] activateAfterLogin EXCEPCIÓN: $e');
     }
   }
 
@@ -87,11 +90,13 @@ class SilentFunctionalityCoordinator {
   /// Activa el Modo Silencio. Requiere permiso de notificaciones y círculo activo.
   /// Kotlin maneja el resto: notificación, KeepAlive y moveTaskToBack.
   static Future<void> activateSilentMode(BuildContext context) async {
+    debugPrint('[SilentCoordinator][DBG] activateSilentMode → logout=$_isManualLogoutInProgress, circle=$_userHasCircle, mounted=${context.mounted}');
     if (_isManualLogoutInProgress) return;
     if (!_userHasCircle) return;
     if (!context.mounted) return;
 
     final hasPermission = await NotificationService.requestPermissions();
+    debugPrint('[SilentCoordinator][DBG] requestPermissions → $hasPermission');
     if (!context.mounted) return;
 
     if (!hasPermission) {
@@ -100,9 +105,11 @@ class SilentFunctionalityCoordinator {
     }
 
     try {
+      debugPrint('[SilentCoordinator][DBG] invokeMethod activate →');
       await _channel.invokeMethod('activate');
+      debugPrint('[SilentCoordinator][DBG] activate → OK');
     } catch (e) {
-      debugPrint('[SilentCoordinator] ❌ Error activando Modo Silencio: $e');
+      debugPrint('[SilentCoordinator][DBG] activate EXCEPCIÓN: $e');
     }
   }
 

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -70,6 +70,13 @@ class SilentFunctionalityCoordinator {
     }
   }
 
+  /// Sincroniza el estado del círculo desde App Resume.
+  /// Si el usuario tiene círculo activo, también cancela cualquier flag de logout residual.
+  static void syncCircleState({required bool hasCircle}) {
+    _userHasCircle = hasCircle;
+    if (hasCircle) _isManualLogoutInProgress = false;
+  }
+
   /// Llamar desde el logout manual (Settings → Cerrar sesión / Eliminar cuenta).
   static Future<void> deactivateAfterLogout() async {
     if (_isManualLogoutInProgress) return; // guard duplicados

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -226,10 +226,12 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
       if (userCircle == null) {
         print('[App Resume] ⚠️ Usuario NO pertenece a círculo - NO mostrar notificaciones');
+        SilentFunctionalityCoordinator.syncCircleState(hasCircle: false);
         return;
       }
 
       print('[App Resume] ✅ Usuario pertenece al círculo: ${userCircle.name}');
+      SilentFunctionalityCoordinator.syncCircleState(hasCircle: true);
 
       // Nota: la notificación persistente es gestionada exclusivamente por
       // KeepAliveService (Kotlin) al activar el Modo Silencio. No se crea aquí.


### PR DESCRIPTION
## Summary

- `_checkPermissionsOnResume()` verificaba el círculo en Firestore pero nunca actualizaba `SilentFunctionalityCoordinator._userHasCircle`
- Tras logout + re-login por sesión cacheada, `_isManualLogoutInProgress` podía quedar `true` si `activateAfterLogin()` no era invocado por esa ruta de navegación
- Resultado: `activateSilentMode → logout=true, circle=false` aunque el usuario tenía círculo activo

## Cambios

- **`SilentFunctionalityCoordinator`**: nuevo método `syncCircleState({required bool hasCircle})` que actualiza `_userHasCircle` y, si `hasCircle=true`, limpia `_isManualLogoutInProgress`
- **`main.dart`** (`_checkPermissionsOnResume`): llama `syncCircleState` en ambas ramas (con y sin círculo) después de verificar Firestore

## Test plan

- [ ] Activar Silent Mode → minimizar → reabrir → botón Silent Mode debe funcionar (`logout=false, circle=true`)
- [ ] Logout → re-login → activar Silent Mode → debe activarse correctamente
- [ ] Cold start con sesión cacheada → activar Silent Mode → debe activarse sin necesidad de pasar por login explícito

🤖 Generated with [Claude Code](https://claude.com/claude-code)