### PR TITLE
fix: immediate keyboard focus on create circle via FocusScope (MN6.06)

### DIFF
--- a/lib/features/circle/presentation/widgets/create_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/create_circle_view.dart
@@ -24,7 +24,7 @@ class _CreateCircleViewState extends ConsumerState<CreateCircleView> {
     // MN6.06: Foco inmediato — postFrameCallback garantiza que el widget está
     // completamente construido antes de pedir foco, evitando el retraso de autofocus.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _focusNode.requestFocus();
+      if (mounted) FocusScope.of(context).requestFocus(_focusNode);
     });
   }
 


### PR DESCRIPTION
MN6.06 - FocusScope.of(context).requestFocus() reliably triggers IME on Android. Previous _focusNode.requestFocus() could silently fail causing >3s delay.