### PR TITLE
feat: add tap hint 'Toca para cambiar tu estado' for current user

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -1382,6 +1382,14 @@ class _MemberListItem extends StatelessWidget {
                               fontWeight: FontWeight.w500,
                             ),
                           ),
+                        if (isCurrentUser && status != 'loading') ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            key: const Key('text_tap_hint'),
+                            'Toca para cambiar tu estado',
+                            style: TextStyle(fontSize: 11, color: Colors.grey[500]),
+                          ),
+                        ],
                       ],
                     ),
                   ),


### PR DESCRIPTION
## Summary
- Adds hint text below the current user's status row in the circle view
- Only visible to the current user (`isCurrentUser && status != 'loading'`)
- No logic, navigation, or layout changes — pure additive Text widget

## Test plan
- [ ] Open circle view as current user → hint "Toca para cambiar tu estado" visible under your row
- [ ] Other members' rows → hint NOT visible
- [ ] While status is loading → hint NOT visible
- [ ] Tapping the row still opens the status selector (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)