### PR TITLE
fix: restore pre-silent status on app open, eliminate icon reappearance (N1.01, N1.03)

### DIFF
--- a/TEST_PLAN_2.md
+++ b/TEST_PLAN_2.md
@@ -176,8 +176,6 @@
 
 ---
 
----
-
 # SECCIÓN 2 — NUEVOS
 
 > Tests pendientes de primera validación en dispositivo físico.
@@ -191,12 +189,12 @@
 
 | ID | Caso de prueba | Pasos | Resultado esperado | Estado |
 |:--:|:--------------|:------|:-------------------|:------:|
-| N1.01 | Ícono "i" desaparece al abrir desde launcher | (A) Activar Modo Silencio → (B) Tocar ícono ZYNC en launcher | Ícono "i" desaparece de BN en ≤2s | |
-| N1.02 | App aterriza en Pantalla Círculo — no en Login | Mismos pasos de N1.01 | Pantalla Círculo directa. Login no aparece | |
-| N1.03 | Sesión y datos preservados al reabrir | Mismos pasos de N1.01 → verificar nombre de usuario, emoji actual, miembros | Todos los datos coinciden con el estado previo al cierre | |
-| N1.04 | Emoji actualizado desde BN se refleja al reabrir | (A) Seleccionar emoji desde BN → (B) Abrir app desde launcher | El emoji seleccionado en BN es el que aparece en Pantalla Círculo | |
-| N1.05 | Abrir app sin Modo Silencio activo → sin efectos | Cerrar app normalmente → reabrir desde launcher | No aparece ícono "i". Comportamiento normal sin efectos secundarios | |
-
+| N1.01 | Ícono "i" desaparece al abrir desde launcher | (A) Activar Modo Silencio → (B) Tocar ícono ZYNC en launcher | Ícono "i" desaparece de BN en ≤2s | ⚠️ tarda ≥8s |
+| N1.02 | App aterriza en Pantalla Círculo — no en Login≥8s CRÍTICO!! | Mismos pasos de N1.01 | Pantalla Círculo directa. Login no aparece | ✅ |
+| N1.03 | Sesión y datos preservados al reabrir | Mismos pasos de N1.01 → verificar nombre de usuario, emoji actual, miembros | Todos los datos coinciden con el estado previo al cierre | ❌ Justo antes de cerrarse la app, esta adopta el emoji "NO Molestar", cuando debería mostrar el que elegió el usuario antes del cierre o el estado que tenía por geofencing |
+| N1.04 | Emoji actualizado desde BN se refleja al reabrir | (A) Seleccionar emoji desde BN → (B) Abrir app desde launcher | El emoji seleccionado en BN es el que aparece en Pantalla Círculo |✅ |
+| N1.05 | Abrir app sin Modo Silencio activo → sin efectos | Cerrar app normalmente → reabrir desde launcher | No aparece ícono "i". Comportamiento normal sin efectos secundarios | ✅ |
+| N1.06 | La BN es persistente, sea que se cierre manualmente con el botón "Borrar" del dispositivo o se haga un swipe sobre el mensaje de aviso de la BN | Cerrar la BN con el botón "Borrar"/swipe desde Android |  Persiste exitosamente el ícono "i", sin efectos secundarios | ✅ |
 ---
 
 ## N2 — Último estado preservado al reabrir (PR #101)

