### PR TITLE
feat: periodic handler to re-assert foreground notification (Change 6)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -4,7 +4,9 @@ import android.app.*
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
 import android.util.Log
 import androidx.core.app.NotificationCompat
 
@@ -13,13 +15,46 @@ import androidx.core.app.NotificationCompat
  * Patrón usado por WhatsApp/Telegram para evitar process kill de Android
  */
 class KeepAliveService : Service() {
-    
+
+    // ========================================================================
+    // [CAMBIO 6] Handler periódico — re-llama startForeground() cada 5 s
+    // Fecha: 2026-04-14
+    //
+    // PROBLEMA ORIGINAL:
+    // - OEM agresivos (Samsung "Borrar todo", Xiaomi MIUI, Huawei) pueden descartar
+    //   la notificación foreground después de un tiempo aunque START_STICKY esté activo.
+    //   Esto hace que el ícono "i" desaparezca sin que el usuario haya reabierto la app.
+    //
+    // SOLUCIÓN IMPLEMENTADA:
+    // - Un Handler en el main looper re-llama startForeground() cada KEEP_ALIVE_INTERVAL_MS.
+    // - Re-llamar startForeground() con la misma notificación es idempotente: si ya existe,
+    //   Android simplemente la reafirma; no crea duplicados ni genera vibración/sonido.
+    // - El handler se cancela en onDestroy() para no leak de callbacks.
+    // ========================================================================
+    private val keepAliveHandler = Handler(Looper.getMainLooper())
+    private val keepAliveRunnable = object : Runnable {
+        override fun run() {
+            try {
+                val notification = createNotification()
+                startForeground(NOTIFICATION_ID, notification)
+                Log.d(TAG, "🔄 [KEEP-ALIVE] startForeground re-afirmado (handler periódico)")
+            } catch (e: Exception) {
+                Log.w(TAG, "⚠️ [KEEP-ALIVE] Error en tick periódico: ${e.message}")
+            }
+            keepAliveHandler.postDelayed(this, KEEP_ALIVE_INTERVAL_MS)
+        }
+    }
+
     companion object {
         private const val TAG = "KeepAliveService"
         // Canal propio del Modo Silencio — IMPORTANCE_HIGH evita que Samsung lo descarte
         // con "Borrar todo". Canal nuevo (_v2) para forzar recreación con la nueva importance.
         private const val CHANNEL_ID = "zync_silent_mode_v2"
         private const val NOTIFICATION_ID = 12346
+        // Cambio 6: Intervalo del handler periódico que re-llama startForeground().
+        // 5 s es suficientemente frecuente para resistir OEM agresivos (Samsung, Xiaomi)
+        // sin impacto perceptible en batería (la notificación ya existe; solo se reafirma).
+        private const val KEEP_ALIVE_INTERVAL_MS = 5_000L
         
         fun start(context: Context) {
             Log.d(TAG, "🟢 Iniciando servicio keep-alive")
@@ -55,10 +90,16 @@ class KeepAliveService : Service() {
     
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "onStartCommand() - Iniciando foreground")
-        
+
         val notification = createNotification()
         startForeground(NOTIFICATION_ID, notification)
-        
+
+        // Cambio 6: Iniciar handler periódico. Cancelar cualquier callback previo primero
+        // para evitar duplicados si onStartCommand se llama más de una vez (START_STICKY restart).
+        keepAliveHandler.removeCallbacks(keepAliveRunnable)
+        keepAliveHandler.postDelayed(keepAliveRunnable, KEEP_ALIVE_INTERVAL_MS)
+        Log.d(TAG, "🔄 [KEEP-ALIVE] Handler periódico iniciado (intervalo: ${KEEP_ALIVE_INTERVAL_MS}ms)")
+
         // Point 3.1: START_STICKY garantiza que Android reinicie el servicio si lo mata
         // Esto mantiene la notificación persistente incluso si el sistema necesita memoria
         return START_STICKY
@@ -83,7 +124,11 @@ class KeepAliveService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         Log.d(TAG, "onDestroy() - Servicio destruido")
-        
+
+        // Cambio 6: Cancelar handler periódico para evitar callbacks tras destrucción.
+        keepAliveHandler.removeCallbacks(keepAliveRunnable)
+        Log.d(TAG, "🔄 [KEEP-ALIVE] Handler periódico cancelado en onDestroy()")
+
         // Point 3.1: Si el servicio se destruye inesperadamente (no por logout manual),
         // Android lo reiniciará automáticamente gracias a START_STICKY
     }


### PR DESCRIPTION
## Summary
- `KeepAliveService` schedules a Handler that calls `startForeground()` every 5 s
- Defends against OEM battery killers (Samsung, Xiaomi, Huawei) that discard foreground notifications even with START_STICKY active
- Re-calling `startForeground()` is idempotent — no duplicate notifications, sound, or vibration
- Handler cancelled in `onDestroy()` to prevent callback leaks

## File modified
- `android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt`

## Test plan
- [ ] Activate Silent Mode → icon 'i' appears
- [ ] Leave device idle 30+ s → icon 'i' persists; logcat shows 🔄 [KEEP-ALIVE] ticks
- [ ] Logout → icon 'i' disappears (handler cancelled)
- [ ] Reopen app → icon 'i' disappears (Regla 1, PR #100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)