### PR TITLE
diag: G1.3 diagnostic logs for Silent Mode spurious onResume (#88)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -92,6 +92,9 @@ class EmojiDialogActivity : Activity() {
 
     override fun onDestroy() {
         sosHoldRunnable?.let { sosHandler.removeCallbacks(it) }
+        val modalWasOpen = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+            .getBoolean("modal_was_open", false)
+        Log.d(TAG, "🔍 [DIAG-G1.3] onDestroy — modal_was_open=$modalWasOpen (debe ser true para que MainActivity no desactive Silent Mode)")
         super.onDestroy()
     }
 

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -148,14 +148,18 @@ class MainActivity: FlutterActivity() {
         // 🌙 SILENT MODE: Si estaba activo, desactivarlo solo si el usuario abrió la app
         // intencionalmente. Si el resume viene de EmojiDialogActivity (modal de notificación),
         // el flag modal_was_open=true lo indica — en ese caso NO desactivar.
+        val silentPrefs = getSharedPreferences("zync_silent_mode", MODE_PRIVATE)
+        val modalWasOpen = silentPrefs.getBoolean("modal_was_open", false)
+        Log.d(TAG, "🔍 [DIAG-G1.3] onResume — isSilentModeActive=$isSilentModeActive | modal_was_open=$modalWasOpen")
+
         if (isSilentModeActive) {
-            val silentPrefs = getSharedPreferences("zync_silent_mode", MODE_PRIVATE)
-            val returningFromModal = silentPrefs.getBoolean("modal_was_open", false)
+            val returningFromModal = modalWasOpen
             silentPrefs.edit().putBoolean("modal_was_open", false).apply()
 
             if (returningFromModal) {
                 Log.d(TAG, "🌙 [SILENT] Resume desde modal — Modo Silencio se mantiene activo")
             } else {
+                Log.w(TAG, "⚠️ [DIAG-G1.3] onResume con isSilentModeActive=true y modal_was_open=false — DESACTIVANDO (posible edge case)")
                 Log.d(TAG, "🌙 [SILENT] App al frente con Silent Mode activo — desactivando")
                 KeepAliveService.stop(this)
                 NotificationManagerCompat.from(this).cancelAll()
@@ -402,7 +406,7 @@ class MainActivity: FlutterActivity() {
                     // El diálogo del sistema aparece mientras la app ya se está minimizando.
                     val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
                     if (!pm.isIgnoringBatteryOptimizations(packageName)) {
-                        Log.d(TAG, "🔋 [SILENT] Primera vez — solicitando exención de batería")
+                        Log.w(TAG, "⚠️ [DIAG-G1.3] startActivity(batteryIntent) — onResume() se disparará al volver. modal_was_open NO se establece aquí → posible desactivación espuria")
                         val batteryIntent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
                             data = Uri.parse("package:$packageName")
                         }
@@ -410,6 +414,7 @@ class MainActivity: FlutterActivity() {
                     }
                     KeepAliveService.start(this)
                     isSilentModeActive = true
+                    Log.d(TAG, "🔍 [DIAG-G1.3] isSilentModeActive establecido en true — moveTaskToBack a continuación")
                     moveTaskToBack(true)
                     result.success(true)
                 }
@@ -484,6 +489,7 @@ class MainActivity: FlutterActivity() {
                 }
                 "openNotificationSettings" -> {
                     Log.d(TAG, "[FASE 5] 🔧 Abriendo Settings de notificaciones...")
+                    Log.w(TAG, "⚠️ [DIAG-G1.3] startActivity(notificationSettings) — onResume() se disparará al volver. isSilentModeActive=$isSilentModeActive | modal_was_open NO se establece aquí")
                     try {
                         val intent = Intent().apply {
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
## Summary

Logs diagnósticos para identificar el edge case G1.3: ícono de notificación desaparece durante interacción prolongada con el modal.

**Hipótesis principal:** `onResume()` se dispara con `isSilentModeActive=true` y `modal_was_open=false` cuando el usuario vuelve de un diálogo del sistema (batería o settings de notificación), causando que KeepAliveService se detenga incorrectamente.

## Puntos de log agregados

| Ubicación | Tag | Qué captura |
|-----------|-----|-------------|
| `MainActivity.onResume()` | `[DIAG-G1.3]` | Valores de `isSilentModeActive` y `modal_was_open` antes de cualquier decisión |
| `MainActivity.onResume()` | `[DIAG-G1.3]` | Warning cuando se toma la rama de desactivación sin contexto de modal |
| `MainActivity.activate` | `[DIAG-G1.3]` | Warning antes de `startActivity(batteryIntent)` — disparador conocido |
| `MainActivity.openNotificationSettings` | `[DIAG-G1.3]` | Warning antes de `startActivity(settings)` — segundo disparador |
| `EmojiDialogActivity.onDestroy()` | `[DIAG-G1.3]` | Confirma que `modal_was_open=true` al cerrar el dialog |

## Cómo reproducir G1.3 con estos logs

1. Activar Modo Silencio por primera vez (solicita exención de batería)
2. Descartar el diálogo de batería
3. Verificar en logcat: ¿aparece el warning de `onResume` con `modal_was_open=false`?

🤖 Generated with [Claude Code](https://claude.com/claude-code)