### PR TITLE
fix: Silent Mode icon remains active always while app is open/minimized

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -83,48 +83,45 @@ class EmojiDialogActivity : Activity() {
         setupActivityUI()
 
         // ========================================================================
-        // [BUG FIX] Persistencia de timestamp de apertura del modal
-        // Fecha: 2026-04-11
-        // Relacionado con: Bug #1 y Bug #2 en MainActivity.kt
+        // [CORRECCIÓN] Modo Silencio permanece activo siempre (app abierta/minimizada)
+        // Fecha: 2026-04-11 (segunda iteración)
         // 
-        // CÓDIGO ORIGINAL COMENTADO:
+        // Ya NO necesitamos persistir timestamps porque MainActivity.onResume() ya no
+        // desactiva el Modo Silencio. El ícono permanece activo siempre hasta logout.
+        // 
+        // CÓDIGO ANTERIOR COMENTADO (PR #94 - timestamps):
+        // val openTime = System.currentTimeMillis()
+        // getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+        //     .edit().putLong("last_modal_open_time", openTime).apply()
+        // Log.d(TAG, "🔔 [SILENT-FIX] Modal abierto — timestamp guardado: $openTime")
+        //
+        // CÓDIGO ORIGINAL (pre-PR #94 - flag booleano):
         // getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
         //     .edit().putBoolean("modal_was_open", true).apply()
         // Log.d(TAG, "🔔 [SILENT] Flag modal_was_open=true guardado")
-        // 
-        // NUEVO CÓDIGO:
-        // Ya no usamos flag booleano modal_was_open porque se limpiaba demasiado pronto.
-        // Ahora persistimos timestamp de apertura para cálculo de ventana de gracia.
         // ========================================================================
-        val openTime = System.currentTimeMillis()
-        getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
-            .edit().putLong("last_modal_open_time", openTime).apply()
-        Log.d(TAG, "🔔 [SILENT-FIX] Modal abierto — timestamp guardado: $openTime")
+        
+        Log.d(TAG, "🔔 [SILENT] Modal abierto — Modo Silencio permanece activo (sin necesidad de flags/timestamps)")
     }
 
     override fun onDestroy() {
         sosHoldRunnable?.let { sosHandler.removeCallbacks(it) }
         
         // ========================================================================
-        // [BUG FIX] Persistencia de timestamp de cierre del modal
-        // Fecha: 2026-04-11
-        // Relacionado con: Bug #1 y Bug #2 en MainActivity.kt
+        // [CORRECCIÓN] Modo Silencio permanece activo siempre (app abierta/minimizada)
+        // Fecha: 2026-04-11 (segunda iteración)
         // 
-        // PROBLEMA ORIGINAL:
-        // - modal_was_open se verificaba y limpiaba inmediatamente en MainActivity.onResume()
-        // - Si el usuario maximizaba la app después, el flag ya estaba en false
-        // - MainActivity interpretaba esto como "apertura intencional" → desactivaba Modo Silencio
+        // Ya NO necesitamos persistir timestamp de cierre porque MainActivity.onResume()
+        // ya no desactiva el Modo Silencio. El ícono permanece activo siempre hasta logout.
         // 
-        // SOLUCIÓN:
-        // - Persistir timestamp exacto del cierre del modal (onDestroy)
-        // - MainActivity.onResume() calcula tiempo transcurrido desde el cierre
-        // - Ventana de gracia de 3 segundos: si onResume() ocurre <3s después del cierre,
-        //   se considera "volver del modal" y NO se desactiva el Modo Silencio
+        // CÓDIGO ANTERIOR COMENTADO (PR #94 - timestamp de cierre):
+        // val closeTime = System.currentTimeMillis()
+        // getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+        //     .edit().putLong("last_modal_close_time", closeTime).apply()
+        // Log.d(TAG, "🔍 [SILENT-FIX] onDestroy — timestamp de cierre guardado: $closeTime")
         // ========================================================================
-        val closeTime = System.currentTimeMillis()
-        getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
-            .edit().putLong("last_modal_close_time", closeTime).apply()
-        Log.d(TAG, "🔍 [SILENT-FIX] onDestroy — timestamp de cierre guardado: $closeTime")
+        
+        Log.d(TAG, "🔍 [SILENT] onDestroy — Modo Silencio permanece activo (sin necesidad de timestamps)")
         
         super.onDestroy()
     }

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -151,27 +151,46 @@ class MainActivity: FlutterActivity() {
         Log.d(TAG, "onResume() - App al frente")
 
         // ========================================================================
-        // [BUG FIX] Desactivación espuria del ícono de Modo Silencio
-        // Fecha: 2026-04-11
-        // Issues: Bug #1 (SOS desde notificación + maximizar) y Bug #2 (modal Flutter + minimizar/maximizar)
+        // [CORRECCIÓN] Modo Silencio permanece activo mientras app esté abierta/minimizada
+        // Fecha: 2026-04-11 (segunda iteración)
         // 
-        // PROBLEMA ORIGINAL:
-        // - Bug #1: Usuario toca notificación → selecciona SOS → modal cierra → maximiza app manualmente
-        //   → modal_was_open ya estaba en false → código desactiva Modo Silencio incorrectamente
-        // - Bug #2: Usuario maximiza app → abre modal Flutter (showEmojiStatusBottomSheet) → selecciona emoji
-        //   → minimiza/maximiza después → modal_was_open nunca se estableció → desactiva Modo Silencio
-        // - Causa raíz: modal_was_open se limpia inmediatamente después de verificarlo (línea 162 antigua)
-        //   y no cubre interacciones con modales de Flutter
+        // COMPORTAMIENTO CORRECTO PARA APP ABIERTA/MINIMIZADA (proceso vivo):
+        // - Una vez activado "Modo Silencio", el ícono PERMANECE SIEMPRE
+        // - NO importa cuánto tiempo pase
+        // - NO importa cuántas veces se minimice/maximice
+        // - NO importa si se abre desde launcher o recientes
+        // - NO importa si se interactúa con modales (nativos o Flutter)
+        // - ÚNICA excepción: Logout (cierre de sesión) → desactiva correctamente
         // 
-        // SOLUCIÓN IMPLEMENTADA:
-        // - Usar timestamp de última interacción con modal (last_modal_close_time)
-        // - Ventana de gracia de 3 segundos: si onResume() ocurre dentro de 3s del cierre del modal,
-        //   se considera "volver del modal" y NO se desactiva
-        // - Detectar apertura intencional: solo desactivar si han pasado >3s desde última interacción
-        // - EmojiDialogActivity ahora persiste timestamp en onDestroy()
-        // ========================================================================
-        
-        // CÓDIGO ORIGINAL COMENTADO (mantener como referencia):
+        // CÓDIGO ANTERIOR COMENTADO (PR #94 - ventana de gracia de 3s):
+        // val silentPrefs = getSharedPreferences("zync_silent_mode", MODE_PRIVATE)
+        // val lastModalCloseTime = silentPrefs.getLong("last_modal_close_time", 0L)
+        // val currentTime = System.currentTimeMillis()
+        // val timeSinceModalClose = currentTime - lastModalCloseTime
+        // 
+        // Log.d(TAG, "🔍 [SILENT-FIX] onResume — isSilentModeActive=$isSilentModeActive | timeSinceModalClose=${timeSinceModalClose}ms")
+        //
+        // if (isSilentModeActive) {
+        //     val GRACE_PERIOD_MS = 3000L
+        //     val isReturningFromModal = timeSinceModalClose < GRACE_PERIOD_MS && lastModalCloseTime > 0
+        //     
+        //     if (isReturningFromModal) {
+        //         Log.d(TAG, "🌙 [SILENT-FIX] Resume dentro de ventana de gracia (${timeSinceModalClose}ms) — Modo Silencio se mantiene activo")
+        //     } else {
+        //         // ❌ PROBLEMA: Desactivaba Modo Silencio al abrir app desde launcher o después de >3s
+        //         Log.d(TAG, "🌙 [SILENT-FIX] Apertura intencional detectada (${timeSinceModalClose}ms desde modal) — desactivando Modo Silencio")
+        //         KeepAliveService.stop(this)
+        //         NotificationManagerCompat.from(this).cancelAll()
+        //         isSilentModeActive = false
+        //         silentPrefs.edit()
+        //             .putBoolean("is_silent_mode_active", false)
+        //             .putLong("last_modal_close_time", 0L)
+        //             .apply()
+        //         Log.d(TAG, "✅ [SILENT-FIX] Modo Silencio desactivado desde onResume()")
+        //     }
+        // }
+        //
+        // CÓDIGO ORIGINAL (pre-PR #94 - flag modal_was_open):
         // val silentPrefs = getSharedPreferences("zync_silent_mode", MODE_PRIVATE)
         // val modalWasOpen = silentPrefs.getBoolean("modal_was_open", false)
         // Log.d(TAG, "🔍 [DIAG-G1.3] onResume — isSilentModeActive=$isSilentModeActive | modal_was_open=$modalWasOpen")
@@ -188,43 +207,19 @@ class MainActivity: FlutterActivity() {
         //         KeepAliveService.stop(this)
         //         NotificationManagerCompat.from(this).cancelAll()
         //         isSilentModeActive = false
-        //         // G2.C1: Limpiar flag persistido
         //         silentPrefs.edit().putBoolean("is_silent_mode_active", false).apply()
         //         Log.d(TAG, "✅ [SILENT] Modo Silencio desactivado desde onResume()")
         //     }
         // }
         // ========================================================================
-        // FIN CÓDIGO ORIGINAL
+        // FIN CÓDIGO ANTERIOR
         // ========================================================================
 
-        // 🌙 NUEVO CÓDIGO: Detección robusta de intención de apertura
-        val silentPrefs = getSharedPreferences("zync_silent_mode", MODE_PRIVATE)
-        val lastModalCloseTime = silentPrefs.getLong("last_modal_close_time", 0L)
-        val currentTime = System.currentTimeMillis()
-        val timeSinceModalClose = currentTime - lastModalCloseTime
-        
-        Log.d(TAG, "🔍 [SILENT-FIX] onResume — isSilentModeActive=$isSilentModeActive | timeSinceModalClose=${timeSinceModalClose}ms")
-
+        // 🌙 NUEVO CÓDIGO: Modo Silencio permanece activo siempre (app abierta/minimizada)
         if (isSilentModeActive) {
-            // Ventana de gracia: 3 segundos desde el cierre del modal
-            val GRACE_PERIOD_MS = 3000L
-            val isReturningFromModal = timeSinceModalClose < GRACE_PERIOD_MS && lastModalCloseTime > 0
-            
-            if (isReturningFromModal) {
-                Log.d(TAG, "🌙 [SILENT-FIX] Resume dentro de ventana de gracia (${timeSinceModalClose}ms) — Modo Silencio se mantiene activo")
-            } else {
-                // Usuario abrió la app intencionalmente (launcher, recientes, etc.)
-                Log.d(TAG, "🌙 [SILENT-FIX] Apertura intencional detectada (${timeSinceModalClose}ms desde modal) — desactivando Modo Silencio")
-                KeepAliveService.stop(this)
-                NotificationManagerCompat.from(this).cancelAll()
-                isSilentModeActive = false
-                // G2.C1: Limpiar flag persistido
-                silentPrefs.edit()
-                    .putBoolean("is_silent_mode_active", false)
-                    .putLong("last_modal_close_time", 0L) // Limpiar timestamp
-                    .apply()
-                Log.d(TAG, "✅ [SILENT-FIX] Modo Silencio desactivado desde onResume()")
-            }
+            // Para app abierta/minimizada: NUNCA desactivar en onResume()
+            // Solo desactivar con logout explícito (manejado en deactivate() del canal KEEP_ALIVE_CHANNEL)
+            Log.d(TAG, "🌙 [SILENT] onResume con Modo Silencio activo — manteniéndolo activo (app abierta/minimizada)")
         }
 
         // Procesar estado pendiente del cache (selección desde EmojiDialogActivity)


### PR DESCRIPTION
## Summary

**CORRECCIÓN CRÍTICA**: Eliminada lógica de ventana de gracia (PR #94) que desactivaba incorrectamente el Modo Silencio.

El PR #94 introdujo una ventana de gracia de 3 segundos que, aunque resolvió los bugs originales, creó un nuevo problema: desactivaba el Modo Silencio cuando el usuario abría la app desde launcher o después de >3s.

## Comportamiento CORRECTO para App Abierta/Minimizada

Una vez activado el "Modo Silencio", el ícono "i" **PERMANECE SIEMPRE** mientras la app esté abierta/minimizada (proceso vivo):

✅ **NO importa**:
- Cuánto tiempo pase
- Cuántas veces se minimice/maximice
- Si se abre desde launcher o recientes
- Si se interactúa con modales (nativos o Flutter)

✅ **ÚNICA excepción**: Logout (cierre de sesión) → desactiva correctamente

## Problema del PR #94

### Lógica implementada (INCORRECTA):
```kotlin
if (isSilentModeActive) {
    val GRACE_PERIOD_MS = 3000L
    if (timeSinceModalClose < GRACE_PERIOD_MS) {
        // Mantener activo ✅
    } else {
        // ❌ DESACTIVAR (INCORRECTO para app abierta/minimizada)
        KeepAliveService.stop(this)
        NotificationManagerCompat.from(this).cancelAll()
    }
}
```

### Casos afectados:
- ❌ Abrir app desde launcher (>3s después de modal)
- ❌ Maximizar app después de tiempo prolongado
- ❌ Volver de Settings de batería
- ❌ Volver de llamada telefónica
- ❌ Cualquier `onResume()` >3s después del último modal

## Solución Implementada

### Nueva lógica (CORRECTA):
```kotlin
if (isSilentModeActive) {
    // Para app abierta/minimizada: NUNCA desactivar en onResume()
    // Solo desactivar con logout explícito
    Log.d(TAG, "🌙 [SILENT] onResume con Modo Silencio activo — manteniéndolo activo")
}
```

**Desactivación SOLO en**:
- ✅ Logout explícito (canal `KEEP_ALIVE_CHANNEL` método `deactivate()`)

## Caso Edge Agregado

### E7: Idempotencia del botón "Modo Silencio"
**Escenario**: Activar "Modo Silencio" → minimizar → maximizar → tocar botón nuevamente

**Esperado**: 
- Ícono permanece visible
- NO se crea un segundo ícono
- `KeepAliveService.start()` debe ser idempotente

**Testing requerido**: Verificar que no se duplican notificaciones

## Code Changes

### `MainActivity.kt` (líneas 149-238)
- ✅ **Comentado código PR #94** (líneas 165-191) con documentación completa
- ✅ **Nueva lógica simple** (líneas 218-223): solo log, sin desactivación
- ✅ **Preservado código original** (pre-PR #94) como referencia histórica

### `EmojiDialogActivity.kt` (líneas 85-127)
- ✅ **Eliminado código de timestamps** (ya no necesario)
- ✅ **Comentado código anterior** con explicación
- ✅ **Logs simplificados** sin persistencia de timestamps

## Testing Checklist

### Casos Normales - App Abierta/Minimizada
- [ ] Activar Modo Silencio → minimizar → ícono aparece ✅
- [ ] Toca notificación → selecciona emoji → ícono permanece ✅
- [ ] Minimiza/maximiza rápido (<3s) → ícono permanece ✅
- [ ] **NUEVO**: Minimiza/maximiza lento (>3s) → ícono permanece ✅
- [ ] **NUEVO**: Abrir desde launcher → ícono permanece ✅
- [ ] **NUEVO**: Abrir desde recientes → ícono permanece ✅
- [ ] Maximiza → modal Flutter → emoji → ícono permanece ✅
- [ ] Logout → ícono desaparece ✅

### Casos Edge
- [ ] E1: Notificación → SOS → maximizar → ícono permanece ✅
- [ ] E2: Modal Flutter → emoji → minimizar/maximizar → ícono permanece ✅
- [ ] E3: Notificación → BACK → maximizar → ícono permanece ✅
- [ ] E4: **NUEVO**: Settings batería → volver → ícono permanece ✅
- [ ] E5: **NUEVO**: Llamada → terminar → volver → ícono permanece ✅
- [ ] E6: Cambiar estado 5 veces → maximizar → ícono permanece ✅
- [ ] E7: **NUEVO**: Activar → minimizar → maximizar → activar nuevamente → sin duplicar ícono ✅

## Files Modified

- `android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt` (+68 lines, -76 lines)
- `android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt` (simplified)

## Documentation

Todo el código anterior preservado como comentarios con:
- Fecha de cambio (2026-04-11 segunda iteración)
- Explicación del problema del PR #94
- Comportamiento correcto esperado
- Referencias cruzadas entre archivos

## Related PRs

- Revierte parcialmente: PR #94 (mantiene fixes de Bug #1 y Bug #2, elimina ventana de gracia)
- Basado en: Análisis de comportamiento correcto para app abierta/minimizada

## Next Steps

Después de este PR, abordar:
- **SEGUNDO TRAMO**: Comportamiento cuando app está cerrada (proceso matado)
- **TERCER CASO**: Logout (ya funciona correctamente)
