### PR TITLE
chore: remove diagnostic DIAG log tags

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -530,7 +530,6 @@ class EmojiDialogActivity : Activity() {
         Log.d(TAG, "🔥 [HYBRID] Actualizando estado: $emoji ($status)")
 
         val timestamp = System.currentTimeMillis()
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] updateUserStatus: statusType=$status emoji=$emoji timestamp=$timestamp")
 
         val intent = Intent("com.datainfers.zync.UPDATE_STATUS").apply {
             putExtra("emoji", emoji)
@@ -538,7 +537,6 @@ class EmojiDialogActivity : Activity() {
             setPackage(packageName)
         }
         sendBroadcast(intent)
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] broadcast enviado (solo válido si app está viva)")
 
         val prefs = getSharedPreferences("pending_status", Context.MODE_PRIVATE)
         prefs.edit()
@@ -546,7 +544,6 @@ class EmojiDialogActivity : Activity() {
             .putString("emoji", emoji)
             .putLong("timestamp", timestamp)
             .apply()
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] pending_status guardado: statusType=$status timestamp=$timestamp")
 
         val workData = Data.Builder()
             .putString("statusType", status)
@@ -560,7 +557,6 @@ class EmojiDialogActivity : Activity() {
             .build()
 
         WorkManager.getInstance(this).enqueue(workRequest)
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] WorkManager.enqueue → worker encolado con tag=status_update_$timestamp")
 
         Log.d(TAG, "✅ [HYBRID] Estado enviado - cerrando dialog")
         finish()

--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -44,7 +44,6 @@ class KeepAliveService : Service() {
                 val notification = createNotification()
                 startForeground(NOTIFICATION_ID, notification)
                 Log.d(TAG, "🔄 [KEEP-ALIVE] startForeground re-afirmado (handler periódico)")
-                Log.d(TAG, "🔔 [DIAG-NOTIF] handler periódico re-afirmó notificación @ ${System.currentTimeMillis()}")
             } catch (e: Exception) {
                 Log.w(TAG, "⚠️ [KEEP-ALIVE] Error en tick periódico: ${e.message}")
             }
