### PR TITLE
diag: add Firebase Auth uid telemetry during Silent Mode

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/KeepAliveService.kt
@@ -44,6 +44,8 @@ class KeepAliveService : Service() {
                 val notification = createNotification()
                 startForeground(NOTIFICATION_ID, notification)
                 Log.d(TAG, "🔄 [KEEP-ALIVE] startForeground re-afirmado (handler periódico)")
+                val uid = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
+                Log.d("DIAG-AUTH-001", "[KeepAlive tick] uid=$uid ts=${System.currentTimeMillis()}")
             } catch (e: Exception) {
                 Log.w(TAG, "⚠️ [KEEP-ALIVE] Error en tick periódico: ${e.message}")
             }

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -102,6 +102,9 @@ class MainActivity: FlutterActivity() {
         // Verificar si hay estado guardado
         currentUserId = NativeStateManager.getUserId(this)
 
+        val uid = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
+        Log.d("DIAG-AUTH-001", "[MainActivity.onCreate] uid=$uid ts=${System.currentTimeMillis()}")
+
         // G2.C1: Restaurar isSilentModeActive desde SharedPrefs (sobrevive al swipe/kill del proceso)
         val silentPrefs = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
         isSilentModeActive = silentPrefs.getBoolean("is_silent_mode_active", false)


### PR DESCRIPTION
## Summary
- Agrega logs de telemetría `DIAG-AUTH-001` en `KeepAliveService.kt` y `MainActivity.kt`
- Valida que el token Firebase Auth UID permanece activo durante el ciclo de vida del Modo Silencio
- No modifica lógica de negocio — solo instrumentación de diagnóstico

## Contexto
Esta rama fue creada desde `fix/work-icon-sync`. El commit `bf13827` (fix: sync predefined emoji icons) incluido en el historial ya fue integrado a `main` vía PR #135. Solo el commit `9653abe` es nuevo.

## Fix ID
AUTH-20260504-001

## Test plan
- [ ] Verificar que los logs `DIAG-AUTH-001` aparecen en logcat durante entrada/salida de Silent Mode
- [ ] Confirmar que el UID no es null en ningún punto del ciclo
- [ ] Confirmar que no hay regresiones en flujos de auth existentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)