### PR TITLE
diag: diagnostic logs for silent mode issues

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -530,6 +530,7 @@ class EmojiDialogActivity : Activity() {
         Log.d(TAG, "🔥 [HYBRID] Actualizando estado: $emoji ($status)")
 
         val timestamp = System.currentTimeMillis()
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] updateUserStatus: statusType=$status emoji=$emoji timestamp=$timestamp")
 
         val intent = Intent("com.datainfers.zync.UPDATE_STATUS").apply {
             putExtra("emoji", emoji)
@@ -537,6 +538,7 @@ class EmojiDialogActivity : Activity() {
             setPackage(packageName)
         }
         sendBroadcast(intent)
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] broadcast enviado (solo válido si app está viva)")
 
         val prefs = getSharedPreferences("pending_status", Context.MODE_PRIVATE)
         prefs.edit()
@@ -544,6 +546,7 @@ class EmojiDialogActivity : Activity() {
             .putString("emoji", emoji)
             .putLong("timestamp", timestamp)
             .apply()
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] pending_status guardado: statusType=$status timestamp=$timestamp")
 
         val workData = Data.Builder()
             .putString("statusType", status)
@@ -557,6 +560,7 @@ class EmojiDialogActivity : Activity() {
             .build()
 
         WorkManager.getInstance(this).enqueue(workRequest)
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] WorkManager.enqueue → worker encolado con tag=status_update_$timestamp")
 
         Log.d(TAG, "✅ [HYBRID] Estado enviado - cerrando dialog")
         finish()

--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -44,6 +44,7 @@ class KeepAliveService : Service() {
                 val notification = createNotification()
                 startForeground(NOTIFICATION_ID, notification)
                 Log.d(TAG, "🔄 [KEEP-ALIVE] startForeground re-afirmado (handler periódico)")
+                Log.d(TAG, "🔔 [DIAG-NOTIF] handler periódico re-afirmó notificación @ ${System.currentTimeMillis()}")
             } catch (e: Exception) {
                 Log.w(TAG, "⚠️ [KEEP-ALIVE] Error en tick periódico: ${e.message}")
             }
@@ -115,6 +116,7 @@ class KeepAliveService : Service() {
     
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "onStartCommand() - Iniciando foreground")
+        Log.d(TAG, "🔔 [DIAG-NOTIF] startForeground llamado desde onStartCommand @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped")
 
         val notification = createNotification()
         startForeground(NOTIFICATION_ID, notification)
@@ -133,6 +135,7 @@ class KeepAliveService : Service() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
         Log.d(TAG, "⚠️ onTaskRemoved() - Usuario cerró app desde recientes")
+        Log.d(TAG, "🔔 [DIAG-NOTIF] onTaskRemoved @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped")
         
         // Point 3.1: Reiniciar el servicio para mantener la notificación activa
         // Esto garantiza que la notificación persista incluso cuando la app está cerrada
@@ -149,6 +152,7 @@ class KeepAliveService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         Log.d(TAG, "onDestroy() - Servicio destruido")
+        Log.d(TAG, "🔔 [DIAG-NOTIF] onDestroy @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped ← notificación debería desaparecer aquí")
 
         // Cambio 6: Cancelar handler periódico para evitar callbacks tras destrucción.
         keepAliveHandler.removeCallbacks(keepAliveRunnable)

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -269,6 +269,7 @@ class MainActivity: FlutterActivity() {
         val prefs = getSharedPreferences("pending_status", MODE_PRIVATE)
         val pendingStatus = prefs.getString("statusType", null)
 
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] onResume: pendingStatus=${pendingStatus ?: "NONE"} | flutterEngineAvailable=${flutterEngine != null}")
         if (pendingStatus != null) {
             Log.d(TAG, "💾 [RESUME] Estado pendiente: $pendingStatus — enviando a Flutter")
             flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
@@ -276,7 +277,10 @@ class MainActivity: FlutterActivity() {
                 channel.invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
                 prefs.edit().clear().apply()
                 Log.d(TAG, "✅ [RESUME] Estado enviado y cache limpiado")
+                Log.d(TAG, "📋 [DIAG-BN-WRITE] onResume: pending_status LIMPIADO — worker NO escribirá a Firestore (Flutter lo hará)")
             } ?: Log.d(TAG, "⏳ [RESUME] FlutterEngine no disponible — estado pendiente preservado para [HYBRID]")
+        } else {
+            Log.d(TAG, "📋 [DIAG-BN-WRITE] onResume: sin pending_status — worker escribirá a Firestore si está encolado")
         }
     }
     

