### PR TITLE
feat: show active status indicator in circle and notification bar modals

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -63,6 +63,16 @@ class EmojiDialogActivity : Activity() {
     // Tipos de zona configurados (se bloquean en el grid)
     private lateinit var configuredZoneTypes: Set<String>
 
+    // ════════════════════════════════════════════════════════════
+    // [FIX] Indicador visual de estado activo
+    // Fecha: 2026-05-04
+    // PROBLEMA: El modal nativo no mostraba cuál estado estaba activo.
+    // SOLUCIÓN: Leer flutter.current_status_id de SharedPreferences en
+    //           onCreate() y aplicar borde 2px #1CE4B3 + fondo #1CE4B3
+    //           al 12% en la celda coincidente.
+    // ════════════════════════════════════════════════════════════
+    private var activeStatusId: String? = null
+
     // SOS press & hold
     private val sosHandler = Handler(Looper.getMainLooper())
     private var sosHoldRunnable: Runnable? = null
@@ -79,6 +89,11 @@ class EmojiDialogActivity : Activity() {
 
         emojis = loadEmojisFromCache()
         configuredZoneTypes = loadConfiguredZoneTypes()
+
+        // [FIX] Leer estado activo desde SharedPreferences (escrito por StatusService en Flutter)
+        val flutterPrefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+        activeStatusId = flutterPrefs.getString("flutter.current_status_id", null)
+        Log.d(TAG, "[ACTIVE-STATUS] activeStatusId=$activeStatusId")
 
         val ws = getSharedPreferences("worker_state", Context.MODE_PRIVATE)
         Log.d(TAG, "[DIAG-WS] BN onCreate worker_state: userId=${ws.getString("userId", null)} circleId='${ws.getString("circleId", null)}'")
@@ -300,16 +315,27 @@ class EmojiDialogActivity : Activity() {
 
         mainEmojis.forEach { (emoji, label, statusId) ->
             val isBlocked = configuredZoneTypes.contains(statusId)
+            val isActive = statusId == activeStatusId
             if (isBlocked) Log.d(TAG, "[DIAG-MN409] BLOCKED: $statusId")
+            if (isActive) Log.d(TAG, "[ACTIVE-STATUS] Resaltando celda activa: $statusId")
 
             val container = LinearLayout(this).apply {
                 orientation = LinearLayout.VERTICAL
                 gravity = Gravity.CENTER
                 setPadding(dpToPx(4), dpToPx(6), dpToPx(4), dpToPx(6))
                 background = GradientDrawable().apply {
-                    setColor(if (isBlocked) Color.parseColor("#4D424242") else Color.parseColor("#99424242"))
+                    // [FIX] Decorador visual: fondo #1CE4B3 al 12% + borde 2px #1CE4B3 si activo
+                    setColor(when {
+                        isActive  -> Color.argb(31, 28, 228, 179)  // #1CE4B3 @ ~12%
+                        isBlocked -> Color.parseColor("#4D424242")
+                        else      -> Color.parseColor("#99424242")
+                    })
                     cornerRadius = dpToPx(12).toFloat()
-                    setStroke(dpToPx(1), Color.parseColor("#66757575"))
+                    if (isActive) {
+                        setStroke(dpToPx(2), Color.parseColor("#1CE4B3"))
+                    } else {
+                        setStroke(dpToPx(1), Color.parseColor("#66757575"))
+                    }
                 }
                 if (!isBlocked) {
                     foreground = android.graphics.drawable.RippleDrawable(
@@ -381,15 +407,19 @@ class EmojiDialogActivity : Activity() {
 
     private fun buildSosButton(sosItem: Triple<String, String, String>): LinearLayout {
         val (sosEmoji, _, sosId) = sosItem
+        // [FIX] Decorador visual para SOS cuando es el estado activo
+        val isSosActive = sosId == activeStatusId
 
         val button = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             gravity = Gravity.CENTER
             setPadding(dpToPx(16), dpToPx(14), dpToPx(16), dpToPx(14))
             background = GradientDrawable().apply {
-                setColor(Color.parseColor("#E53935")) // rojo
+                // Si SOS está activo: fondo #1CE4B3 al 12% + borde 2px #1CE4B3
+                // Si no: fondo rojo normal + borde rojo
+                setColor(if (isSosActive) Color.argb(31, 28, 228, 179) else Color.parseColor("#E53935"))
                 cornerRadius = dpToPx(12).toFloat()
-                setStroke(dpToPx(2), Color.parseColor("#E53935"))
+                setStroke(dpToPx(2), if (isSosActive) Color.parseColor("#1CE4B3") else Color.parseColor("#E53935"))
             }
             layoutParams = LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
 import 'app_badge_service.dart';
 import 'gps_service.dart';
@@ -229,6 +230,21 @@ class StatusService {
 
       await batch.commit();
       log('[StatusService] ✅ Estado actualizado exitosamente${coordinates != null ? ' con GPS' : ''}');
+
+      // ════════════════════════════════════════════════════════════
+      // [FIX] Persistir ID del estado activo en SharedPreferences
+      // Fecha: 2026-05-04
+      // PROBLEMA: El modal de selección no mostraba cuál estado estaba activo.
+      // SOLUCIÓN: Escribir flutter.current_status_id tras commit exitoso para
+      //           que in_circle_view y EmojiDialogActivity puedan leerlo.
+      // ════════════════════════════════════════════════════════════
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('flutter.current_status_id', newStatus.id);
+        log('[StatusService] 💾 current_status_id guardado: ${newStatus.id}');
+      } catch (e) {
+        log('[StatusService] ⚠️ Error guardando current_status_id: $e');
+      }
 
       // Actualizar notificación persistente con nuevo estado
       await _updatePersistentNotification(newStatus);

--- a/lib/core/widgets/emoji_modal.dart
+++ b/lib/core/widgets/emoji_modal.dart
@@ -293,13 +293,20 @@ class _EmojiStatusBottomSheetState extends ConsumerState<EmojiStatusBottomSheet>
 }
 
 /// Función helper para mostrar el modal unificado
-void showEmojiStatusBottomSheet(BuildContext context) {
+// ════════════════════════════════════════════════════════════
+// [FIX] Indicador visual de estado activo
+// Fecha: 2026-05-04
+// PROBLEMA: El modal no resaltaba el estado ya seleccionado.
+// SOLUCIÓN: Parámetro activeStatusId opcional propagado a StatusSelectorOverlay.
+// ════════════════════════════════════════════════════════════
+void showEmojiStatusBottomSheet(BuildContext context, {String? activeStatusId}) {
   // Usar el mismo modal que las notificaciones para consistencia
   Navigator.of(context).push(
     PageRouteBuilder(
       opaque: false, // Permite transparencia
       pageBuilder: (context, animation, secondaryAnimation) {
         return StatusSelectorOverlay(
+          activeStatusId: activeStatusId,
           onClose: () {
             print('[EmojiModal] Modal cerrado por usuario');
           },

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 // Asegúrate que las rutas de importación sean correctas para tu proyecto
 import '../../../../services/circle_service.dart';
@@ -750,9 +751,27 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                                 isCurrentUser: isCurrentUser,
                                 isFirst: index == 0,
                                 memberData: memberData,
+                                // ════════════════════════════════════════════════════════════
+                                // [FIX] Indicador visual de estado activo
+                                // Fecha: 2026-05-04
+                                // PROBLEMA: El modal no resaltaba el estado ya seleccionado.
+                                // SOLUCIÓN: Leer flutter.current_status_id de SharedPreferences
+                                //           y pasarlo a showEmojiStatusBottomSheet.
+                                // ════════════════════════════════════════════════════════════
                                 onTap: isCurrentUser
-                                    ? () => showEmojiStatusBottomSheet(
-                                        context) // Asume que esta función existe y es importada
+                                    ? () async {
+                                        String? activeStatusId;
+                                        try {
+                                          final prefs = await SharedPreferences.getInstance();
+                                          activeStatusId = prefs.getString('flutter.current_status_id');
+                                        } catch (_) {}
+                                        if (context.mounted) {
+                                          showEmojiStatusBottomSheet(
+                                            context,
+                                            activeStatusId: activeStatusId,
+                                          );
+                                        }
+                                      }
                                     : null,
                                 onOpenMaps: _openGoogleMaps,
                                 predefinedEmojis: _predefinedEmojis, // NUEVO: Pasar lista de emojis

--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -11,10 +11,19 @@ import '../core/services/status_service.dart';
 /// Reutiliza el StatusService existente sin romper nada
 class StatusSelectorOverlay extends StatefulWidget {
   final VoidCallback? onClose;
+  // ════════════════════════════════════════════════════════════
+  // [FIX] Indicador visual de estado activo
+  // Fecha: 2026-05-04
+  // PROBLEMA: El modal no mostraba cuál estado estaba activo.
+  // SOLUCIÓN: Parámetro opcional activeStatusId — la celda coincidente
+  //           recibe borde 2px #1CE4B3 + fondo #1CE4B3 al 12%.
+  // ════════════════════════════════════════════════════════════
+  final String? activeStatusId;
 
   const StatusSelectorOverlay({
     super.key,
     this.onClose,
+    this.activeStatusId,
   });
 
   @override
@@ -238,6 +247,7 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
     // - S.O.S siempre visible (sin reemplazar por spinner)
     // - Subtítulo: "Enviando SOS..." inmediato al presionar
     final bgColor = _sosHolding ? const Color(0xFFB71C1C) : Colors.red;
+    final isSosActive = widget.activeStatusId == 'sos';
 
     // Listener en lugar de GestureDetector: onPointerCancel sólo se dispara
     // por cancelación de hardware (ej: llamada entrante), NO por micro-movimientos
@@ -251,10 +261,12 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
         margin: const EdgeInsets.only(top: 8),
         padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 16),
         decoration: BoxDecoration(
-          color: bgColor,
+          color: isSosActive && !_sosHolding
+              ? const Color(0xFF1CE4B3).withValues(alpha: 0.12)
+              : bgColor,
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: bgColor,
+            color: isSosActive ? const Color(0xFF1CE4B3) : bgColor,
             width: 2,
           ),
         ),
@@ -512,6 +524,7 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
   /// Construye botón de estado individual
   Widget _buildStatusButton(StatusType status) {
     final isBlockedZone = _configuredZoneTypes.contains(status.id);
+    final isActive = widget.activeStatusId != null && widget.activeStatusId == status.id;
 
     return Material(
       color: Colors.transparent,
@@ -520,13 +533,17 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
         borderRadius: BorderRadius.circular(12),
         child: Container(
           decoration: BoxDecoration(
-            color: (_isUpdating || isBlockedZone)
-                ? Colors.grey.shade800.withOpacity(0.3)
-                : Colors.grey.shade800.withOpacity(0.6), // Fondo oscuro transparente
+            color: isActive
+                ? const Color(0xFF1CE4B3).withValues(alpha: 0.12)
+                : (_isUpdating || isBlockedZone)
+                    ? Colors.grey.shade800.withOpacity(0.3)
+                    : Colors.grey.shade800.withOpacity(0.6),
             borderRadius: BorderRadius.circular(12),
             border: Border.all(
-              color: Colors.grey.shade600.withOpacity(0.4), // Borde sutil
-              width: 1,
+              color: isActive
+                  ? const Color(0xFF1CE4B3)
+                  : Colors.grey.shade600.withOpacity(0.4),
+              width: isActive ? 2 : 1,
             ),
           ),
           child: Column(


### PR DESCRIPTION
## Summary

- Agrega indicador visual (borde 2px `#1CE4B3` + fondo al 12% de opacidad) en la celda del estado activo actual
- El indicador aplica en ambos modales: modal del Círculo (`status_selector_overlay.dart`, `emoji_modal.dart`) y modal de Barra de Notificaciones (`EmojiDialogActivity.kt`)
- `StatusService` expone el estado activo actual para que los modales puedan consultarlo al renderizar

## Archivos modificados

- `lib/core/services/status_service.dart`
- `lib/widgets/status_selector_overlay.dart`
- `lib/core/widgets/emoji_modal.dart`
- `lib/features/circle/presentation/widgets/in_circle_view.dart`
- `android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt`

## Test plan

- [ ] Abrir modal del Círculo — verificar que la celda del estado activo muestra borde teal y fondo tenue
- [ ] Cambiar estado desde el modal — verificar que el indicador se mueve al nuevo estado activo
- [ ] Abrir modal de Barra de Notificaciones — verificar el mismo comportamiento visual
- [ ] Verificar que el indicador no aparece cuando no hay estado activo seleccionado

## Fix ID

AUTH-20260504-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)