### PR TITLE
fix(AUTH-20260505-002): introduce manual_status_id to decouple BN Worker from modal indicator

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -242,6 +242,17 @@ class StatusService {
         final prefs = await SharedPreferences.getInstance();
         await prefs.setString('current_status_id', newStatus.id);
         log('[StatusService] 💾 current_status_id guardado: ${newStatus.id}');
+        // ════════════════════════════════════════════════════════════
+        // [FIX] Persistir manual_status_id desacoplado del BN Worker
+        // Fecha: 2026-05-05
+        // PROBLEMA: StatusUpdateWorker (Kotlin) sobreescribe flutter.current_status_id
+        //           al procesar BN, borrando el último emoji manual del usuario.
+        //           Al abrir el modal, in_circle_view mostraba el emoji incorrecto.
+        // SOLUCIÓN: Escribir también manual_status_id (solo este método lo escribe).
+        //           in_circle_view leerá manual_status_id para el indicador del modal.
+        // ════════════════════════════════════════════════════════════
+        await prefs.setString('manual_status_id', newStatus.id);
+        log('[StatusService] 💾 manual_status_id guardado: ${newStatus.id}');
       } catch (e) {
         log('[StatusService] ⚠️ Error guardando current_status_id: $e');
       }

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -763,7 +763,16 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                                         String? activeStatusId;
                                         try {
                                           final prefs = await SharedPreferences.getInstance();
-                                          activeStatusId = prefs.getString('current_status_id');
+                                          // ════════════════════════════════════════════════════════════
+                                          // [FIX] Leer manual_status_id en lugar de current_status_id
+                                          // Fecha: 2026-05-05
+                                          // PROBLEMA: current_status_id es sobreescrito por
+                                          //           StatusUpdateWorker (Kotlin/BN), borrando el último
+                                          //           emoji manual al abrir el modal.
+                                          // SOLUCIÓN: Leer manual_status_id, que solo escribe
+                                          //           StatusService.updateUserStatus() (Dart).
+                                          // ════════════════════════════════════════════════════════════
+                                          activeStatusId = prefs.getString('manual_status_id');
                                         } catch (_) {}
                                         if (context.mounted) {
                                           showEmojiStatusBottomSheet(


### PR DESCRIPTION
## Fix AUTH-20260505-002

Nueva clave `manual_status_id` en Flutter SharedPreferences.

- Escrita por `StatusService.updateUserStatus()` al confirmar un estado manual exitoso.
- Leída por `in_circle_view.dart` para determinar qué emoji mostrar en el indicador del modal.
- Evita que `StatusUpdateWorker` (Background Native Worker) sobreescriba el último emoji seleccionado manualmente por el usuario.

## Pruebas
- Confirmadas PASS en dispositivo por @implementer.

🤖 Merge ejecutado por @merger [Sonnet-4.6]