### PR TITLE
fix: direct Firestore write from BN when app is closed (MS3.03/04/05)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -18,7 +18,6 @@ import android.widget.TextView
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
-import java.util.concurrent.TimeUnit
 
 /**
  * Modal nativo de Android para selección de emojis
@@ -553,7 +552,6 @@ class EmojiDialogActivity : Activity() {
             .build()
 
         val workRequest = OneTimeWorkRequestBuilder<StatusUpdateWorker>()
-            .setInitialDelay(30, TimeUnit.SECONDS)
             .setInputData(workData)
             .addTag("status_update_$timestamp")
             .build()

--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -1,50 +1,96 @@
 package com.datainfers.zync
 
 import android.content.Context
-import android.content.Intent
 import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
 
 /**
- * Worker para actualizar estado cuando la app está cerrada
- * Parte del enfoque híbrido: Broadcast inmediato + Cache + WorkManager backup
+ * Worker para actualizar estado en Firestore cuando la app está cerrada.
+ *
+ * Antes: re-enviaba un broadcast que nadie escuchaba con app cerrada.
+ * Ahora: escribe DIRECTAMENTE a Firestore usando Firebase SDK nativo +
+ *        NativeStateManager (userId/circleId en SQLite Room, sin Flutter).
+ *
+ * Fix MS3.03/MS3.04/MS3.05: seleccionar emoji desde BN con app cerrada
+ * ahora actualiza Firebase de inmediato en lugar de esperar a que Flutter abra.
  */
 class StatusUpdateWorker(
     context: Context,
     params: WorkerParameters
 ) : Worker(context, params) {
-    
+
     private val TAG = "StatusUpdateWorker"
-    
+
     override fun doWork(): Result {
         val statusType = inputData.getString("statusType") ?: return Result.failure()
         val timestamp = inputData.getLong("timestamp", 0L)
-        
-        Log.d(TAG, "💼 [WORKER] Verificando estado pendiente: $statusType (timestamp: $timestamp)")
-        
-        // Verificar si el estado ya fue actualizado
+
+        Log.d(TAG, "💼 [WORKER] Iniciando write directo a Firestore: $statusType (ts: $timestamp)")
+
+        // Verificar si Flutter ya procesó el estado al reabrir la app
         val prefs = applicationContext.getSharedPreferences("pending_status", Context.MODE_PRIVATE)
-        val pendingStatus = prefs.getString("statusType", null)
         val pendingTimestamp = prefs.getLong("timestamp", 0L)
-        
-        if (pendingStatus == null || pendingTimestamp != timestamp) {
-            Log.d(TAG, "✅ [WORKER] Estado ya fue actualizado - cancelando worker")
+
+        if (pendingTimestamp != timestamp) {
+            Log.d(TAG, "✅ [WORKER] Estado ya fue procesado por Flutter — cancelando worker")
             return Result.success()
         }
-        
-        // El estado aún está pendiente - intentar enviar broadcast de nuevo
-        Log.d(TAG, "📡 [WORKER] Estado aún pendiente - enviando broadcast")
-        
-        val intent = Intent("com.datainfers.zync.UPDATE_STATUS").apply {
-            putExtra("emoji", "")
-            putExtra("status", statusType)
-            setPackage(applicationContext.packageName)
+
+        return try {
+            // Leer userId y circleId desde SQLite Room (sin necesidad de Flutter)
+            val state = NativeStateManager.getState(applicationContext)
+            val circleId = state?.circleId
+            val userId = state?.userId
+
+            if (circleId.isNullOrEmpty() || userId.isNullOrEmpty()) {
+                Log.w(TAG, "⚠️ [WORKER] circleId o userId no disponibles en NativeStateManager")
+                return Result.failure()
+            }
+
+            // Firebase Auth persiste entre sesiones — no requiere Flutter para autenticar
+            val currentUser = FirebaseAuth.getInstance().currentUser
+            if (currentUser == null) {
+                Log.w(TAG, "⚠️ [WORKER] Sin usuario Firebase autenticado")
+                return Result.failure()
+            }
+            if (currentUser.uid != userId) {
+                Log.w(TAG, "⚠️ [WORKER] UID Firebase (${currentUser.uid}) ≠ NativeStateManager ($userId)")
+                return Result.failure()
+            }
+
+            // Write directo a Firestore — mismo esquema que StatusService.updateUserStatus() en Flutter
+            val db = FirebaseFirestore.getInstance()
+            val statusData = hashMapOf<String, Any?>(
+                "userId"        to userId,
+                "statusType"    to statusType,
+                "timestamp"     to FieldValue.serverTimestamp(),
+                "autoUpdated"   to false,
+                "manualOverride" to false,
+                "locationUnknown" to false,
+                "customEmoji"   to null,
+                "zoneName"      to null,
+                "zoneId"        to null,
+            )
+
+            Tasks.await(
+                db.collection("circles")
+                    .document(circleId)
+                    .update("memberStatus.$userId", statusData)
+            )
+
+            // Limpiar pending_status para que Flutter no lo reprocese al reabrir la app
+            prefs.edit().clear().apply()
+
+            Log.d(TAG, "✅ [WORKER] '$statusType' escrito en Firestore. Circle: $circleId, User: $userId")
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ [WORKER] Error escribiendo a Firestore: ${e.message}", e)
+            Result.failure()
         }
-        
-        applicationContext.sendBroadcast(intent)
-        
-        Log.d(TAG, "✅ [WORKER] Broadcast enviado - Flutter actualizará cuando se abra la app")
-        return Result.success()
     }
 }


### PR DESCRIPTION
## Summary
- `StatusUpdateWorker`: reemplaza re-broadcast inútil (nadie escucha con app cerrada) con write directo a Firestore usando `FirebaseFirestore.getInstance()` + `NativeStateManager.getState()` (userId/circleId de SQLite Room)
- `EmojiDialogActivity`: elimina `setInitialDelay(30, TimeUnit.SECONDS)` — worker se encola inmediatamente al seleccionar emoji desde BN con app cerrada
- Limpieza: elimina import huérfano `java.util.concurrent.TimeUnit`

## Test plan
- [ ] Activar Modo Silencioso (ícono "i" en BN visible)
- [ ] Cerrar app completamente (swipe desde recientes)
- [ ] Expandir BN → tocar notificación "Zync" → seleccionar emoji
- [ ] Verificar en Firestore Console que `memberStatus.<userId>.statusType` se actualizó sin reabrir la app
- [ ] Reabrir app → verificar que el estado mostrado coincide con el emoji seleccionado desde BN

🤖 Generated with [Claude Code](https://claude.com/claude-code)