### PR TITLE
fix: add Firebase SDK deps for StatusUpdateWorker (compile error)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -83,4 +83,10 @@ dependencies {
     
     // WorkManager for background status updates
     implementation("androidx.work:work-runtime-ktx:2.9.0")
+
+    // Firebase SDK directo para StatusUpdateWorker (write a Firestore sin Flutter)
+    implementation(platform("com.google.firebase:firebase-bom:33.1.2"))
+    implementation("com.google.firebase:firebase-firestore-ktx")
+    implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.android.gms:play-services-tasks:18.2.0")
 }


### PR DESCRIPTION
## Summary
- Agrega dependencias Firebase explícitas en `build.gradle.kts` para que `StatusUpdateWorker.kt` compile
- `FirebaseFirestore`, `FirebaseAuth` y `play-services-tasks` no estaban declarados — el plugin `google-services` no los inyecta automáticamente en el classpath de Kotlin nativo
- Usa `firebase-bom:33.1.2` para alinear versiones con los plugins de Flutter

## Root cause
PR #114 asumió que Firebase estaba disponible transitivamente. No lo está para código Kotlin nativo fuera de Flutter — requiere declaración explícita.

## Test plan
- [ ] `flutter run` compila sin errores Kotlin
- [ ] Seleccionar emoji desde BN con app cerrada actualiza Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)