--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -31,13 +31,16 @@ class StatusUpdateWorker(
         val timestamp = inputData.getLong("timestamp", 0L)
 
         Log.d(TAG, "💼 [WORKER] Iniciando write directo a Firestore: $statusType (ts: $timestamp)")
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] Worker doWork START: statusType=$statusType timestamp=$timestamp")
 
         // Verificar si Flutter ya procesó el estado al reabrir la app
         val prefs = applicationContext.getSharedPreferences("pending_status", Context.MODE_PRIVATE)
         val pendingTimestamp = prefs.getLong("timestamp", 0L)
+        Log.d(TAG, "📋 [DIAG-BN-WRITE] pending_status en SharedPrefs: pendingTimestamp=$pendingTimestamp | workerTimestamp=$timestamp | match=${pendingTimestamp == timestamp}")
 
         if (pendingTimestamp != timestamp) {
             Log.d(TAG, "✅ [WORKER] Estado ya fue procesado por Flutter — cancelando worker")
+            Log.d(TAG, "📋 [DIAG-BN-WRITE] Worker CANCELADO (timestamp mismatch: worker=$timestamp, prefs=$pendingTimestamp)")
             return Result.success()
         }
 
@@ -46,22 +49,28 @@ class StatusUpdateWorker(
             val state = NativeStateManager.getState(applicationContext)
             val circleId = state?.circleId
             val userId = state?.userId
+            Log.d(TAG, "📋 [DIAG-BN-WRITE] NativeStateManager: userId=$userId circleId=$circleId")
 
             if (circleId.isNullOrEmpty() || userId.isNullOrEmpty()) {
                 Log.w(TAG, "⚠️ [WORKER] circleId o userId no disponibles en NativeStateManager")
+                Log.w(TAG, "📋 [DIAG-BN-WRITE] FALLA: NativeStateManager vacío — ¿Flutter nunca sincronizó el estado?")
                 return Result.failure()
             }
 
             // Firebase Auth persiste entre sesiones — no requiere Flutter para autenticar
             val currentUser = FirebaseAuth.getInstance().currentUser
+            Log.d(TAG, "📋 [DIAG-BN-WRITE] FirebaseAuth.currentUser: ${currentUser?.uid ?: "NULL"}")
             if (currentUser == null) {
                 Log.w(TAG, "⚠️ [WORKER] Sin usuario Firebase autenticado")
+                Log.w(TAG, "📋 [DIAG-BN-WRITE] FALLA: FirebaseAuth.currentUser es null — token expiró o nunca se autenticó")
                 return Result.failure()
             }
             if (currentUser.uid != userId) {
                 Log.w(TAG, "⚠️ [WORKER] UID Firebase (${currentUser.uid}) ≠ NativeStateManager ($userId)")
+                Log.w(TAG, "📋 [DIAG-BN-WRITE] FALLA: UID mismatch — Firebase=${currentUser.uid} vs Room=$userId")
                 return Result.failure()
             }
+            Log.d(TAG, "📋 [DIAG-BN-WRITE] Auth OK: uid=${currentUser.uid} coincide con NativeStateManager")
 
             // Write directo a Firestore — mismo esquema que StatusService.updateUserStatus() en Flutter
             val db = FirebaseFirestore.getInstance()

--- a/lib/core/services/emoji_service.dart
+++ b/lib/core/services/emoji_service.dart
@@ -45,6 +45,7 @@ class EmojiService {
       _cachedPredefined = snapshot.docs.map((doc) => StatusType.fromFirestore(doc)).toList();
 
       log('[EmojiService] ✓ ${_cachedPredefined!.length} predefinidos cargados desde Firebase');
+      log('[DIAG-GRID] IDs en /predefinedEmojis: ${_cachedPredefined!.map((e) => e.id).toList()}');
       return _cachedPredefined!;
     } catch (e) {
       log('[EmojiService] ❌ Error cargando desde Firebase: $e');

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -99,28 +99,31 @@ class SilentFunctionalityCoordinator {
   /// Activa el Modo Silencio. Requiere permiso de notificaciones y círculo activo.
   /// Kotlin maneja el resto: notificación, KeepAlive y moveTaskToBack.
   static Future<void> activateSilentMode(BuildContext context) async {
-    debugPrint('[SilentCoordinator][DBG] activateSilentMode → logout=$_isManualLogoutInProgress, circle=$_userHasCircle, mounted=${context.mounted}');
+    final t0 = DateTime.now().millisecondsSinceEpoch;
+    debugPrint('[DIAG-MS1.08] ⏱ activateSilentMode START t=0ms | logout=$_isManualLogoutInProgress, circle=$_userHasCircle');
     if (_isManualLogoutInProgress) return;
     if (!context.mounted) return;
 
     // Bug 2 fix: _userHasCircle puede ser false en cold start por race condition
     // (activateAfterLogin aún no terminó). Re-verificar desde Firebase antes de cancelar.
     if (!_userHasCircle) {
+      debugPrint('[DIAG-MS1.08] ⚠️ _userHasCircle=false → Firebase re-check START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
       try {
         final userCircle = await CircleService().getUserCircle();
-        debugPrint('[SilentCoordinator][DBG] activateSilentMode — re-check circle → ${userCircle != null ? userCircle.name : "NULL"}');
+        debugPrint('[DIAG-MS1.08] ← Firebase re-check END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → ${userCircle != null ? userCircle.name : "NULL"}');
         if (userCircle == null) return;
         _userHasCircle = true;
       } catch (e) {
-        debugPrint('[SilentCoordinator][DBG] activateSilentMode — error re-checking circle: $e');
+        debugPrint('[DIAG-MS1.08] ❌ Firebase re-check ERROR t=${DateTime.now().millisecondsSinceEpoch - t0}ms: $e');
         return;
       }
     }
 
     if (!context.mounted) return;
 
+    debugPrint('[DIAG-MS1.08] → requestPermissions START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
     final hasPermission = await NotificationService.requestPermissions();
-    debugPrint('[SilentCoordinator][DBG] requestPermissions → $hasPermission');
+    debugPrint('[DIAG-MS1.08] ← requestPermissions END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → $hasPermission');
     if (!context.mounted) return;
 
     if (!hasPermission) {
@@ -135,16 +138,20 @@ class SilentFunctionalityCoordinator {
     // el geofencing las corrige solo.
     const zoneControlledIds = {'home', 'school', 'work', 'university'};
     String? preSilentStatusType;
+    debugPrint('[DIAG-MS1.08] → preSilentStatus Firestore reads START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
         final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+        debugPrint('[DIAG-MS1.08]   userDoc read t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
         final circleId = userDoc.data()?['circleId'] as String?;
         if (circleId != null) {
           final circleDoc = await FirebaseFirestore.instance.collection('circles').doc(circleId).get();
+          debugPrint('[DIAG-MS1.08]   circleDoc read t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
           final memberStatus = circleDoc.data()?['memberStatus'] as Map<String, dynamic>?;
           final myStatus = memberStatus?[user.uid] as Map<String, dynamic>?;
           final rawId = myStatus?['statusType'] as String?;
+          debugPrint('[DIAG-MS1.08]   rawStatusType=$rawId');
           // Solo reemplazar por 'fine' si la zona está activamente configurada para
           // geofencing. Sin zona configurada, el emoji actúa como status manual normal.
           if (rawId != null && zoneControlledIds.contains(rawId)) {
@@ -155,6 +162,7 @@ class SilentFunctionalityCoordinator {
                 .where('type', isEqualTo: rawId)
                 .limit(1)
                 .get();
+            debugPrint('[DIAG-MS1.08]   zones read t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
             preSilentStatusType = zonesSnap.docs.isNotEmpty ? 'fine' : rawId;
           } else {
             preSilentStatusType = rawId;
@@ -163,27 +171,29 @@ class SilentFunctionalityCoordinator {
         }
       }
     } catch (e) {
-      debugPrint('[SilentCoordinator][DBG] Error leyendo estado previo: $e');
+      debugPrint('[DIAG-MS1.08] ❌ preSilentStatus ERROR: $e');
     }
+    debugPrint('[DIAG-MS1.08] ← preSilentStatus Firestore reads END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → preSilent=$preSilentStatusType');
 
-    // Escribir 'do_not_disturb' en Firestore antes de que el isolate Dart muera.
-    // Esto reemplaza el concepto "Desconectado": los miembros del círculo ven
-    // 🔕 No molestar mientras el Modo Silencio está activo.
+    // [DIAG-STATUS-CHANGE] Este bloque escribe 'do_not_disturb' en Firestore.
+    // El usuario ve "No Molestar" en el círculo mientras el Modo Silencio está activo.
+    debugPrint('[DIAG-STATUS-CHANGE] ⚠️ ESCRIBIENDO do_not_disturb en Firestore t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
+    debugPrint('[DIAG-STATUS-CHANGE]   statusAnterior=$preSilentStatusType → cambiando a do_not_disturb');
     final doNotDisturb = StatusType.fallbackPredefined.firstWhere((s) => s.id == 'do_not_disturb');
     await StatusService.updateUserStatus(doNotDisturb);
-    debugPrint('[SilentCoordinator][DBG] do_not_disturb escrito en Firestore');
+    debugPrint('[DIAG-STATUS-CHANGE] ← do_not_disturb escrito t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
 
     if (!context.mounted) return;
 
     try {
-      debugPrint('[SilentCoordinator][DBG] invokeMethod activate →');
+      debugPrint('[DIAG-MS1.08] → invokeMethod(activate) START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
       await _channel.invokeMethod('activate', {
         if (preSilentStatusType != null && preSilentStatusType != 'do_not_disturb')
           'preSilentStatusType': preSilentStatusType,
       });
-      debugPrint('[SilentCoordinator][DBG] activate → OK');
+      debugPrint('[DIAG-MS1.08] ← invokeMethod(activate) END t=${DateTime.now().millisecondsSinceEpoch - t0}ms ← ÍCONO DEBERÍA APARECER AQUÍ');
     } catch (e) {
-      debugPrint('[SilentCoordinator][DBG] activate EXCEPCIÓN: $e');
+      debugPrint('[DIAG-MS1.08] ❌ activate EXCEPCIÓN t=${DateTime.now().millisecondsSinceEpoch - t0}ms: $e');
     }
   }
 

--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -87,6 +87,11 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
       final allEmojis = <StatusType?>[...predefined, ...custom];
 
       print('[StatusSelectorOverlay] ✅ Grid cargado desde Firebase: ${allEmojis.length} emojis');
+      print('[DIAG-GRID] IDs predefinidos (${predefined.length}): ${predefined.map((e) => e.id).toList()}');
+      print('[DIAG-GRID] IDs custom (${custom.length}): ${custom.map((e) => e.id).toList()}');
+      final hasUniversity = allEmojis.any((e) => e?.id == 'university');
+      final hasMeeting = allEmojis.any((e) => e?.id == 'meeting');
+      print('[DIAG-GRID] university presente: $hasUniversity | meeting presente: $hasMeeting');
 
       // Verificar zonas predefinidas configuradas para dimming de botones
       final zonesSnapshot =


### PR DESCRIPTION
## Summary
Solo logs diagnósticos — sin cambios de lógica.

| Tag | Dónde | Qué captura |
|-----|-------|-------------|
| `DIAG-MS1.08` | `SilentFunctionalityCoordinator` | Timestamp en cada paso de `activateSilentMode()` para ubicar el delay ≥8s |
| `DIAG-STATUS-CHANGE` | `SilentFunctionalityCoordinator` | Flag explícito cuando `do_not_disturb` se escribe en Firestore al activar Modo Silencioso |
| `DIAG-GRID` | `EmojiService` + `StatusSelectorOverlay` | IDs exactos cargados de Firebase — detecta si `university`/`meeting` están en `/predefinedEmojis` |
| `DIAG-BN-WRITE` | `EmojiDialogActivity` + `StatusUpdateWorker` + `MainActivity` | Cadena completa BN→SharedPrefs→Worker→Firestore con puntos de falla |
| `DIAG-NOTIF` | `KeepAliveService` | Timestamps de lifecycle de notificación (start/handler/destroy) |

## Test plan
- [ ] Ejecutar Logcat con el comando indicado
- [ ] Activar Modo Silencioso y pegar los logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)