### PR TITLE
fix: Silent Mode + BN now writes to Firebase (circleId always empty)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -79,6 +79,10 @@ class EmojiDialogActivity : Activity() {
 
         emojis = loadEmojisFromCache()
         configuredZoneTypes = loadConfiguredZoneTypes()
+
+        val ws = getSharedPreferences("worker_state", Context.MODE_PRIVATE)
+        Log.d(TAG, "[DIAG-WS] BN onCreate worker_state: userId=${ws.getString("userId", null)} circleId='${ws.getString("circleId", null)}'")
+
         setupActivityUI()
 
         // ========================================================================
@@ -547,7 +551,8 @@ class EmojiDialogActivity : Activity() {
             .putString("statusType", status)
             .putString("emoji", emoji)
             .putLong("timestamp", timestamp)
-            .apply()
+            .commit()
+        Log.d(TAG, "[DIAG-BN] pending_status COMMITTED ts=$timestamp status=$status emoji=$emoji")
 
         val workData = Data.Builder()
             .putString("statusType", status)

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -417,19 +417,22 @@ class MainActivity: FlutterActivity() {
                     val circleId = call.argument<String>("circleId") ?: ""
                     
                     if (userId != null && userId.isNotEmpty()) {
-                        Log.d(TAG, "📤 [FLUTTER→KOTLIN] Sincronizando userId: $userId (circleId=$circleId)")
-                        currentUserId = userId
-                        NativeStateManager.saveUserState(this, userId, email, circleId)
+                        // Si circleId llega vacío, preservar el valor existente en worker_state
+                        // para que setUserId desde main.dart (onPause, sin circleId) no borre
+                        // el circleId real sincronizado por InCircleView.
+                        val existingCircleId = getSharedPreferences("worker_state", Context.MODE_PRIVATE)
+                            .getString("circleId", "") ?: ""
+                        val finalCircleId = if (circleId.isNotEmpty()) circleId else existingCircleId
 
-                        // Backup sync para Worker: Room escribe async y puede perderse si el
-                        // proceso muere antes de que el coroutine complete. commit() es síncrono
-                        // y garantiza persistencia antes de que este método retorne.
+                        Log.d(TAG, "[DIAG-WS] setUserId WROTE worker_state: userId=$userId circleId='$finalCircleId' (incoming='$circleId' preserved=${circleId.isEmpty() && finalCircleId.isNotEmpty()})")
+                        currentUserId = userId
+                        NativeStateManager.saveUserState(this, userId, email, finalCircleId)
+
                         getSharedPreferences("worker_state", Context.MODE_PRIVATE)
                             .edit()
                             .putString("userId", userId)
-                            .putString("circleId", circleId)
+                            .putString("circleId", finalCircleId)
                             .commit()
-                        Log.d(TAG, "💾 [WORKER-STATE] userId/circleId guardados sync en SharedPrefs")
 
                         // Point 4: Pre-calentar engine para modal instantáneo
                         warmUpModalEngine()

--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -30,15 +30,15 @@ class StatusUpdateWorker(
         val statusType = inputData.getString("statusType") ?: return Result.failure()
         val timestamp = inputData.getLong("timestamp", 0L)
 
-        Log.d(TAG, "💼 [WORKER] Iniciando write directo a Firestore: $statusType (ts: $timestamp)")
+        Log.d(TAG, "[DIAG-W1] doWork START — input ts=$timestamp status=$statusType")
 
         // Verificar si Flutter ya procesó el estado al reabrir la app
         val prefs = applicationContext.getSharedPreferences("pending_status", Context.MODE_PRIVATE)
         val pendingTimestamp = prefs.getLong("timestamp", 0L)
 
-        Log.d(TAG, "[DIAG-BN] pendingTimestamp=$pendingTimestamp vs enqueue timestamp=$timestamp")
+        Log.d(TAG, "[DIAG-W2] pendingTs=$pendingTimestamp == enqueueTs=$timestamp ? ${pendingTimestamp == timestamp}")
         if (pendingTimestamp != timestamp) {
-            Log.d(TAG, "[DIAG-BN] BAIL-OUT — timestamp mismatch, Flutter ya procesó o prefs fueron limpiados")
+            Log.d(TAG, "[DIAG-W2] BAIL-OUT — timestamp mismatch")
             return Result.success()
         }
 
@@ -48,30 +48,34 @@ class StatusUpdateWorker(
             // antes de que el coroutine terminara. SharedPreferences usa commit() (sync) y
             // siempre tiene los valores del último setUserId exitoso desde Flutter.
             val state = NativeStateManager.getState(applicationContext)
-            var circleId = state?.circleId
-            var userId = state?.userId
+            val nativeUserId = state?.userId
+            val nativeCircleId = state?.circleId
+            Log.d(TAG, "[DIAG-W3] NativeState: userId=$nativeUserId circleId=$nativeCircleId")
+
+            var userId = nativeUserId
+            var circleId = nativeCircleId
 
             if (circleId.isNullOrEmpty() || userId.isNullOrEmpty()) {
-                Log.w(TAG, "⚠️ [WORKER] NativeStateManager vacío — leyendo fallback SharedPrefs")
                 val fallback = applicationContext.getSharedPreferences("worker_state", Context.MODE_PRIVATE)
                 userId = fallback.getString("userId", null)
                 circleId = fallback.getString("circleId", null)
-                Log.d(TAG, "[WORKER] Fallback — userId=$userId circleId=$circleId")
+                Log.d(TAG, "[DIAG-W4] Fallback worker_state: userId=$userId circleId='$circleId' (empty=${circleId.isNullOrEmpty()})")
             }
 
             if (circleId.isNullOrEmpty() || userId.isNullOrEmpty()) {
-                Log.w(TAG, "⚠️ [WORKER] circleId o userId no disponibles en ninguna fuente")
+                Log.w(TAG, "[DIAG-W4] FAIL — circleId o userId no disponibles en ninguna fuente")
                 return Result.failure()
             }
 
             // Firebase Auth persiste entre sesiones — no requiere Flutter para autenticar
             val currentUser = FirebaseAuth.getInstance().currentUser
+            Log.d(TAG, "[DIAG-W5] FirebaseAuth.currentUser?.uid=${currentUser?.uid} expected=$userId")
             if (currentUser == null) {
-                Log.w(TAG, "⚠️ [WORKER] Sin usuario Firebase autenticado")
+                Log.w(TAG, "[DIAG-W5] FAIL — Sin usuario Firebase autenticado")
                 return Result.failure()
             }
             if (currentUser.uid != userId) {
-                Log.w(TAG, "⚠️ [WORKER] UID Firebase (${currentUser.uid}) ≠ NativeStateManager ($userId)")
+                Log.w(TAG, "[DIAG-W5] FAIL — UID mismatch: Firebase=${currentUser.uid} NativeState=$userId")
                 return Result.failure()
             }
 
@@ -89,6 +93,7 @@ class StatusUpdateWorker(
                 "zoneId"        to null,
             )
 
+            Log.d(TAG, "[DIAG-W6] Firestore.update STARTING — circle=$circleId userId=$userId statusType=$statusType")
             Tasks.await(
                 db.collection("circles")
                     .document(circleId)
@@ -98,10 +103,10 @@ class StatusUpdateWorker(
             // Limpiar pending_status para que Flutter no lo reprocese al reabrir la app
             prefs.edit().clear().apply()
 
-            Log.d(TAG, "✅ [WORKER] '$statusType' escrito en Firestore. Circle: $circleId, User: $userId")
+            Log.d(TAG, "[DIAG-W6] Firestore.update SUCCESS — '$statusType' escrito. Circle: $circleId")
             Result.success()
         } catch (e: Exception) {
-            Log.e(TAG, "❌ [WORKER] Error escribiendo a Firestore: ${e.message}", e)
+            Log.e(TAG, "[DIAG-W7] EXCEPTION: ${e.javaClass.simpleName}: ${e.message}", e)
             Result.failure()
         }
     }

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -21,6 +21,7 @@ import '../../../geofencing/services/geofencing_service.dart'; // Servicio de ge
 // CACHE-FIRST: Importar caches
 import '../../../../core/cache/in_memory_cache.dart';
 import '../../../../core/cache/persistent_cache.dart';
+import '../../../../core/services/native_state_bridge.dart';
 // Asumo que tienes una clase Coordinates en gps_service.dart o similar
 // import '../../../../core/services/gps_service.dart' show Coordinates;
 
@@ -159,6 +160,19 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
 
     // PASO 4: Iniciar monitoreo de geofencing
     _startGeofencingMonitoring();
+
+    // Sincronizar circleId real con Kotlin — garantiza que StatusUpdateWorker
+    // tenga un circleId válido cuando la app esté cerrada (Silent Mode + BN).
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser != null) {
+      NativeStateBridge.setUserId(
+        userId: currentUser.uid,
+        email: currentUser.email ?? '',
+        circleId: widget.circle.id,
+      ).catchError((e) {
+        // Esperado en iOS o si el canal no está disponible
+      });
+    }
 
     // PASO 5: Escuchar solicitudes de ingreso (solo si el usuario actual es el creador)
     final currentUid = FirebaseAuth.instance.currentUser?.uid;


### PR DESCRIPTION
## Summary
- Root cause confirmed via diagnostic logs: `circleId` was always `''` in `worker_state` SharedPrefs — `StatusUpdateWorker` always hit FAIL at W4
- Fix 1 (`in_circle_view.dart`): `InCircleView.initState` now syncs real `circle.id` to Kotlin native state — first time circleId is actually available
- Fix 2 (`MainActivity.kt`): `setUserId` handler preserves existing circleId when incoming is empty — prevents `main.dart` onPause from overwriting valid value
- Includes diagnostic logs DIAG-WS/BN/W1-W7 for future debugging (can be stripped pre-release)

## Verified on device R58W315389R
```
preserved=true → BN circleId='iLlx3g...' → W6 Firestore.update SUCCESS
```
Confirmed in Firebase console ✅

## Files changed
- `lib/features/circle/presentation/widgets/in_circle_view.dart`
- `android/.../MainActivity.kt`
- `android/.../StatusUpdateWorker.kt`
- `android/.../EmojiDialogActivity.kt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)