### PR TITLE
fix: reduce SOS hold threshold to 500ms in circle modal (MN4.05)

### DIFF
--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -221,7 +221,7 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
         timer.cancel();
         return;
       }
-      setState(() => _sosHoldProgress += 30 / 1000);
+      setState(() => _sosHoldProgress += 30 / 500);
       if (_sosHoldProgress >= 1.0) {
         timer.cancel();
         _triggerSos();


### PR DESCRIPTION
MN4.05 - SOS now fires in 500ms instead of 1000ms. Matches BN modal behavior.