### PR TITLE
fix: SOS location row opens maps instead of emoji modal (#89)

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -1283,7 +1283,10 @@ class _MemberListItem extends StatelessWidget {
         onTap: (status == 'loading') // No permitir taps mientras carga
             ? null
             : () {
-                if (isCurrentUser && onTap != null) {
+                if (isCurrentUser && isSOS && hasGPS && coordinates != null) {
+                  HapticFeedback.lightImpact();
+                  onOpenMaps(context, coordinates, nickname);
+                } else if (isCurrentUser && onTap != null) {
                   HapticFeedback.mediumImpact();
                   onTap!();
                 } else if (hasGPS && coordinates != null) {
@@ -1416,20 +1419,26 @@ class _MemberListItem extends StatelessWidget {
               // Mostrar sección SOS solo si el status NO es 'loading'
               if (hasGPS && coordinates != null && status != 'loading') ...[
                 const SizedBox(height: 12),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 8.0),
-                  child: Row(
-                    children: [
-                      const Icon(Icons.location_on, size: 20, color: _AppColors.sosRed),
-                      const SizedBox(width: 8),
-                      const Expanded(
-                        child: Text(
-                          'Ubicación SOS compartida',
-                          style: TextStyle(fontSize: 13, color: _AppColors.textPrimary, fontWeight: FontWeight.w500),
+                GestureDetector(
+                  onTap: () {
+                    HapticFeedback.lightImpact();
+                    onOpenMaps(context, coordinates, nickname);
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 8.0),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.location_on, size: 20, color: _AppColors.sosRed),
+                        const SizedBox(width: 8),
+                        const Expanded(
+                          child: Text(
+                            'Ubicación SOS compartida',
+                            style: TextStyle(fontSize: 13, color: _AppColors.textPrimary, fontWeight: FontWeight.w500),
+                          ),
                         ),
-                      ),
-                      Icon(Icons.arrow_forward_ios, size: 14, color: Colors.red[300]), // Mantener o usar sosRed
-                    ],
+                        Icon(Icons.arrow_forward_ios, size: 14, color: Colors.red[300]),
+                      ],
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
## Summary

- **T1** — Fila "Ubicación SOS compartida" en `_MemberListItem` envuelta en `GestureDetector`. Antes: el tap propagaba al `InkWell` padre que abría el modal de emojis para el usuario propio. Ahora: llama directamente a `onOpenMaps()`.
- **T2** — Excepción SOS en `InkWell.onTap`: si el usuario actual tiene status `sos` con GPS activo, se abre el mapa en lugar del modal. La condición `isCurrentUser && isSOS && hasGPS && coordinates != null` tiene prioridad sobre `isCurrentUser && onTap != null`.

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `in_circle_view.dart` | T1 + T2 en `_MemberListItem` |

## Test plan

- [ ] Usuario propio con SOS activo — tap en card abre Google Maps
- [ ] Usuario propio con SOS activo — tap en fila "Ubicación SOS compartida" abre Google Maps
- [ ] Usuario propio sin SOS — tap en card abre modal de emojis (comportamiento previo intacto)
- [ ] Otro miembro con SOS — tap en card sigue abriendo Google Maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)