### PR TITLE
fix: G1.B5 + G2.C1 — silent mode notification tap and state persistence (#91)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -88,6 +88,14 @@
             android:name=".ShowQuickStatusReceiver"
             android:exported="true"/>
 
+        <receiver
+            android:name=".NotificationTapReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.datainfers.zync.NOTIFICATION_TAP"/>
+            </intent-filter>
+        </receiver>
+
         <provider
             android:name="com.google.firebase.provider.FirebaseInitProvider"
             android:authorities="${applicationId}.firebaseinitprovider"

--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -108,12 +108,14 @@ class KeepAliveService : Service() {
     }
     
     private fun createNotification(): Notification {
-        // ✅ Abrir EmojiDialogActivity (nativo INSTANTÁNEO con cache Firebase)
-        val intent = Intent(this, EmojiDialogActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        // Tap en notificación → NotificationTapReceiver escribe modal_was_open=true
+        // ANTES de lanzar EmojiDialogActivity, evitando que onResume() desactive
+        // el Modo Silencio (G1.B5).
+        val intent = Intent(this, NotificationTapReceiver::class.java).apply {
+            action = "com.datainfers.zync.NOTIFICATION_TAP"
         }
-        
-        val pendingIntent = PendingIntent.getActivity(
+
+        val pendingIntent = PendingIntent.getBroadcast(
             this,
             0,
             intent,

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -101,6 +101,11 @@ class MainActivity: FlutterActivity() {
         
         // Verificar si hay estado guardado
         currentUserId = NativeStateManager.getUserId(this)
+
+        // G2.C1: Restaurar isSilentModeActive desde SharedPrefs (sobrevive al swipe/kill del proceso)
+        val silentPrefs = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+        isSilentModeActive = silentPrefs.getBoolean("is_silent_mode_active", false)
+        Log.d(TAG, "🌙 [SILENT] onCreate — isSilentModeActive restaurado: $isSilentModeActive")
         
         // �📊 PERFORMANCE: Detectar si es recreación o primer launch
         val wasRunning = savedInstanceState?.getBoolean("was_running", false) ?: false
@@ -164,6 +169,8 @@ class MainActivity: FlutterActivity() {
                 KeepAliveService.stop(this)
                 NotificationManagerCompat.from(this).cancelAll()
                 isSilentModeActive = false
+                // G2.C1: Limpiar flag persistido
+                silentPrefs.edit().putBoolean("is_silent_mode_active", false).apply()
                 Log.d(TAG, "✅ [SILENT] Modo Silencio desactivado desde onResume()")
             }
         }
@@ -414,6 +421,9 @@ class MainActivity: FlutterActivity() {
                     }
                     KeepAliveService.start(this)
                     isSilentModeActive = true
+                    // G2.C1: Persistir para sobrevivir swipe/kill del proceso
+                    getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+                        .edit().putBoolean("is_silent_mode_active", true).apply()
                     Log.d(TAG, "🔍 [DIAG-G1.3] isSilentModeActive establecido en true — moveTaskToBack a continuación")
                     moveTaskToBack(true)
                     result.success(true)
@@ -423,6 +433,9 @@ class MainActivity: FlutterActivity() {
                     KeepAliveService.stop(this)
                     NotificationManagerCompat.from(this).cancelAll()
                     isSilentModeActive = false
+                    // G2.C1: Limpiar flag persistido
+                    getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+                        .edit().putBoolean("is_silent_mode_active", false).apply()
                     result.success(true)
                 }
                 "checkBatteryOptimization" -> {

--- a/android/app/src/main/kotlin/com/datainfers/zync/NotificationTapReceiver.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/NotificationTapReceiver.kt
@@ -1,0 +1,37 @@
+package com.datainfers.zync
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * Receiver que intercepts el tap en la notificación del Modo Silencio.
+ *
+ * Problema que resuelve (G1.B5):
+ * Si la notificación lanzaba EmojiDialogActivity directamente, Android traía
+ * el task de MainActivity al primer plano ANTES de que EmojiDialogActivity
+ * pudiera escribir modal_was_open=true — onResume() veía modal_was_open=false
+ * y desactivaba el Modo Silencio.
+ *
+ * Solución: este receiver escribe modal_was_open=true PRIMERO y luego lanza
+ * EmojiDialogActivity — garantizando que onResume() siempre vea el flag correcto.
+ */
+class NotificationTapReceiver : BroadcastReceiver() {
+    private val TAG = "NotificationTapReceiver"
+
+    override fun onReceive(context: Context, intent: Intent) {
+        Log.d(TAG, "🔔 [SILENT] Tap en notificación recibido — escribiendo modal_was_open=true")
+
+        // Escribir el flag ANTES de lanzar la Activity para que onResume() lo lea correctamente
+        context.getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+            .edit().putBoolean("modal_was_open", true).apply()
+
+        Log.d(TAG, "✅ [SILENT] modal_was_open=true escrito — lanzando EmojiDialogActivity")
+
+        val modalIntent = Intent(context, EmojiDialogActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        context.startActivity(modalIntent)
+    }
+}


### PR DESCRIPTION
## Summary

### G1.B5 — Ícono desaparecía al seleccionar emoji desde la BN (CRÍTICO)

**Causa raíz:** El tap en la notificación traía `MainActivity` al primer plano antes de que `EmojiDialogActivity` pudiera escribir `modal_was_open=true`. `onResume()` leía `false` y desactivaba el Modo Silencio.

**Fix:** `NotificationTapReceiver` intercepta el tap, escribe `modal_was_open=true` primero y luego lanza `EmojiDialogActivity`. El orden ahora es siempre correcto.

### G2.C1 — Sesión no preservada tras swipe (CRÍTICO)

**Causa raíz:** `isSilentModeActive` vivía solo en memoria. Al hacer swipe, el proceso muere y el flag se pierde. `KeepAliveService` reiniciaba con `START_STICKY` pero `MainActivity` arrancaba con `isSilentModeActive=false`.

**Fix:** El flag se persiste en `zync_silent_mode` SharedPrefs al activar y se limpia al desactivar. `onCreate()` lo restaura al reiniciar el proceso.

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `NotificationTapReceiver.kt` | Nuevo — intercepta tap y escribe flag antes de abrir modal |
| `KeepAliveService.kt` | PendingIntent apunta a `NotificationTapReceiver` via `getBroadcast` |
| `MainActivity.kt` | Persiste/restaura `isSilentModeActive` en SharedPrefs (3 puntos) |
| `AndroidManifest.xml` | Registra `NotificationTapReceiver` con `exported=false` |

## Test plan

- [ ] G1.B5: Modo Silencio activo → tap en notificación → seleccionar emoji → ícono permanece en BN
- [ ] G2.C1: Modo Silencio activo → swipe para cerrar app → ícono permanece → reabrir → Modo Silencio se desactiva correctamente
- [ ] Logout con Modo Silencio activo → ícono desaparece (ruta deactivate intacta)
- [ ] Reabrir app voluntariamente → Modo Silencio se desactiva (ruta onResume intacta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)