### PR TITLE
fix: close app from recents when activating Silent Mode (Rule 2)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -448,19 +448,18 @@ class MainActivity: FlutterActivity() {
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, KEEP_ALIVE_CHANNEL).setMethodCallHandler { call, result ->
             when (call.method) {
                 "activate" -> {
-                    // Idempotencia: si ya está activo, solo minimizar sin reiniciar el servicio.
+                    // Idempotencia: si ya está activo, cerrar app sin reiniciar el servicio.
                     if (isSilentModeActive) {
-                        Log.d(TAG, "🌙 [SILENT] Ya activo — ignorando activación redundante")
-                        moveTaskToBack(true)
+                        Log.d(TAG, "🌙 [SILENT] Ya activo — cerrando app (Regla 2, idempotencia)")
                         result.success(true)
+                        finishAndRemoveTask()
                         return@setMethodCallHandler
                     }
                     Log.d(TAG, "🌙 [SILENT] Activando Modo Silencio")
                     // Exención de batería: se solicita una sola vez, sin bloquear la activación.
-                    // El diálogo del sistema aparece mientras la app ya se está minimizando.
+                    // El diálogo del sistema aparece mientras la app ya se está cerrando.
                     val pm = getSystemService(Context.POWER_SERVICE) as PowerManager
                     if (!pm.isIgnoringBatteryOptimizations(packageName)) {
-                        Log.w(TAG, "⚠️ [DIAG-G1.3] startActivity(batteryIntent) — onResume() se disparará al volver. modal_was_open NO se establece aquí → posible desactivación espuria")
                         val batteryIntent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
                             data = Uri.parse("package:$packageName")
                         }
@@ -471,9 +470,9 @@ class MainActivity: FlutterActivity() {
                     // G2.C1: Persistir para sobrevivir swipe/kill del proceso
                     getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
                         .edit().putBoolean("is_silent_mode_active", true).apply()
-                    Log.d(TAG, "🔍 [DIAG-G1.3] isSilentModeActive establecido en true — moveTaskToBack a continuación")
-                    moveTaskToBack(true)
+                    Log.d(TAG, "🌙 [SILENT] isSilentModeActive=true — cerrando app (Regla 2)")
                     result.success(true)
+                    finishAndRemoveTask()
                 }
                 "deactivate" -> {
                     Log.d(TAG, "🌙 [SILENT] Desactivando Modo Silencio (logout)")
@@ -502,30 +501,6 @@ class MainActivity: FlutterActivity() {
                 else -> result.notImplemented()
             }
         }
-
-        // =====================================================================
-        // [POC DEBUG] Canal temporal — rama feat/silent-app-closed-0
-        // ELIMINAR antes de merge a producción
-        // Propósito: validar que finishAndRemoveTask() no mata el proceso
-        // =====================================================================
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "zync/debug_poc").setMethodCallHandler { call, result ->
-            when (call.method) {
-                "finishAndRemoveTask" -> {
-                    Log.d(TAG, "🧪 [POC] Iniciando KeepAliveService + finishAndRemoveTask()")
-                    KeepAliveService.start(this)
-                    isSilentModeActive = true
-                    getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
-                        .edit().putBoolean("is_silent_mode_active", true).apply()
-                    result.success(true)
-                    finishAndRemoveTask()
-                    Log.d(TAG, "🧪 [POC] finishAndRemoveTask() llamado")
-                }
-                else -> result.notImplemented()
-            }
-        }
-        // =====================================================================
-        // FIN [POC DEBUG]
-        // =====================================================================
 
         // Point 21 FASE 5: Canal para notificaciones (apunta a StatusModalActivity)
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -1,5 +1,4 @@
 import 'dart:async'; // Necesario para StreamSubscription
-import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -990,37 +989,6 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                 ),
               ],
             ),
-            // =================================================================
-            // [POC DEBUG] Botón temporal — rama feat/silent-app-closed-0
-            // ELIMINAR antes de merge a producción
-            // Propósito: validar que finishAndRemoveTask() no mata el proceso
-            // =================================================================
-            if (kDebugMode)
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton.icon(
-                    onPressed: () async {
-                      const channel = MethodChannel('zync/debug_poc');
-                      await channel.invokeMethod('finishAndRemoveTask');
-                    },
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.orange,
-                      side: const BorderSide(color: Colors.orange),
-                      padding: const EdgeInsets.symmetric(vertical: 10),
-                    ),
-                    icon: const Icon(Icons.bug_report, size: 16),
-                    label: const Text(
-                      '[POC] finishAndRemoveTask',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                  ),
-                ),
-              ),
-            // =================================================================
-            // FIN [POC DEBUG]
-            // =================================================================
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- Implementa Regla 2: tap "Modo Silencio" → app desaparece de recientes
- Reemplaza `moveTaskToBack(true)` por `finishAndRemoveTask()` en ambos bloques del handler `activate`
- `result.success(true)` se llama antes de `finishAndRemoveTask()` en ambos casos para evitar race condition en el canal Flutter
- Elimina código PoC debug (`zync/debug_poc` canal + botón naranja) de `feat/silent-app-closed-0`

## Archivos modificados
- `android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt` — Cambios 1 y 2 en handler `activate`
- `lib/features/circle/presentation/widgets/in_circle_view.dart` — eliminación del botón PoC debug

## Tests a ejecutar (dispositivo físico)
- ST.A1 — App desaparece de recientes al activar
- ST.A2 — Ícono "i" aparece en BN
- ST.A3 — Proceso sigue vivo (`adb shell ps`)
- ST.A4 — Notificación persiste 30s
- ST.A5 — Idempotencia: segundo tap también cierra
- ST.A6 — Notificación no parpadea durante cierre
- ST.D1–ST.D5 — Regresiones

## Validación previa
PoC (PR #98) confirmó que `finishAndRemoveTask()` no destruye el proceso. `KeepAliveService` sobrevive con `isForeground=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)