### PR TITLE
fix: eliminate Disconnected status, restore last status on app reopen

### DIFF
--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import '../../notifications/notification_service.dart';
 import '../../quick_actions/quick_actions_service.dart';
 import '../../services/circle_service.dart';
+import '../models/user_status.dart';
 import 'status_modal_service.dart';
 import 'status_service.dart';
 
@@ -63,8 +64,7 @@ class SilentFunctionalityCoordinator {
         return;
       }
       _userHasCircle = true;
-      await StatusService.clearOfflineStatus();
-      debugPrint('[SilentCoordinator][DBG] clearOfflineStatus → OK');
+      // El último estado se preserva en Firestore — no se resetea a 'fine'.
     } catch (e) {
       debugPrint('[SilentCoordinator][DBG] activateAfterLogin EXCEPCIÓN: $e');
     }
@@ -99,7 +99,22 @@ class SilentFunctionalityCoordinator {
   static Future<void> activateSilentMode(BuildContext context) async {
     debugPrint('[SilentCoordinator][DBG] activateSilentMode → logout=$_isManualLogoutInProgress, circle=$_userHasCircle, mounted=${context.mounted}');
     if (_isManualLogoutInProgress) return;
-    if (!_userHasCircle) return;
+    if (!context.mounted) return;
+
+    // Bug 2 fix: _userHasCircle puede ser false en cold start por race condition
+    // (activateAfterLogin aún no terminó). Re-verificar desde Firebase antes de cancelar.
+    if (!_userHasCircle) {
+      try {
+        final userCircle = await CircleService().getUserCircle();
+        debugPrint('[SilentCoordinator][DBG] activateSilentMode — re-check circle → ${userCircle != null ? userCircle.name : "NULL"}');
+        if (userCircle == null) return;
+        _userHasCircle = true;
+      } catch (e) {
+        debugPrint('[SilentCoordinator][DBG] activateSilentMode — error re-checking circle: $e');
+        return;
+      }
+    }
+
     if (!context.mounted) return;
 
     final hasPermission = await NotificationService.requestPermissions();
@@ -110,6 +125,15 @@ class SilentFunctionalityCoordinator {
       _showNotificationsDisabledInfo(context);
       return;
     }
+
+    // Escribir 'do_not_disturb' en Firestore antes de que el isolate Dart muera.
+    // Esto reemplaza el concepto "Desconectado": los miembros del círculo ven
+    // 🔕 No molestar mientras el Modo Silencio está activo.
+    final doNotDisturb = StatusType.fallbackPredefined.firstWhere((s) => s.id == 'do_not_disturb');
+    await StatusService.updateUserStatus(doNotDisturb);
+    debugPrint('[SilentCoordinator][DBG] do_not_disturb escrito en Firestore');
+
+    if (!context.mounted) return;
 
     try {
       debugPrint('[SilentCoordinator][DBG] invokeMethod activate →');

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -240,60 +240,32 @@ class StatusService {
     }
   }
 
-  /// Marca al usuario como desconectado en su círculo (cierre de sesión deliberado).
-  /// Fire-and-forget: no lanza excepción para no bloquear el flujo de logout.
+  // ========================================================================
+  // [ELIMINADO] setOfflineStatus / clearOfflineStatus — concepto "Desconectado"
+  // Fecha: 2026-04-14
+  //
+  // PROBLEMA ORIGINAL:
+  // - Con finishAndRemoveTask() el isolate Dart muere en AppLifecycleState.detached.
+  //   Flutter escribía "loggedOut: true" en Firestore, mostrando "💤 Desconectado"
+  //   a los miembros del círculo aunque el usuario solo activó Modo Silencio.
+  //
+  // SOLUCIÓN IMPLEMENTADA:
+  // - Eliminar el concepto "Desconectado" por completo.
+  // - Al activar Modo Silencio → se escribe 'do_not_disturb' en Firestore (ver
+  //   SilentFunctionalityCoordinator.activateSilentMode).
+  // - Al reabrir la app → el último estado persiste en Firestore sin reset a 'fine'.
+  // - Estos métodos se conservan como no-ops para evitar errores de compilación
+  //   durante la transición; eliminar en post-MVP.
+  // ========================================================================
+
+  /// @deprecated — No-op. Reemplazado por escritura de 'do_not_disturb' en activateSilentMode.
   static Future<void> setOfflineStatus() async {
-    try {
-      final user = FirebaseAuth.instance.currentUser;
-      if (user == null) return;
-
-      final userDoc = await FirebaseFirestore.instance
-          .collection('users')
-          .doc(user.uid)
-          .get();
-      final circleId = userDoc.data()?['circleId'] as String?;
-      if (circleId == null) return;
-
-      await FirebaseFirestore.instance
-          .collection('circles')
-          .doc(circleId)
-          .update({
-        'memberStatus.${user.uid}.loggedOut': true,
-        'memberStatus.${user.uid}.timestamp': FieldValue.serverTimestamp(),
-      });
-      log('[StatusService] 💤 Estado offline registrado — logout deliberado');
-    } catch (e) {
-      log('[StatusService] ⚠️ setOfflineStatus falló (no bloqueante): $e');
-    }
+    log('[StatusService] ⚠️ setOfflineStatus() llamado — no-op (deprecado)');
   }
 
-  /// Limpia el estado offline al iniciar sesión nuevamente.
-  /// Resetea a statusType 'fine' para que el usuario aparezca activo en su círculo.
-  /// Fire-and-forget: no lanza excepción.
+  /// @deprecated — No-op. El último estado se preserva en Firestore; no resetear a fine.
   static Future<void> clearOfflineStatus() async {
-    try {
-      final user = FirebaseAuth.instance.currentUser;
-      if (user == null) return;
-
-      final userDoc = await FirebaseFirestore.instance
-          .collection('users')
-          .doc(user.uid)
-          .get();
-      final circleId = userDoc.data()?['circleId'] as String?;
-      if (circleId == null) return;
-
-      await FirebaseFirestore.instance
-          .collection('circles')
-          .doc(circleId)
-          .update({
-        'memberStatus.${user.uid}.loggedOut': FieldValue.delete(),
-        'memberStatus.${user.uid}.statusType': 'fine',
-        'memberStatus.${user.uid}.timestamp': FieldValue.serverTimestamp(),
-      });
-      log('[StatusService] 🟢 Estado offline limpiado — usuario activo nuevamente');
-    } catch (e) {
-      log('[StatusService] ⚠️ clearOfflineStatus falló (no bloqueante): $e');
-    }
+    log('[StatusService] ⚠️ clearOfflineStatus() llamado — no-op (deprecado)');
   }
 
   static Future<bool> _isSpecificZoneTypeConfigured(String circleId, String zoneType) async {

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -418,27 +418,6 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
       };
     }
 
-    // T5.6: Logout deliberado — máxima prioridad, retorno temprano
-    final loggedOut = statusData['loggedOut'] as bool? ?? false;
-    if (loggedOut) {
-      final timestamp = statusData['timestamp'];
-      DateTime? loggedOutAt;
-      if (timestamp is Timestamp) loggedOutAt = timestamp.toDate();
-      return {
-        'emoji': '💤',
-        'status': 'offline',
-        'coordinates': null,
-        'hasGPS': false,
-        'lastUpdate': loggedOutAt,
-        'autoUpdated': false,
-        'zoneName': null,
-        'displayText': 'Desconectado',
-        'showManualBadge': false,
-        'locationInfo': null,
-        'isOffline': true,
-      };
-    }
-
     final rawStatusType = statusData['statusType'] as String?;
     final statusType = _migrateOldStatus(rawStatusType);
     final autoUpdated = statusData['autoUpdated'] as bool? ?? false;
@@ -547,7 +526,6 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
       'displayText': displayText, // 🆕 Texto a mostrar (zona o estado)
       'showManualBadge': showManualBadge, // 🆕 Mostrar badge ✋ Manual
       'locationInfo': locationInfo, // 🆕 Info de ubicación desconocida/última zona
-      'isOffline': false, // T5.6: No desconectado (cambia a true solo via loggedOut)
     };
 
     print('[InCircleView] 🎯 RETORNANDO: emoji=$emoji, displayText=$displayText, autoUpdated=$autoUpdated');
