### PR TITLE
fix: guard FirebaseAuth.getInstance() against uninitialized Firebase in MainActivity

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -102,8 +102,12 @@ class MainActivity: FlutterActivity() {
         // Verificar si hay estado guardado
         currentUserId = NativeStateManager.getUserId(this)
 
-        val uid = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
-        Log.d("DIAG-AUTH-001", "[MainActivity.onCreate] uid=$uid ts=${System.currentTimeMillis()}")
+        if (com.google.firebase.FirebaseApp.getApps(this).isNotEmpty()) {
+            val uid = com.google.firebase.auth.FirebaseAuth.getInstance().currentUser?.uid
+            Log.d("DIAG-AUTH-001", "[MainActivity.onCreate] uid=$uid ts=${System.currentTimeMillis()}")
+        } else {
+            Log.d("DIAG-AUTH-001", "[MainActivity.onCreate] Firebase NOT initialized ts=${System.currentTimeMillis()}")
+        }
 
         // G2.C1: Restaurar isSilentModeActive desde SharedPrefs (sobrevive al swipe/kill del proceso)
         val silentPrefs = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)


### PR DESCRIPTION
## Summary
- `MainActivity.onCreate()` crasheaba con `IllegalStateException: Default FirebaseApp is not initialized` al llamar `FirebaseAuth.getInstance()` en línea 105 (telemetría DIAG-AUTH-001)
- Firebase se auto-inicializa via `FirebaseInitProvider`, pero en cold starts en ciertos dispositivos Samsung la secuencia puede no estar completa al llegar a `onCreate()`
- Fix: chequear `FirebaseApp.getApps(this).isNotEmpty()` antes de llamar `getInstance()`. Si Firebase no está listo, el log lo reporta explícitamente

## Archivos modificados
- `android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt` (líneas 105-109)

## Test plan
- [ ] Cold start en dispositivo físico — app arranca sin crash
- [ ] `adb logcat | grep DIAG-AUTH-001` muestra uid válido o "Firebase NOT initialized"

🤖 Generated with [Claude Code](https://claude.com/claude-code)