--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -34,6 +34,12 @@ class KeepAliveService : Service() {
     private val keepAliveHandler = Handler(Looper.getMainLooper())
     private val keepAliveRunnable = object : Runnable {
         override fun run() {
+            // N1.01 fix: abortar si stop() ya fue llamado para evitar que el ícono
+            // reaparezca en la ventana entre stopService() y onDestroy().
+            if (isBeingStopped) {
+                Log.d(TAG, "🛑 [KEEP-ALIVE] Handler abortado — isBeingStopped=true")
+                return
+            }
             try {
                 val notification = createNotification()
                 startForeground(NOTIFICATION_ID, notification)
@@ -55,8 +61,25 @@ class KeepAliveService : Service() {
         // 5 s es suficientemente frecuente para resistir OEM agresivos (Samsung, Xiaomi)
         // sin impacto perceptible en batería (la notificación ya existe; solo se reafirma).
         private const val KEEP_ALIVE_INTERVAL_MS = 5_000L
-        
+
+        // ========================================================================
+        // [CORRECCIÓN] N1.01 — Flag para evitar reaparición del ícono tras stop()
+        // Fecha: 2026-04-15
+        //
+        // PROBLEMA ORIGINAL:
+        // - stopService() es asíncrono: onDestroy() puede tardar ~5-8s en ejecutarse.
+        // - En ese intervalo, el handler periódico disparaba startForeground() y el ícono
+        //   "i" reaparecía brevemente en la BN (≥8s desde el cancelAll en Regla 1).
+        //
+        // SOLUCIÓN IMPLEMENTADA:
+        // - isBeingStopped se pone en true en stop(), antes de stopService().
+        // - keepAliveRunnable comprueba el flag al inicio y aborta si está en true.
+        // - Se resetea a false en start() y en onCreate() (cubre START_STICKY restart).
+        // ========================================================================
+        @Volatile var isBeingStopped = false
+
         fun start(context: Context) {
+            isBeingStopped = false  // Resetear al iniciar (cubre reactivación)
             Log.d(TAG, "🟢 Iniciando servicio keep-alive")
             try {
                 val intent = Intent(context, KeepAliveService::class.java)
@@ -74,9 +97,10 @@ class KeepAliveService : Service() {
                 Log.e(TAG, "❌ Error iniciando servicio: ${e.message}", e)
             }
         }
-        
+
         fun stop(context: Context) {
-            Log.d(TAG, "🔴 Deteniendo servicio keep-alive")
+            isBeingStopped = true   // Señal al handler de no re-afirmar startForeground()
+            Log.d(TAG, "🔴 Deteniendo servicio keep-alive (isBeingStopped=true)")
             val intent = Intent(context, KeepAliveService::class.java)
             context.stopService(intent)
         }
@@ -84,6 +108,7 @@ class KeepAliveService : Service() {
     
     override fun onCreate() {
         super.onCreate()
+        isBeingStopped = false  // Resetear si Android reinicia el servicio (START_STICKY)
         Log.d(TAG, "onCreate() - Servicio creado")
         createNotificationChannel()
     }

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -126,7 +126,27 @@ class MainActivity: FlutterActivity() {
             KeepAliveService.stop(this)
             NotificationManagerCompat.from(this).cancelAll()
             isSilentModeActive = false
-            silentPrefs.edit().putBoolean("is_silent_mode_active", false).apply()
+
+            // Leer estado previo ANTES de limpiar las prefs
+            val preSilentStatus = silentPrefs.getString("pre_silent_status_type", null)
+
+            // Limpiar todas las flags de Modo Silencio en un solo commit
+            silentPrefs.edit()
+                .putBoolean("is_silent_mode_active", false)
+                .remove("pre_silent_status_type")
+                .apply()
+
+            // Si hay estado previo guardado, encolarlo en pending_status para que
+            // Flutter lo restaure en Firestore al arrancar (vía canal pending_status)
+            if (!preSilentStatus.isNullOrEmpty()) {
+                getSharedPreferences("pending_status", Context.MODE_PRIVATE)
+                    .edit()
+                    .putString("statusType", preSilentStatus)
+                    .putLong("timestamp", System.currentTimeMillis())
+                    .apply()
+                Log.d(TAG, "📌 [SILENT] onCreate — Estado previo encolado para restaurar: $preSilentStatus")
+            }
+
             Log.d(TAG, "✅ [SILENT] onCreate — ícono 'i' eliminado, isSilentModeActive=false")
         }
 
@@ -490,9 +510,20 @@ class MainActivity: FlutterActivity() {
                     }
                     KeepAliveService.start(this)
                     isSilentModeActive = true
-                    // G2.C1: Persistir para sobrevivir swipe/kill del proceso
-                    getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
-                        .edit().putBoolean("is_silent_mode_active", true).apply()
+
+                    // N1.03 — Opción A: Guardar estado previo al Modo Silencio para
+                    // restaurarlo en Firestore cuando el usuario reabre la app (Regla 1).
+                    // Flutter pasa el statusType actual antes de escribir do_not_disturb.
+                    val preSilentStatusType = call.argument<String>("preSilentStatusType")
+                    val silentPrefsEditor = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
+                        .edit()
+                        .putBoolean("is_silent_mode_active", true)
+                    if (!preSilentStatusType.isNullOrEmpty() && preSilentStatusType != "do_not_disturb") {
+                        silentPrefsEditor.putString("pre_silent_status_type", preSilentStatusType)
+                        Log.d(TAG, "📌 [SILENT] Estado previo guardado: $preSilentStatusType")
+                    }
+                    silentPrefsEditor.apply()
+
                     Log.d(TAG, "🌙 [SILENT] isSilentModeActive=true — cerrando app (Regla 2)")
                     result.success(true)
                     finishAndRemoveTask()

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../notifications/notification_service.dart';
@@ -126,6 +128,23 @@ class SilentFunctionalityCoordinator {
       return;
     }
 
+    // N1.03 — Opción A: Leer el statusType actual antes de sobreescribir con do_not_disturb.
+    // Se pasa a Kotlin para que lo persista y lo restaure en Firestore al reabrir la app.
+    String? preSilentStatusType;
+    try {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user != null) {
+        final userDoc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(user.uid)
+            .get();
+        preSilentStatusType = userDoc.data()?['statusType'] as String?;
+        debugPrint('[SilentCoordinator][DBG] Estado previo leído: $preSilentStatusType');
+      }
+    } catch (e) {
+      debugPrint('[SilentCoordinator][DBG] Error leyendo estado previo: $e');
+    }
+
     // Escribir 'do_not_disturb' en Firestore antes de que el isolate Dart muera.
     // Esto reemplaza el concepto "Desconectado": los miembros del círculo ven
     // 🔕 No molestar mientras el Modo Silencio está activo.
@@ -137,7 +156,10 @@ class SilentFunctionalityCoordinator {
 
     try {
       debugPrint('[SilentCoordinator][DBG] invokeMethod activate →');
-      await _channel.invokeMethod('activate');
+      await _channel.invokeMethod('activate', {
+        if (preSilentStatusType != null && preSilentStatusType != 'do_not_disturb')
+          'preSilentStatusType': preSilentStatusType,
+      });
       debugPrint('[SilentCoordinator][DBG] activate → OK');
     } catch (e) {
       debugPrint('[SilentCoordinator][DBG] activate EXCEPCIÓN: $e');


### PR DESCRIPTION
## Summary

- **N1.01** — `KeepAliveService`: add `isBeingStopped` static flag. `stop()` sets it to `true` before calling `stopService()`. The periodic handler checks the flag at the start of each tick and aborts — eliminating the ~5-8s window where the "i" icon reappeared after `cancelAll()` was called in Regla 1.

- **N1.03 (Option A — restore previous status)** — Full 3-layer pipeline:
  1. `SilentFunctionalityCoordinator.dart`: reads current `statusType` from Firestore before overwriting with `do_not_disturb`, passes it to native as `preSilentStatusType`
  2. `MainActivity.kt` `activate` handler: persists `preSilentStatusType` to `zync_silent_mode` SharedPrefs alongside `is_silent_mode_active=true`
  3. `MainActivity.kt` Regla 1 block (`onCreate`): reads `pre_silent_status_type`, enqueues it in `pending_status` SharedPrefs, clears it — existing `pending_status` mechanism in `main.dart` (unchanged) picks it up on startup and calls `_updateStatusFromNative()` to restore status in Firestore

## Test plan
- [ ] N1.01: Activate Silent Mode → open from launcher → "i" icon disappears in ≤2s (no reappearance)
- [ ] N1.03: Set "En Camino" → Activate Silent Mode → open from launcher → Circle screen shows "En Camino" (not "No Molestar")
- [ ] N1.03 edge: Set zone-controlled status → Activate → open → geofencing corrects status normally
- [ ] Regression: N1.04, N1.05, N1.06 still pass
- [ ] Regression: R4 (Silent Mode process alive) — all 9 cases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)