### PR TITLE
fix: persist Silent Mode notification after modal interaction (#86)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -81,6 +81,13 @@ class EmojiDialogActivity : Activity() {
         emojis = loadEmojisFromCache()
         configuredZoneTypes = loadConfiguredZoneTypes()
         setupActivityUI()
+
+        // Notificar a MainActivity que el resume siguiente viene del modal,
+        // no de una apertura intencional del usuario. Esto evita que onResume()
+        // desactive el Modo Silencio al volver de esta pantalla.
+        getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+            .edit().putBoolean("modal_was_open", true).apply()
+        Log.d(TAG, "🔔 [SILENT] Flag modal_was_open=true guardado")
     }
 
     override fun onDestroy() {

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -145,14 +145,23 @@ class MainActivity: FlutterActivity() {
         super.onResume()
         Log.d(TAG, "onResume() - App al frente")
 
-        // 🌙 SILENT MODE: Si estaba activo, desactivarlo ahora que el usuario abrió la app.
-        // Kotlin es dueño de este estado — no necesita pasar por Dart.
+        // 🌙 SILENT MODE: Si estaba activo, desactivarlo solo si el usuario abrió la app
+        // intencionalmente. Si el resume viene de EmojiDialogActivity (modal de notificación),
+        // el flag modal_was_open=true lo indica — en ese caso NO desactivar.
         if (isSilentModeActive) {
-            Log.d(TAG, "🌙 [SILENT] App al frente con Silent Mode activo — desactivando")
-            KeepAliveService.stop(this)
-            NotificationManagerCompat.from(this).cancelAll()
-            isSilentModeActive = false
-            Log.d(TAG, "✅ [SILENT] Modo Silencio desactivado desde onResume()")
+            val silentPrefs = getSharedPreferences("zync_silent_mode", MODE_PRIVATE)
+            val returningFromModal = silentPrefs.getBoolean("modal_was_open", false)
+            silentPrefs.edit().putBoolean("modal_was_open", false).apply()
+
+            if (returningFromModal) {
+                Log.d(TAG, "🌙 [SILENT] Resume desde modal — Modo Silencio se mantiene activo")
+            } else {
+                Log.d(TAG, "🌙 [SILENT] App al frente con Silent Mode activo — desactivando")
+                KeepAliveService.stop(this)
+                NotificationManagerCompat.from(this).cancelAll()
+                isSilentModeActive = false
+                Log.d(TAG, "✅ [SILENT] Modo Silencio desactivado desde onResume()")
+            }
         }
 
         // Procesar estado pendiente del cache (selección desde EmojiDialogActivity)
@@ -381,6 +390,13 @@ class MainActivity: FlutterActivity() {
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, KEEP_ALIVE_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "activate" -> {
+                    // Idempotencia: si ya está activo, solo minimizar sin reiniciar el servicio.
+                    if (isSilentModeActive) {
+                        Log.d(TAG, "🌙 [SILENT] Ya activo — ignorando activación redundante")
+                        moveTaskToBack(true)
+                        result.success(true)
+                        return@setMethodCallHandler
+                    }
                     Log.d(TAG, "🌙 [SILENT] Activando Modo Silencio")
                     // Exención de batería: se solicita una sola vez, sin bloquear la activación.
                     // El diálogo del sistema aparece mientras la app ya se está minimizando.


### PR DESCRIPTION
## Bugs corregidos

### Escenario A — Notificación desaparece al cerrar el modal
`onResume()` en `MainActivity` detenía el `KeepAliveService` en **cualquier** resume, incluyendo cuando `EmojiDialogActivity` terminaba y devolvía el foco. El sistema no distinguía entre "usuario abrió la app intencionalmente" vs "modal cerrado → app recuperó foco".

**Fix:** `EmojiDialogActivity.onCreate()` escribe `modal_was_open=true` en `SharedPreferences`. `MainActivity.onResume()` lee y limpia ese flag — si está activo, omite la desactivación y el servicio persiste.

### Escenario B — Re-activación redundante
El handler `activate` en `MainActivity` no tenía guard de idempotencia. Un tap sobre "Modo Silencio" con el servicio ya activo reiniciaba el `KeepAliveService` y llamaba `moveTaskToBack()` innecesariamente.

**Fix:** Guard al inicio del handler — si `isSilentModeActive`, solo ejecuta `moveTaskToBack()` y retorna sin reinicializar.

## Archivos modificados
- `EmojiDialogActivity.kt` — flag `modal_was_open` en `onCreate()`
- `MainActivity.kt` — lectura del flag en `onResume()` + guard idempotencia en `activate`

## Test plan
- [ ] Activar Modo Silencio → tocar notificación → seleccionar estado → notificación debe permanecer (Escenario A)
- [ ] Activar Modo Silencio → abrir app → tocar "Modo Silencio" nuevamente → app va al fondo sin reiniciar servicio (Escenario B)
- [ ] T4.11: Abrir app desde launcher con Modo Silencio activo → notificación desaparece (comportamiento inalterado)
- [ ] T4.9: Logout con Modo Silencio activo → notificación desaparece (comportamiento inalterado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)