@@ -564,7 +542,6 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
         oldData['displayText'] != newData['displayText'] || // 🆕 Detecta cambio de texto
         oldData['showManualBadge'] != newData['showManualBadge'] || // 🆕 Detecta cambio de badge
         oldData['locationInfo'] != newData['locationInfo'] || // 🆕 Detecta cambio de ubicación
-        oldData['isOffline'] != newData['isOffline'] || // T5.6: Detecta transición online ↔ offline
         oldData['lastUpdate']?.millisecondsSinceEpoch != newData['lastUpdate']?.millisecondsSinceEpoch ||
         oldData['coordinates']?.toString() != newData['coordinates']?.toString(); // Comparación simple para coordenadas
   }
@@ -1276,7 +1253,6 @@ class _MemberListItem extends StatelessWidget {
     final displayText = memberData['displayText'] as String?; // 🆕 Texto del estado o zona
     final showManualBadge = memberData['showManualBadge'] as bool? ?? false; // 🆕
     final locationInfo = memberData['locationInfo'] as String?; // 🆕
-    final isOffline = memberData['isOffline'] as bool? ?? false; // T5.6
     final isSOS = status == 'sos';
 
     print(
@@ -1306,12 +1282,9 @@ class _MemberListItem extends StatelessWidget {
                 children: [
                   AnimatedSwitcher(
                     duration: const Duration(milliseconds: 150),
-                    child: Opacity(
-                      opacity: isOffline ? 0.4 : 1.0,
-                      child: Text(emoji,
-                          key: ValueKey(emoji),
-                          style: const TextStyle(fontSize: 32)), // 🆕 Cambio: ValueKey(emoji) detecta cambios de customEmoji
-                    ),
+                    child: Text(emoji,
+                        key: ValueKey(emoji),
+                        style: const TextStyle(fontSize: 32)), // 🆕 Cambio: ValueKey(emoji) detecta cambios de customEmoji
                   ),
                   const SizedBox(width: 12),
                   Expanded(
@@ -1322,9 +1295,7 @@ class _MemberListItem extends StatelessWidget {
                           children: [
                             Flexible(
                                 child: Text(nickname,
-                                    style: isOffline
-                                        ? _AppTextStyles.memberNickname.copyWith(color: _AppColors.textSecondary)
-                                        : _AppTextStyles.memberNickname,
+                                    style: _AppTextStyles.memberNickname,
                                     overflow: TextOverflow.ellipsis)),
                             if (isCurrentUser) ...[
                               const SizedBox(width: 8),
@@ -1386,22 +1357,6 @@ class _MemberListItem extends StatelessWidget {
                             key: const Key('text_location_info'),
                             locationInfo,
                             style: TextStyle(fontSize: 11, color: Colors.grey[500]),
-                          ),
-                        ],
-                        // T5.6: Badge de desconexión deliberada
-                        if (isOffline) ...[
-                          const SizedBox(height: 4),
-                          Container(
-                            key: const Key('badge_offline'),
-                            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                            decoration: BoxDecoration(
-                              color: Colors.grey.withValues(alpha: 0.15),
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: const Text(
-                              '💤 Desconectado',
-                              style: TextStyle(fontSize: 11, color: Colors.grey),
-                            ),
                           ),
                         ],
                         if (isFirst && status != 'loading') // No mostrar "Creador" si está cargando

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -8,7 +8,6 @@ import '../../../../features/auth/presentation/pages/auth_final_page.dart';
 import '../../../../core/widgets/quick_actions_config_widget.dart';
 import '../../../../core/services/silent_functionality_coordinator.dart'; // Point 1 SPEC
 import '../../../../core/services/session_cache_service.dart'; // FIX: Para limpiar cache en logout
-import '../../../../core/services/status_service.dart'; // T5.6: Estado offline en logout
 import 'emoji_management_page.dart'; // Gestión de estados/emojis
 import '../../../geofencing/presentation/pages/zones_page.dart'; // Gestión de zonas geográficas
 import '../../../../services/circle_service.dart'; // Para obtener Circle object
@@ -582,10 +581,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> with SingleTickerPr
                 // FIX: Limpiar SessionCache INMEDIATAMENTE para evitar parpadeo
                 print('🔴 [LOGOUT] Limpiando SessionCache...');
                 await SessionCacheService.clearSession();
-
-                // Registrar desconexión deliberada en el círculo (T5.6)
-                print('🔴 [LOGOUT] Registrando estado offline en círculo...');
-                await StatusService.setOfflineStatus();
 
                 print('🔴 [LOGOUT] Paso 2/3: Cerrando sesión de Firebase...');
 


### PR DESCRIPTION
## Summary
- **Bug 1 fix:** Eliminado el concepto `💤 Desconectado` — era causado por `AppLifecycleState.detached` escribiendo `loggedOut: true` en Firestore cuando `finishAndRemoveTask()` mataba el isolate Dart
- **Nuevo comportamiento al activar Modo Silencio:** escribe `do_not_disturb` (`🔕 No molestar`) en Firestore — los miembros del círculo ven el estado correcto
- **Al reabrir la app / login:** el último estado en Firestore se preserva — no más reset a `fine` (resuelve emojis incorrectos en Universidad y Reunión)
- **Al hacer logout:** no se escribe ningún flag — el último estado permanece tal cual
- **Bug 2 fix:** `activateSilentMode()` re-verifica el círculo desde Firebase si `_userHasCircle == false` (race condition de cold start), evitando que el primer tap no haga nada

## Files modified
- `lib/core/services/status_service.dart` — `setOfflineStatus()` y `clearOfflineStatus()` → no-ops deprecados
- `lib/core/services/silent_functionality_coordinator.dart` — escribe `do_not_disturb` antes de activar; re-check círculo en cold start; elimina `clearOfflineStatus()` en login
- `lib/features/circle/presentation/widgets/in_circle_view.dart` — elimina bloque `loggedOut`, variable `isOffline`, badge `💤 Desconectado`, y sus renders
- `lib/features/settings/presentation/pages/settings_page.dart` — elimina llamada a `setOfflineStatus()` en logout

## Test plan
- [ ] Activar Modo Silencio → miembros del círculo ven `🔕 No molestar`
- [ ] Reabrir app tras Modo Silencio → Pantalla Círculo carga con el último estado (no `🙂 Bien`)
- [ ] Universidad activo → cerrar app → reabrir → sigue mostrando Universidad
- [ ] Logout → reabrir → login → estado cargado desde Firestore (no reset a `fine`)
- [ ] Cold start + tap inmediato en Modo Silencio → funciona al primer tap (Bug 2)
- [ ] Badge `💤 Desconectado` ya no aparece para ningún miembro

🤖 Generated with [Claude Code](https://claude.com/claude-code)