### PR TITLE
fix: suppress geo initial check after BN emoji pick + silent mode notification hint

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -190,6 +190,8 @@ class KeepAliveService : Service() {
         
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle("Modo Silencio activo")
+            .setContentText("Toca para cambiar tu estado")
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)

--- a/lib/features/geofencing/services/geofencing_service.dart
+++ b/lib/features/geofencing/services/geofencing_service.dart
@@ -15,6 +15,12 @@ class GeofencingService {
   final ZoneService _zoneService = ZoneService();
   final ZoneEventService _eventService = ZoneEventService();
 
+  // Cuando el usuario elige un emoji desde la BN con el proceso muerto, al reabrir
+  // startMonitoring() dispararía checkCurrentLocation() y sobreescribiría ese emoji
+  // con el estado de zona (ENTRY). Este flag hace que ese primer check se omita,
+  // preservando lo que StatusUpdateWorker ya escribió en Firestore.
+  static bool _suppressNextInitialCheck = false;
+
   // Estado del servicio
   bool _isMonitoring = false;
   StreamSubscription<Position>? _positionSubscription;
@@ -39,8 +45,17 @@ class GeofencingService {
       _isMonitoring = true;
 
       // Verificar ubicación actual en background — no bloquea el arranque de la UI
-      // ni dispara modales de zona durante initState (fix: modal automático al reabrir)
-      Future.microtask(() => checkCurrentLocation());
+      // ni dispara modales de zona durante initState (fix: modal automático al reabrir).
+      // Si el flag está activo, omitir el check inicial para no sobreescribir el emoji
+      // elegido en la BN mientras el proceso estaba muerto (fix Bug 1 Silent Mode reopen).
+      Future.microtask(() async {
+        if (_suppressNextInitialCheck) {
+          _suppressNextInitialCheck = false;
+          log('[GeofencingService] ⏭️ Initial check omitido — status pendiente de BN');
+          return;
+        }
+        checkCurrentLocation();
+      });
 
       // Configurar monitoreo continuo
       _positionSubscription = Geolocator.getPositionStream(
@@ -201,6 +216,12 @@ class GeofencingService {
       }
     } // Actualizar estado actual
     _currentZoneId = newZoneId;
+  }
+
+  /// Señala que el próximo checkCurrentLocation() al iniciar debe omitirse.
+  /// Llamar desde main.dart tras aplicar un status elegido en la BN con proceso muerto.
+  static void suppressNextCheckOnReopen() {
+    _suppressNextInitialCheck = true;
   }
 
   /// Obtener zona actual del usuario

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:nunakin_app/firebase_options.dart';
 import 'package:nunakin_app/features/auth/presentation/pages/auth_wrapper.dart';
+import 'package:nunakin_app/features/geofencing/services/geofencing_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
@@ -98,6 +99,9 @@ Future<void> _updateStatusFromNative(String statusTypeName) async {
     final result = await StatusService.updateUserStatus(statusType);
 
     if (result.isSuccess) {
+      // Suprimir el próximo checkCurrentLocation() al reabrir la app: evita que
+      // GeofencingService sobreescriba este emoji con el estado de zona (Bug 1).
+      GeofencingService.suppressNextCheckOnReopen();
       print('✅ [NATIVE→FLUTTER] Estado actualizado en Firebase: ${statusType.description}');
     } else {
       print('❌ [NATIVE→FLUTTER] Error actualizando estado: ${result.errorMessage}');


### PR DESCRIPTION
## Summary

- **Bug 1:** After Silent Mode killed the process and the user picked an emoji from the notification bar, reopening the app triggered `checkCurrentLocation()` via `Future.microtask()`. With a fresh `GeofencingService` instance (`_currentZoneId = null`), GPS detected the user inside their home zone and fired an ENTRY event, overwriting the BN-chosen emoji with "Casa". Fixed by adding a static `_suppressNextInitialCheck` flag that `main.dart` sets (via `suppressNextCheckOnReopen()`) after a successful native status update.
- **Bug 2:** The persistent KeepAlive foreground notification had no content text when expanded — the hint "Toca para cambiar tu estado" was not visible. Fixed by adding `setContentTitle` and `setContentText` to the notification builder in `KeepAliveService.kt`.

## Files changed

- `lib/features/geofencing/services/geofencing_service.dart` — static flag + `suppressNextCheckOnReopen()` method + conditional microtask
- `lib/main.dart` — import + call `suppressNextCheckOnReopen()` after successful native status
- `android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt` — `setContentTitle` + `setContentText` en `createNotification()`

## Test plan

- [ ] Silent Mode activo → elegir emoji desde BN → reabrir app → emoji elegido se muestra (no "Casa")
- [ ] Expandir notificación persistente en barra → ver "Modo Silencio activo" y "Toca para cambiar tu estado"
- [ ] Entrada/salida de zona normal (sin Silent Mode) sigue funcionando correctamente

🤖 Generated with [Claude Code](https://claude.ai/claude-code)