### PR TITLE
feat: deactivate Silent Mode on app open (Rule 1 — node ③)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -106,8 +106,31 @@ class MainActivity: FlutterActivity() {
         val silentPrefs = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
         isSilentModeActive = silentPrefs.getBoolean("is_silent_mode_active", false)
         Log.d(TAG, "🌙 [SILENT] onCreate — isSilentModeActive restaurado: $isSilentModeActive")
-        
-        // �📊 PERFORMANCE: Detectar si es recreación o primer launch
+
+        // ========================================================================
+        // [CORRECCIÓN] Regla 1 — app start con Modo Silencio activo → desactivar ícono "i"
+        // Fecha: 2026-04-14
+        //
+        // PROBLEMA ORIGINAL:
+        // - Al reabrir la app mientras Modo Silencio estaba activo, el ícono "i"
+        //   permanecía visible en la barra de notificaciones aunque el usuario ya
+        //   estaba interactuando activamente con la app.
+        //
+        // SOLUCIÓN IMPLEMENTADA:
+        // - En onCreate(): si isSilentModeActive == true → detener KeepAliveService,
+        //   cancelar todas las notificaciones y limpiar el flag persistido.
+        // - Implementa el nodo ③ del flujo: "Existe ícono i → Desaparece → Pantalla Círculo"
+        // ========================================================================
+        if (isSilentModeActive) {
+            Log.d(TAG, "🌙 [SILENT] onCreate — Modo Silencio activo detectado → desactivando (Regla 1)")
+            KeepAliveService.stop(this)
+            NotificationManagerCompat.from(this).cancelAll()
+            isSilentModeActive = false
+            silentPrefs.edit().putBoolean("is_silent_mode_active", false).apply()
+            Log.d(TAG, "✅ [SILENT] onCreate — ícono 'i' eliminado, isSilentModeActive=false")
+        }
+
+        //�📊 PERFORMANCE: Detectar si es recreación o primer launch
         val wasRunning = savedInstanceState?.getBoolean("was_running", false) ?: false
         if (wasRunning) {
             Log.d(TAG, "onCreate() - Restaurando estado (Android destruyó la actividad)")

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -17,7 +17,7 @@ import 'status_service.dart';
 ///   - Estado isSilentModeActive
 ///   - Notificación persistente (via startForeground)
 ///   - moveTaskToBack() al activar
-///   - Detener todo en onResume() cuando el usuario reabre la app
+///   - Detener todo en onCreate() cuando el usuario reabre la app (Regla 1)
 class SilentFunctionalityCoordinator {
   static const _channel = MethodChannel('zync/keep_alive');
 


### PR DESCRIPTION
## Summary
- Implements **Cambio 3 (Regla 1)**: when the app opens and `isSilentModeActive == true`, `onCreate()` now stops `KeepAliveService`, cancels all notifications, and clears the persisted flag
- Implements flow node ③: *"Existe ícono 'i' → Desaparece → Pantalla Círculo"*
- **Cambio 5**: updates doc comment in `SilentFunctionalityCoordinator` — deactivation now happens in `onCreate()`, not `onResume()`

## Files modified
- `android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt` — Regla 1 block after flag restore in `onCreate()`
- `lib/core/services/silent_functionality_coordinator.dart` — doc comment line 20

## Test plan
- [ ] Activate Silent Mode — app closes, icon 'i' appears (unchanged)
- [ ] Reopen app from launcher — icon 'i' disappears, home screen loads normally
- [ ] Reopen app from notification tap — icon 'i' disappears, home screen loads normally
- [ ] Open app with no Silent Mode active — normal cold start, no behavior change
- [ ] Logout — icon 'i' disappears (unchanged)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>