### PR TITLE
fix: correct emoji broadcast key mismatch and silent fallback (#87)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -503,7 +503,7 @@ class EmojiDialogActivity : Activity() {
 
         val intent = Intent("com.datainfers.zync.UPDATE_STATUS").apply {
             putExtra("emoji", emoji)
-            putExtra("status", status)
+            putExtra("statusType", status)
             setPackage(packageName)
         }
         sendBroadcast(intent)

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -170,12 +170,12 @@ class MainActivity: FlutterActivity() {
 
         if (pendingStatus != null) {
             Log.d(TAG, "💾 [RESUME] Estado pendiente: $pendingStatus — enviando a Flutter")
+            prefs.edit().clear().apply()
             flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
                 val channel = MethodChannel(messenger, "com.datainfers.zync/status_update")
                 channel.invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
-                prefs.edit().clear().apply()
                 Log.d(TAG, "✅ [RESUME] Estado enviado y cache limpiado")
-            } ?: Log.e(TAG, "❌ [RESUME] FlutterEngine no disponible")
+            } ?: Log.e(TAG, "❌ [RESUME] FlutterEngine no disponible — cache limpiado para evitar estado stale")
         }
     }
     

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -99,10 +99,12 @@ Future<void> _updateStatusFromNative(String statusTypeName) async {
     }
 
     // Buscar el estado por ID
-    final statusType = allEmojis.firstWhere(
-      (e) => e.id == statusTypeName,
-      orElse: () => allEmojis.first, // Default al primero si no encuentra
-    );
+    final matches = allEmojis.where((e) => e.id == statusTypeName);
+    if (matches.isEmpty) {
+      debugPrint('❌ [NATIVE→FLUTTER] ID "$statusTypeName" no encontrado en lista de emojis — abortando');
+      return;
+    }
+    final statusType = matches.first;
 
     // Actualizar en Firebase usando StatusService
     final result = await StatusService.updateUserStatus(statusType);


### PR DESCRIPTION
## Summary

- **T2** — EmojiDialogActivity: putExtra \"status\" → \"statusType\" en broadcast (Falla A)
- **T3** — main.dart: reemplaza orElse fallback por log + return explícito (Falla B)
- **T4** — MainActivity.onResume(): clear pending_status antes del let block para evitar estado stale

## Archivos modificados

- EmojiDialogActivity.kt — T2: key broadcast corregida
- MainActivity.kt — T4: clear siempre en onResume
- lib/main.dart — T3: sin fallback silencioso

## Test plan

- [ ] Seleccionar emoji desde modal de notificación → estado correcto aplicado
- [ ] ID desconocido → log de error, sin cambio de estado
- [ ] pending_status se limpia aunque FlutterEngine no esté disponible

🤖 Generated with [Claude Code](https://claude.com/claude-code)