### PR TITLE
fix: only replace zone status with fine when zone is configured (N1.03)

### DIFF
--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -145,7 +145,20 @@ class SilentFunctionalityCoordinator {
           final memberStatus = circleDoc.data()?['memberStatus'] as Map<String, dynamic>?;
           final myStatus = memberStatus?[user.uid] as Map<String, dynamic>?;
           final rawId = myStatus?['statusType'] as String?;
-          preSilentStatusType = (zoneControlledIds.contains(rawId)) ? 'fine' : rawId;
+          // Solo reemplazar por 'fine' si la zona está activamente configurada para
+          // geofencing. Sin zona configurada, el emoji actúa como status manual normal.
+          if (rawId != null && zoneControlledIds.contains(rawId)) {
+            final zonesSnap = await FirebaseFirestore.instance
+                .collection('circles')
+                .doc(circleId)
+                .collection('zones')
+                .where('type', isEqualTo: rawId)
+                .limit(1)
+                .get();
+            preSilentStatusType = zonesSnap.docs.isNotEmpty ? 'fine' : rawId;
+          } else {
+            preSilentStatusType = rawId;
+          }
           debugPrint('[SilentCoordinator][DBG] Estado previo: $rawId → guardando: $preSilentStatusType');
         }
       }


### PR DESCRIPTION
## Summary
Fix B was too aggressive — replaced zone IDs with 'fine' unconditionally.
Without configured zones, statuses like 'university' are regular manual statuses.
Now mirrors `StatusService._isSpecificZoneTypeConfigured()`: queries zones subcollection,
only uses 'fine' fallback if the zone is actively configured for geofencing.

## Test plan
- [ ] N1.03 + zone configured: "Universidad" → reopen → "Todo bien" (geofencing corrects)
- [ ] N1.03 + no zone: "Universidad" emoji → Silent Mode → reopen → "Universidad" preserved
- [ ] N1.03: "Reunión" → reopen → correct emoji restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)