### PR TITLE
fix: remove redundant notification text in silent mode (MS2.09)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -194,7 +194,6 @@ class KeepAliveService : Service() {
         
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("Zync")
-            .setContentText("Toca para cambiar tu estado") // Point 21: Texto claro
             .setSmallIcon(android.R.drawable.ic_dialog_info) // Usar icono genérico por ahora
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_HIGH)


### PR DESCRIPTION
MS2.09 - Remove 'Toca para cambiar tu estado'. Redundant with icon.