### PR TITLE
fix: no status change on silent mode activation + single notification handler

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -136,13 +136,9 @@ class KeepAliveService : Service() {
         super.onTaskRemoved(rootIntent)
         Log.d(TAG, "⚠️ onTaskRemoved() - Usuario cerró app desde recientes")
         Log.d(TAG, "🔔 [DIAG-NOTIF] onTaskRemoved @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped")
-        
-        // Point 3.1: Reiniciar el servicio para mantener la notificación activa
-        // Esto garantiza que la notificación persista incluso cuando la app está cerrada
-        val restartServiceIntent = Intent(applicationContext, KeepAliveService::class.java)
-        applicationContext.startService(restartServiceIntent)
-        
-        Log.d(TAG, "✅ Servicio programado para reinicio automático")
+        // START_STICKY garantiza reinicio automático si el sistema mata el proceso.
+        // El startService() manual fue eliminado — era redundante y causaba un segundo
+        // onStartCommand con handler duplicado al activar Modo Silencio.
     }
     
     override fun onBind(intent: Intent?): IBinder? {

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -5,9 +5,7 @@ import 'package:flutter/services.dart';
 import '../../notifications/notification_service.dart';
 import '../../quick_actions/quick_actions_service.dart';
 import '../../services/circle_service.dart';
-import '../models/user_status.dart';
 import 'status_modal_service.dart';
-import 'status_service.dart';
 
 /// Coordinador de Modo Silencio — interfaz mínima entre Flutter y Kotlin.
 ///
@@ -175,20 +173,12 @@ class SilentFunctionalityCoordinator {
     }
     debugPrint('[DIAG-MS1.08] ← preSilentStatus Firestore reads END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → preSilent=$preSilentStatusType');
 
-    // [DIAG-STATUS-CHANGE] Este bloque escribe 'do_not_disturb' en Firestore.
-    // El usuario ve "No Molestar" en el círculo mientras el Modo Silencio está activo.
-    debugPrint('[DIAG-STATUS-CHANGE] ⚠️ ESCRIBIENDO do_not_disturb en Firestore t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
-    debugPrint('[DIAG-STATUS-CHANGE]   statusAnterior=$preSilentStatusType → cambiando a do_not_disturb');
-    final doNotDisturb = StatusType.fallbackPredefined.firstWhere((s) => s.id == 'do_not_disturb');
-    await StatusService.updateUserStatus(doNotDisturb);
-    debugPrint('[DIAG-STATUS-CHANGE] ← do_not_disturb escrito t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
-
     if (!context.mounted) return;
 
     try {
       debugPrint('[DIAG-MS1.08] → invokeMethod(activate) START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
       await _channel.invokeMethod('activate', {
-        if (preSilentStatusType != null && preSilentStatusType != 'do_not_disturb')
+        if (preSilentStatusType != null)
           'preSilentStatusType': preSilentStatusType,
       });
       debugPrint('[DIAG-MS1.08] ← invokeMethod(activate) END t=${DateTime.now().millisecondsSinceEpoch - t0}ms ← ÍCONO DEBERÍA APARECER AQUÍ');


### PR DESCRIPTION
## Summary
- **Fix A**: `SilentFunctionalityCoordinator` ya no escribe `do_not_disturb` en Firestore al activar Modo Silencioso. El status del usuario permanece sin cambios (no hay estados temporales). Elimina también 460ms de delay en la activación.
- **Fix B**: `KeepAliveService.onTaskRemoved()` ya no llama `startService()` manualmente. `START_STICKY` es el mecanismo correcto para sobrevivir kills del sistema. El restart manual causaba un segundo `onStartCommand` con su propio handler periódico, lo que hacía que la notificación persistiera después de reabrir la app.
- Limpieza: imports `StatusType` y `StatusService` eliminados de `silent_functionality_coordinator.dart` (quedaron huérfanos tras Fix A).

## Test plan
- [ ] Activar Modo Silencioso → verificar que el status en el círculo NO cambia a "No Molestar"
- [ ] Activar Modo Silencioso → verificar que el ícono "i" aparece en <1s (sin delay de escritura Firestore)
- [ ] Reabrir app desde launcher → verificar que la notificación desaparece sin persistir extra
- [ ] Activar Modo Silencioso, cerrar app desde recientes → verificar que el ícono "i" sigue visible en BN

🤖 Generated with [Claude Code](https://claude.com/claude-code)