### PR TITLE
fix: revert notification PendingIntent — restore modal on notification tap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@
 - Si encuentra un bug o inconsistencia no relacionada con la tarea, REPORTARLO sin corregirlo.
 - Confirmar el alcance exacto de cada cambio antes de ejecutarlo.
 - Al cierre de sesión, proponer entradas para las secciones 11 y 12 si corresponde, y esperar aprobación.
+- **Antes de proponer cualquier cambio en lógica de navegación, tap handlers o flujos de usuario:** listar explícitamente TODOS los flujos que pasan por el mismo código — no solo el flujo roto — y confirmar que ninguno regresiona. Si algún flujo existente se ve afectado, reportarlo ANTES de pedir VoBo, no después de implementar.
+- **Para bugs de lifecycle nativo Android:** leer los logs diagnósticos antes de proponer cualquier fix. Los logs son la única fuente de la verdad — está bien confiar en el instinto, pero dado que tenemos bugs persistentes, no se pueden asumir comportamientos no comprobados en los logs.
 
 ### Modo autónomo vs. modo con autorización
 

--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -108,14 +108,14 @@ class KeepAliveService : Service() {
     }
     
     private fun createNotification(): Notification {
-        // Tap en notificación → NotificationTapReceiver escribe modal_was_open=true
-        // ANTES de lanzar EmojiDialogActivity, evitando que onResume() desactive
-        // el Modo Silencio (G1.B5).
-        val intent = Intent(this, NotificationTapReceiver::class.java).apply {
-            action = "com.datainfers.zync.NOTIFICATION_TAP"
+        // Tap en notificación → abre EmojiDialogActivity directamente via getActivity().
+        // FLAG_ACTIVITY_NEW_TASK: requerido al lanzar Activity desde Service.
+        // FLAG_ACTIVITY_CLEAR_TOP: evita instancias duplicadas del modal.
+        val intent = Intent(this, EmojiDialogActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
 
-        val pendingIntent = PendingIntent.getBroadcast(
+        val pendingIntent = PendingIntent.getActivity(
             this,
             0,
             intent,


### PR DESCRIPTION
## Summary
- Reverts `KeepAliveService.kt` PendingIntent from `getBroadcast(NotificationTapReceiver)` back to `getActivity(EmojiDialogActivity)` with `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP`
- Root cause of PR #91 regression: Android 10+ (API 29+) prohibits `startActivity()` from background `BroadcastReceiver`s — tapping the notification fired the receiver but the modal never appeared
- Adds mandatory rule to `CLAUDE.md`: for Android lifecycle bugs, read diagnostic logs before proposing any fix

## Files changed
- `android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt` — PendingIntent reverted
- `CLAUDE.md` — diagnostic-logs rule added to LA IA DEBE section

## Test plan
- [ ] Activate Silent Mode
- [ ] Minimize app — notification should appear in status bar
- [ ] Tap notification — `EmojiDialogActivity` modal must open immediately
- [ ] Select an emoji — status must update, Silent Mode must remain active
- [ ] Verify `MainActivity.onResume()` does NOT deactivate Silent Mode after modal closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)