@@ -116,7 +115,6 @@ class KeepAliveService : Service() {
     
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         Log.d(TAG, "onStartCommand() - Iniciando foreground")
-        Log.d(TAG, "🔔 [DIAG-NOTIF] startForeground llamado desde onStartCommand @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped")
 
         val notification = createNotification()
         startForeground(NOTIFICATION_ID, notification)
@@ -135,7 +133,6 @@ class KeepAliveService : Service() {
     override fun onTaskRemoved(rootIntent: Intent?) {
         super.onTaskRemoved(rootIntent)
         Log.d(TAG, "⚠️ onTaskRemoved() - Usuario cerró app desde recientes")
-        Log.d(TAG, "🔔 [DIAG-NOTIF] onTaskRemoved @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped")
         // START_STICKY garantiza reinicio automático si el sistema mata el proceso.
         // El startService() manual fue eliminado — era redundante y causaba un segundo
         // onStartCommand con handler duplicado al activar Modo Silencio.
@@ -148,7 +145,6 @@ class KeepAliveService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         Log.d(TAG, "onDestroy() - Servicio destruido")
-        Log.d(TAG, "🔔 [DIAG-NOTIF] onDestroy @ ${System.currentTimeMillis()} | isBeingStopped=$isBeingStopped ← notificación debería desaparecer aquí")
 
         // Cambio 6: Cancelar handler periódico para evitar callbacks tras destrucción.
         keepAliveHandler.removeCallbacks(keepAliveRunnable)

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -269,7 +269,6 @@ class MainActivity: FlutterActivity() {
         val prefs = getSharedPreferences("pending_status", MODE_PRIVATE)
         val pendingStatus = prefs.getString("statusType", null)
 
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] onResume: pendingStatus=${pendingStatus ?: "NONE"} | flutterEngineAvailable=${flutterEngine != null}")
         if (pendingStatus != null) {
             Log.d(TAG, "💾 [RESUME] Estado pendiente: $pendingStatus — enviando a Flutter")
             flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
@@ -277,10 +276,7 @@ class MainActivity: FlutterActivity() {
                 channel.invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
                 prefs.edit().clear().apply()
                 Log.d(TAG, "✅ [RESUME] Estado enviado y cache limpiado")
-                Log.d(TAG, "📋 [DIAG-BN-WRITE] onResume: pending_status LIMPIADO — worker NO escribirá a Firestore (Flutter lo hará)")
             } ?: Log.d(TAG, "⏳ [RESUME] FlutterEngine no disponible — estado pendiente preservado para [HYBRID]")
-        } else {
-            Log.d(TAG, "📋 [DIAG-BN-WRITE] onResume: sin pending_status — worker escribirá a Firestore si está encolado")
         }
     }
     

--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -31,16 +31,13 @@ class StatusUpdateWorker(
         val timestamp = inputData.getLong("timestamp", 0L)
 
         Log.d(TAG, "💼 [WORKER] Iniciando write directo a Firestore: $statusType (ts: $timestamp)")
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] Worker doWork START: statusType=$statusType timestamp=$timestamp")
 
         // Verificar si Flutter ya procesó el estado al reabrir la app
         val prefs = applicationContext.getSharedPreferences("pending_status", Context.MODE_PRIVATE)
         val pendingTimestamp = prefs.getLong("timestamp", 0L)
-        Log.d(TAG, "📋 [DIAG-BN-WRITE] pending_status en SharedPrefs: pendingTimestamp=$pendingTimestamp | workerTimestamp=$timestamp | match=${pendingTimestamp == timestamp}")
 
         if (pendingTimestamp != timestamp) {
             Log.d(TAG, "✅ [WORKER] Estado ya fue procesado por Flutter — cancelando worker")
-            Log.d(TAG, "📋 [DIAG-BN-WRITE] Worker CANCELADO (timestamp mismatch: worker=$timestamp, prefs=$pendingTimestamp)")
             return Result.success()
         }
 
@@ -49,28 +46,22 @@ class StatusUpdateWorker(
             val state = NativeStateManager.getState(applicationContext)
             val circleId = state?.circleId
             val userId = state?.userId
-            Log.d(TAG, "📋 [DIAG-BN-WRITE] NativeStateManager: userId=$userId circleId=$circleId")
 
             if (circleId.isNullOrEmpty() || userId.isNullOrEmpty()) {
                 Log.w(TAG, "⚠️ [WORKER] circleId o userId no disponibles en NativeStateManager")
-                Log.w(TAG, "📋 [DIAG-BN-WRITE] FALLA: NativeStateManager vacío — ¿Flutter nunca sincronizó el estado?")
                 return Result.failure()
             }
 
             // Firebase Auth persiste entre sesiones — no requiere Flutter para autenticar
             val currentUser = FirebaseAuth.getInstance().currentUser
-            Log.d(TAG, "📋 [DIAG-BN-WRITE] FirebaseAuth.currentUser: ${currentUser?.uid ?: "NULL"}")
             if (currentUser == null) {
                 Log.w(TAG, "⚠️ [WORKER] Sin usuario Firebase autenticado")
-                Log.w(TAG, "📋 [DIAG-BN-WRITE] FALLA: FirebaseAuth.currentUser es null — token expiró o nunca se autenticó")
                 return Result.failure()
             }
             if (currentUser.uid != userId) {
                 Log.w(TAG, "⚠️ [WORKER] UID Firebase (${currentUser.uid}) ≠ NativeStateManager ($userId)")
-                Log.w(TAG, "📋 [DIAG-BN-WRITE] FALLA: UID mismatch — Firebase=${currentUser.uid} vs Room=$userId")
                 return Result.failure()
             }
-            Log.d(TAG, "📋 [DIAG-BN-WRITE] Auth OK: uid=${currentUser.uid} coincide con NativeStateManager")
 
             // Write directo a Firestore — mismo esquema que StatusService.updateUserStatus() en Flutter
             val db = FirebaseFirestore.getInstance()

--- a/lib/core/services/emoji_service.dart
+++ b/lib/core/services/emoji_service.dart
@@ -45,7 +45,6 @@ class EmojiService {
       _cachedPredefined = snapshot.docs.map((doc) => StatusType.fromFirestore(doc)).toList();
 
       log('[EmojiService] ✓ ${_cachedPredefined!.length} predefinidos cargados desde Firebase');
-      log('[DIAG-GRID] IDs en /predefinedEmojis: ${_cachedPredefined!.map((e) => e.id).toList()}');
       return _cachedPredefined!;
     } catch (e) {
       log('[EmojiService] ❌ Error cargando desde Firebase: $e');

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -97,31 +97,25 @@ class SilentFunctionalityCoordinator {
   /// Activa el Modo Silencio. Requiere permiso de notificaciones y círculo activo.
   /// Kotlin maneja el resto: notificación, KeepAlive y moveTaskToBack.
   static Future<void> activateSilentMode(BuildContext context) async {
-    final t0 = DateTime.now().millisecondsSinceEpoch;
-    debugPrint('[DIAG-MS1.08] ⏱ activateSilentMode START t=0ms | logout=$_isManualLogoutInProgress, circle=$_userHasCircle');
     if (_isManualLogoutInProgress) return;
     if (!context.mounted) return;
 
     // Bug 2 fix: _userHasCircle puede ser false en cold start por race condition
     // (activateAfterLogin aún no terminó). Re-verificar desde Firebase antes de cancelar.
     if (!_userHasCircle) {
-      debugPrint('[DIAG-MS1.08] ⚠️ _userHasCircle=false → Firebase re-check START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
       try {
         final userCircle = await CircleService().getUserCircle();
-        debugPrint('[DIAG-MS1.08] ← Firebase re-check END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → ${userCircle != null ? userCircle.name : "NULL"}');
         if (userCircle == null) return;
         _userHasCircle = true;
       } catch (e) {
-        debugPrint('[DIAG-MS1.08] ❌ Firebase re-check ERROR t=${DateTime.now().millisecondsSinceEpoch - t0}ms: $e');
+        debugPrint('[SilentCoordinator] ❌ Firebase re-check ERROR: $e');
         return;
       }
     }
 
     if (!context.mounted) return;
 
-    debugPrint('[DIAG-MS1.08] → requestPermissions START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
     final hasPermission = await NotificationService.requestPermissions();
-    debugPrint('[DIAG-MS1.08] ← requestPermissions END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → $hasPermission');
     if (!context.mounted) return;
 
     if (!hasPermission) {
@@ -136,20 +130,16 @@ class SilentFunctionalityCoordinator {
     // el geofencing las corrige solo.
     const zoneControlledIds = {'home', 'school', 'work', 'university'};
     String? preSilentStatusType;
-    debugPrint('[DIAG-MS1.08] → preSilentStatus Firestore reads START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
     try {
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
         final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
-        debugPrint('[DIAG-MS1.08]   userDoc read t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
         final circleId = userDoc.data()?['circleId'] as String?;
         if (circleId != null) {
           final circleDoc = await FirebaseFirestore.instance.collection('circles').doc(circleId).get();
-          debugPrint('[DIAG-MS1.08]   circleDoc read t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
           final memberStatus = circleDoc.data()?['memberStatus'] as Map<String, dynamic>?;
           final myStatus = memberStatus?[user.uid] as Map<String, dynamic>?;
           final rawId = myStatus?['statusType'] as String?;
-          debugPrint('[DIAG-MS1.08]   rawStatusType=$rawId');
           // Solo reemplazar por 'fine' si la zona está activamente configurada para
           // geofencing. Sin zona configurada, el emoji actúa como status manual normal.
           if (rawId != null && zoneControlledIds.contains(rawId)) {
@@ -160,30 +150,25 @@ class SilentFunctionalityCoordinator {
                 .where('type', isEqualTo: rawId)
                 .limit(1)
                 .get();
-            debugPrint('[DIAG-MS1.08]   zones read t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
             preSilentStatusType = zonesSnap.docs.isNotEmpty ? 'fine' : rawId;
           } else {
             preSilentStatusType = rawId;
           }
-          debugPrint('[SilentCoordinator][DBG] Estado previo: $rawId → guardando: $preSilentStatusType');
         }
       }
     } catch (e) {
-      debugPrint('[DIAG-MS1.08] ❌ preSilentStatus ERROR: $e');
+      debugPrint('[SilentCoordinator] ❌ preSilentStatus ERROR: $e');
     }
-    debugPrint('[DIAG-MS1.08] ← preSilentStatus Firestore reads END t=${DateTime.now().millisecondsSinceEpoch - t0}ms → preSilent=$preSilentStatusType');
 
     if (!context.mounted) return;
 
     try {
-      debugPrint('[DIAG-MS1.08] → invokeMethod(activate) START t=${DateTime.now().millisecondsSinceEpoch - t0}ms');
       await _channel.invokeMethod('activate', {
         if (preSilentStatusType != null)
           'preSilentStatusType': preSilentStatusType,
       });
-      debugPrint('[DIAG-MS1.08] ← invokeMethod(activate) END t=${DateTime.now().millisecondsSinceEpoch - t0}ms ← ÍCONO DEBERÍA APARECER AQUÍ');
     } catch (e) {
-      debugPrint('[DIAG-MS1.08] ❌ activate EXCEPCIÓN t=${DateTime.now().millisecondsSinceEpoch - t0}ms: $e');
+      debugPrint('[SilentCoordinator] ❌ activate EXCEPCIÓN: $e');
     }
   }
 

--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -86,12 +86,7 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
       final custom = await EmojiService.getCustomEmojis(circleId);
       final allEmojis = <StatusType?>[...predefined, ...custom];
 
-      print('[StatusSelectorOverlay] ✅ Grid cargado desde Firebase: ${allEmojis.length} emojis');
-      print('[DIAG-GRID] IDs predefinidos (${predefined.length}): ${predefined.map((e) => e.id).toList()}');
-      print('[DIAG-GRID] IDs custom (${custom.length}): ${custom.map((e) => e.id).toList()}');
-      final hasUniversity = allEmojis.any((e) => e?.id == 'university');
-      final hasMeeting = allEmojis.any((e) => e?.id == 'meeting');
-      print('[DIAG-GRID] university presente: $hasUniversity | meeting presente: $hasMeeting');
+      debugPrint('[StatusSelectorOverlay] ✅ Grid cargado desde Firebase: ${allEmojis.length} emojis');
 
       // Verificar zonas predefinidas configuradas para dimming de botones
       final zonesSnapshot =


### PR DESCRIPTION
## Summary
- Remove `[DIAG-MS1.08]` timing logs from `silent_functionality_coordinator.dart`
- Remove `[DIAG-GRID]` logs from `emoji_service.dart` and `status_selector_overlay.dart`
- Remove `[DIAG-BN-WRITE]` logs from `EmojiDialogActivity.kt`, `StatusUpdateWorker.kt`, `MainActivity.kt`
- Remove `[DIAG-NOTIF]` timestamp logs from `KeepAliveService.kt`

All tagged issues were diagnosed and fixed in PRs #113–#117. Logs no longer serve a purpose and were adding noise to Logcat.

## Test plan
- [ ] Build compiles without errors
- [ ] Silent Mode activation works normally (Fix A verified separately)
- [ ] Notification disappears on app reopen (Fix B verified separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)