### PR TITLE
fix: preserve BN selection after Silent Mode + auth resilience

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -100,10 +100,31 @@ class StatusUpdateWorker(
                     .update("memberStatus.$userId", statusData)
             )
 
+            // ════════════════════════════════════════════════════════════
+            // [FIX] Bugs 2 & 3 — Preservar selección BN al reabrir la app
+            // Fecha: 2026-04-29
+            // PROBLEMA: si el Worker procesa antes de que la app se reabra,
+            //   limpia pending_status y MainActivity.onResume() ya no invoca el
+            //   canal status_update. Como GeofencingService.suppressNextCheckOnReopen()
+            //   solo se llama desde _updateStatusFromNative() en Flutter, el flag
+            //   in-memory queda en false y el initial check de geofencing
+            //   sobreescribe la selección BN al detectar zona vigente.
+            // SOLUCIÓN: persistir un flag en FlutterSharedPreferences que main.dart
+            //   leerá antes de runApp() para suprimir el próximo check inicial.
+            //   Solo se escribe tras éxito real en Firestore — si el worker falla
+            //   o hace bail-out por timestamp mismatch, no se setea (Flutter ya
+            //   habrá procesado vía canal e invocado el suppress in-memory).
+            // ════════════════════════════════════════════════════════════
+            applicationContext
+                .getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+                .edit()
+                .putBoolean("flutter.suppress_next_geofence_check", true)
+                .apply()
+
             // Limpiar pending_status para que Flutter no lo reprocese al reabrir la app
             prefs.edit().clear().apply()
 
-            Log.d(TAG, "[DIAG-W6] Firestore.update SUCCESS — '$statusType' escrito. Circle: $circleId")
+            Log.d(TAG, "[DIAG-W6] Firestore.update SUCCESS — '$statusType' escrito. Circle: $circleId. Flag suppress_next_geofence_check=true")
             Result.success()
         } catch (e: Exception) {
             Log.e(TAG, "[DIAG-W7] EXCEPTION: ${e.javaClass.simpleName}: ${e.message}", e)

--- a/lib/features/auth/presentation/pages/auth_wrapper.dart
+++ b/lib/features/auth/presentation/pages/auth_wrapper.dart
@@ -1,7 +1,7 @@
 // lib/features/auth/presentation/pages/auth_wrapper.dart
 
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth, FirebaseAuthException, User;
 import 'package:nunakin_app/features/circle/presentation/pages/home_page.dart';
 import 'package:nunakin_app/features/auth/presentation/pages/auth_final_page.dart';
 import 'package:nunakin_app/core/services/silent_functionality_coordinator.dart';
@@ -105,10 +105,29 @@ class _AuthWrapperState extends State<AuthWrapper> {
             });
           }
         }
+      } on FirebaseAuthException catch (e) {
+        // ════════════════════════════════════════════════════════════
+        // [FIX] Bug 1 — No desautenticar tras Modo Silencio prolongado
+        // Fecha: 2026-04-29
+        // PROBLEMA: el catch genérico cerraba sesión ante CUALQUIER excepción
+        //   en user.reload() — incluyendo errores transitorios (red caída tras
+        //   horas en MS, token caducado momentáneamente). El default de MS es
+        //   permanecer activo; jamás debe disparar logout por sí mismo.
+        // SOLUCIÓN: solo cerrar sesión cuando la cuenta está genuinamente
+        //   inválida (user-not-found, user-disabled). Errores transitorios
+        //   preservan la sesión — Firebase Auth refresca token automáticamente
+        //   en la próxima operación.
+        // ════════════════════════════════════════════════════════════
+        if (e.code == 'user-not-found' || e.code == 'user-disabled') {
+          print('⚠️ [AuthWrapper] Cuenta inválida (${e.code}) — cerrando sesión');
+          await FirebaseAuth.instance.signOut();
+          await SessionCacheService.clearSession();
+        } else {
+          print('ℹ️ [AuthWrapper] Error transitorio verificando cuenta (${e.code}) — manteniendo sesión');
+        }
       } catch (e) {
-        print('⚠️ [AuthWrapper] Token inválido al verificar cuenta: $e — cerrando sesión...');
-        await FirebaseAuth.instance.signOut();
-        await SessionCacheService.clearSession();
+        // Errores no-Firebase (red, timeout, plataforma) → mantener sesión.
+        print('ℹ️ [AuthWrapper] Error no-Firebase verificando cuenta: $e — manteniendo sesión');
       }
     });
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nunakin_app/firebase_options.dart';
 import 'package:nunakin_app/features/auth/presentation/pages/auth_wrapper.dart';
 import 'package:nunakin_app/features/geofencing/services/geofencing_service.dart';
