### PR TITLE
fix: revert T2 — SOS card tap always opens emoji modal (#90)

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -1283,10 +1283,7 @@ class _MemberListItem extends StatelessWidget {
         onTap: (status == 'loading') // No permitir taps mientras carga
             ? null
             : () {
-                if (isCurrentUser && isSOS && hasGPS && coordinates != null) {
-                  HapticFeedback.lightImpact();
-                  onOpenMaps(context, coordinates, nickname);
-                } else if (isCurrentUser && onTap != null) {
+                if (isCurrentUser && onTap != null) {
                   HapticFeedback.mediumImpact();
                   onTap!();
                 } else if (hasGPS && coordinates != null) {


### PR DESCRIPTION
## Summary

Revierte T2 de PR #89. El bloque `isCurrentUser && isSOS && hasGPS` en el `InkWell.onTap` impedía al usuario cambiar su estado mientras tenía SOS activo — abría el mapa en lugar del modal de emojis.

**Comportamiento restaurado:** el card del usuario propio siempre abre el modal de emojis via `onTap()`, sin excepción por status.

**T1 se mantiene intacto:** la fila "Ubicación SOS compartida" con `GestureDetector` es el camino correcto y suficiente para abrir el mapa.

## Test plan

- [ ] Usuario propio con SOS activo — tap en card abre modal de emojis ✅
- [ ] Usuario propio con SOS activo — tap en fila "Ubicación SOS compartida" abre Google Maps ✅
- [ ] Usuario propio sin SOS — tap en card abre modal de emojis ✅
- [ ] Otro miembro con SOS — tap en card abre Google Maps ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)