### PR TITLE
fix: preserve pending_status on cold start — FlutterEngine not ready

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -181,12 +181,12 @@ class MainActivity: FlutterActivity() {
 
         if (pendingStatus != null) {
             Log.d(TAG, "💾 [RESUME] Estado pendiente: $pendingStatus — enviando a Flutter")
-            prefs.edit().clear().apply()
             flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
                 val channel = MethodChannel(messenger, "com.datainfers.zync/status_update")
                 channel.invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
+                prefs.edit().clear().apply()
                 Log.d(TAG, "✅ [RESUME] Estado enviado y cache limpiado")
-            } ?: Log.e(TAG, "❌ [RESUME] FlutterEngine no disponible — cache limpiado para evitar estado stale")
+            } ?: Log.d(TAG, "⏳ [RESUME] FlutterEngine no disponible — estado pendiente preservado para [HYBRID]")
         }
     }
     


### PR DESCRIPTION
## Summary
- onResume() cleared pending_status before confirming Flutter was available
- On cold start, FlutterEngine is not ready yet — state was wiped silently
- Fix: only clear after successful invokeMethod call; [HYBRID] handles the rest

## Files changed
- MainActivity.kt — 2 lines moved

## Test plan
- [ ] Close app completely (swipe from recents)
- [ ] Tap notification → modal → select emoji
- [ ] Open app → status must update

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>