### PR TITLE
fix: remove incorrect geo validation in zone form that accepted Ecuador

### DIFF
--- a/lib/features/geofencing/presentation/widgets/zone_form.dart
+++ b/lib/features/geofencing/presentation/widgets/zone_form.dart
@@ -120,26 +120,6 @@ class _ZoneFormState extends State<ZoneForm> {
         ),
       );
 
-      print('📍 [ZoneForm] Ubicación GPS obtenida: ${position.latitude}, ${position.longitude}');
-      print('📍 [ZoneForm] Precisión: ${position.accuracy}m');
-
-      // Validar que la ubicación sea razonable (Perú está entre -18 y 0 lat, -81 y -68 lng)
-      if (position.latitude < -18 || position.latitude > 0 || position.longitude < -82 || position.longitude > -68) {
-        print('⚠️ [ZoneForm] Ubicación fuera de Perú: ${position.latitude}, ${position.longitude}');
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                  '⚠️ La ubicación GPS (${position.latitude.toStringAsFixed(4)}, ${position.longitude.toStringAsFixed(4)}) parece estar fuera de Perú. Usa el mapa para ajustar manualmente.'),
-              backgroundColor: Colors.orange,
-              duration: const Duration(seconds: 4),
-            ),
-          );
-        }
-        setState(() => _isLoadingLocation = false);
-        return;
-      }
-
       setState(() {
         _selectedLocation = LatLng(position.latitude, position.longitude);
         _isLoadingLocation = false;


### PR DESCRIPTION
## Summary

La validación geográfica en `_getCurrentLocation()` usaba bounds incorrectos para "Perú":
- Lat: -18 a 0 / Lon: -82 a -68

Ecuador (lat 0 a -5, lon -81 a -75) **pasa este filtro** sin ser detectado. Cuando el GPS retorna coordenadas ecuatorianas (emulador con GPS mockeado, caché stale o red celular imprecisa), la validación las acepta y `animateCamera()` mueve el mapa a Ecuador en lugar de Lima.

## Fix

Eliminado el bloque de validación geográfica completo (20 líneas). Las coordenadas GPS se usan tal cual — el usuario puede ajustar el pin manualmente si el GPS no es preciso. El fallback a Lima (`LatLng(-12.046374, -77.042793)`) sigue activo para cuando el GPS falla por completo (permisos denegados o timeout).

## Archivos cambiados

- `lib/features/geofencing/presentation/widgets/zone_form.dart` — eliminado bloque de validación geográfica en `_getCurrentLocation()`

## Test plan

- [ ] Abrir formulario de crear zona → mapa debe centrarse en ubicación GPS real del usuario
- [ ] Si GPS falla (permisos denegados) → mapa permanece en Lima (fallback)
- [ ] Botón "mi ubicación" (FAB) → centra en ubicación actual sin error de Ecuador

🤖 Generated with [Claude Code](https://claude.ai/claude-code)