@@ -40,6 +41,27 @@ void main() async {
 
   // SessionCache debe estar listo antes de que AuthWrapper renderice
   await SessionCacheService.init();
+
+  // ════════════════════════════════════════════════════════════
+  // [FIX] Bugs 2 & 3 — Preservar selección BN tras Modo Silencio
+  // Fecha: 2026-04-29
+  // PROBLEMA: cuando StatusUpdateWorker procesa el cambio antes de que la app
+  //   se reabra, limpia pending_status y MainActivity.onResume() no invoca el
+  //   canal status_update, por lo que _updateStatusFromNative() nunca corre y
+  //   GeofencingService.suppressNextCheckOnReopen() no se activa. El check
+  //   inicial de geofencing en InCircleView sobreescribe el emoji elegido en
+  //   la BN al detectar al usuario dentro de una zona vigente.
+  // SOLUCIÓN: el Worker setea flutter.suppress_next_geofence_check=true en
+  //   FlutterSharedPreferences. Aquí (antes de runApp y por tanto antes de
+  //   InCircleView.initState) leemos el flag, suprimimos el próximo check y
+  //   limpiamos el flag.
+  // ════════════════════════════════════════════════════════════
+  final flutterPrefs = await SharedPreferences.getInstance();
+  if (flutterPrefs.getBool('suppress_next_geofence_check') ?? false) {
+    GeofencingService.suppressNextCheckOnReopen();
+    await flutterPrefs.remove('suppress_next_geofence_check');
+    print('🛡️ [main] Flag suppress_next_geofence_check leído — initial check será omitido');
+  }
 
   // Registrar handler antes de runApp para evitar race con onResume nativo.
   // onResume invoca status_update antes del primer frame; si el handler se


### PR DESCRIPTION
## Summary
Fixes 3 Silent Mode regressions reported in dispositivo:

- **Bug 1** — Tras período prolongado en Modo Silencio, la app desautentica al usuario al reabrir. `AuthWrapper._verifyUserAccountOnServer` cerraba sesión ante CUALQUIER excepción en `user.reload()`, incluyendo errores transitorios (red, timeout, token caducado momentáneamente). Solución: solo cerrar sesión en `user-not-found` / `user-disabled`; preservar sesión en errores transitorios — Firebase Auth refresca token automáticamente.

- **Bug 2 & 3** — Tras reabrir la app desde Modo Silencio, la selección hecha desde la BN se sobrescribe por el initial check de geofencing (alfiler 📍 + zona detectada). Causa: cuando `StatusUpdateWorker` procesa antes de que la app se reabra, limpia `pending_status` y `MainActivity.onResume()` nunca invoca el canal `status_update`, por lo que `_updateStatusFromNative()` nunca corre y `GeofencingService.suppressNextCheckOnReopen()` no se activa. Solución: el Worker persiste `flutter.suppress_next_geofence_check=true` tras éxito en Firestore. `main.dart` lee el flag antes de `runApp()` (antes de `InCircleView.initState`) e invoca el suppress in-memory.

## Files
- `lib/features/auth/presentation/pages/auth_wrapper.dart` — Bug 1
- `android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt` — Bug 2/3 (escribe flag)
- `lib/main.dart` — Bug 2/3 (lee flag + suprime initial check)

## Comportamiento esperado tras el fix

### Bug 1
- Modo Silencio sostenido (horas/días) → reabrir app → sesión preservada (sin pantalla de login).
- Solo se cierra sesión si la cuenta fue eliminada o deshabilitada en el servidor.

### Bug 2
- Re-login → MS → cambio desde BN → reabrir app → emoji de BN persiste (sin alfiler ni "Casa").

### Bug 3
- Entrar/salir zona preconfigurada → MS → cambio desde BN → reabrir app → emoji de BN persiste.
- Excepciones donde la selección BN puede ser sobreescrita siguen siendo: SOS o nueva entrada a zona (geofence subsiguiente, no el initial check).

## Test plan
- [ ] **Bug 1:** activar MS → dejar app en background varias horas (probar también con red intermitente) → reabrir → verificar que NO se redirige a auth_final_page.
- [ ] **Bug 1:** simular cuenta eliminada en Firebase Console → reabrir → verificar que SÍ se redirige a login (path correcto).
- [ ] **Bug 2:** logout → login → activar MS → cambiar emoji desde modal de BN → abrir app → verificar emoji elegido y ausencia de alfiler/Casa.
- [ ] **Bug 3:** entrar zona preconfigurada → salir → activar MS → cambiar emoji desde BN → abrir app → verificar emoji elegido (no zona).
- [ ] **Regresión:** activar MS sin BN → reabrir → geofencing debe seguir funcionando en checks subsecuentes (movimiento >50m).
- [ ] **Regresión:** entrar a zona estando con app abierta → estado se actualiza automáticamente (entry event sin afectar por suppress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)