### PR TITLE
fix: show SnackBar when zone status blocked from native modal (Falla C)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,6 +113,19 @@ Future<void> _updateStatusFromNative(String statusTypeName) async {
       print('✅ [NATIVE→FLUTTER] Estado actualizado en Firebase: ${statusType.description}');
     } else {
       print('❌ [NATIVE→FLUTTER] Error actualizando estado: ${result.errorMessage}');
+      if (result.errorMessage == 'zone_manual_selection_not_allowed') {
+        // Falla C fix: la zona está configurada para geofencing — el usuario seleccionó
+        // un estado de zona desde el modal nativo sin que el bloqueo visual estuviera activo
+        // (cache de zonas vacío en EmojiDialogActivity). Mostrar feedback vía SnackBar global.
+        rootScaffoldMessengerKey.currentState?.showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Esa zona se actualiza automáticamente por geofencing y no puede seleccionarse manualmente.',
+            ),
+            duration: Duration(seconds: 4),
+          ),
+        );
+      }
     }
   } catch (e) {
     print('❌ [NATIVE→FLUTTER] Error procesando estado: $e');


### PR DESCRIPTION
## Summary
- **Falla C fix:** `_updateStatusFromNative()` now handles `zone_manual_selection_not_allowed` from the native modal path — shows a SnackBar via `rootScaffoldMessengerKey` (already wired to `MaterialApp`)
- **Falla A** (key mismatch `"status"` vs `"statusType"`) — confirmed already fixed in current code; no change needed
- **Falla B** (`orElse: () => allEmojis.first` silent fallback) — confirmed already fixed in current code; no change needed

## Context
When `EmojiDialogActivity` opens with an empty `configuredZoneTypes` cache (first launch, cleared data, or slow sync), zone buttons appear enabled. If the user selects one, `StatusService.updateUserStatus()` returns `zone_manual_selection_not_allowed` and the update silently fails.

The Flutter modal paths (`StatusSelectorOverlay`, `NotificationStatusSelector`) already handle this error with a dialog. This PR closes the same gap for the native modal path.

## File modified
- `lib/main.dart` — `_updateStatusFromNative()`: handle `zone_manual_selection_not_allowed` with SnackBar

## Test plan
- [ ] Select a non-zone emoji from native modal (Silent Mode) → updates correctly
- [ ] Select a zone emoji when zone is configured and cache is populated → blocked at UI level in native modal (existing behavior)
- [ ] Select a zone emoji when zone cache is empty → SnackBar appears explaining geofencing auto-update
- [ ] Select any emoji from Flutter modal → existing zone-blocked dialog still works (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)