### PR TITLE
fix: bias zone address search to closest result from current GPS position

### DIFF
--- a/lib/features/geofencing/presentation/widgets/zone_form.dart
+++ b/lib/features/geofencing/presentation/widgets/zone_form.dart
@@ -186,7 +186,10 @@ class _ZoneFormState extends State<ZoneForm> {
     );
   }
 
-  /// Buscar dirección y ubicar en mapa
+  /// Buscar dirección y ubicar en mapa.
+  /// Usa locale es_PE para biasear resultados hacia Perú y, si el geocoding
+  /// devuelve múltiples candidatos, elige el más cercano a la posición GPS
+  /// actual del usuario para evitar resultados de otros países.
   Future<void> _searchAddress() async {
     final address = _addressController.text.trim();
     if (address.isEmpty) return;
@@ -200,8 +203,26 @@ class _ZoneFormState extends State<ZoneForm> {
         throw Exception('No se encontró la dirección');
       }
 
-      final location = locations.first;
-      final newLocation = LatLng(location.latitude, location.longitude);
+      // Si hay múltiples resultados, elegir el más cercano a la posición actual
+      final best = locations.length == 1
+          ? locations.first
+          : locations.reduce((a, b) {
+              final distA = Geolocator.distanceBetween(
+                _selectedLocation.latitude,
+                _selectedLocation.longitude,
+                a.latitude,
+                a.longitude,
+              );
+              final distB = Geolocator.distanceBetween(
+                _selectedLocation.latitude,
+                _selectedLocation.longitude,
+                b.latitude,
+                b.longitude,
+              );
+              return distA <= distB ? a : b;
+            });
+
+      final newLocation = LatLng(best.latitude, best.longitude);
 
       setState(() {
         _selectedLocation = newLocation;


### PR DESCRIPTION
## Summary

`locationFromAddress()` retorna múltiples candidatos globales (ej: "Miraflores" en Lima Y en Chile). El código anterior tomaba `locations.first` sin criterio, pudiendo retornar cualquier país.

**Fix:** cuando el geocoding retorna múltiples resultados, se elige el más cercano a `_selectedLocation` (posición GPS actual del usuario) usando `Geolocator.distanceBetween()`. El resultado único sigue usándose directamente.

## Por qué el bug era invisible antes

El usuario no podía llegar a usar la búsqueda porque el GPS ya mostraba Ecuador en el mapa (bug anterior en `_getCurrentLocation()`). Una vez resuelto el GPS, el bug de búsqueda quedó expuesto.

## Archivos cambiados

- `lib/features/geofencing/presentation/widgets/zone_form.dart` — método `_searchAddress()`: reemplaza `locations.first` por selección del resultado más cercano a GPS

## Test plan

- [ ] GPS activo en Lima → buscar "Miraflores" → mapa debe centrarse en Miraflores, Lima (no Chile)
- [ ] GPS activo en Lima → buscar "Plaza de Armas" → resultado en Lima
- [ ] Búsqueda con término único → funciona igual que antes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)