### PR TITLE
fix(AUTH-20260505-003): persist pre-silent status in Flutter SharedPreferences

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -141,6 +141,14 @@ class MainActivity: FlutterActivity() {
                 .remove("pre_silent_status_type")
                 .apply()
 
+            // [FIX-003] Limpiar también los flags escritos por Flutter SharedPreferences
+            // para que in_circle_view.dart no lea is_silent_mode_active=true al reabrir.
+            applicationContext.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+                .edit()
+                .remove("flutter.is_silent_mode_active")
+                .remove("flutter.pre_silent_status_id")
+                .apply()
+
             Log.d(TAG, "✅ [SILENT] onCreate — ícono 'i' eliminado, isSilentModeActive=false")
         }
 
@@ -535,9 +543,15 @@ class MainActivity: FlutterActivity() {
                     KeepAliveService.stop(this)
                     NotificationManagerCompat.from(this).cancelAll()
                     isSilentModeActive = false
-                    // G2.C1: Limpiar flag persistido
+                    // G2.C1: Limpiar flag persistido en Kotlin SharedPreferences
                     getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
                         .edit().putBoolean("is_silent_mode_active", false).apply()
+                    // [FIX-003] Limpiar también los flags escritos por Flutter SharedPreferences
+                    applicationContext.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
+                        .edit()
+                        .remove("flutter.is_silent_mode_active")
+                        .remove("flutter.pre_silent_status_id")
+                        .apply()
                     result.success(true)
                 }
                 "checkBatteryOptimization" -> {

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../notifications/notification_service.dart';
 import '../../quick_actions/quick_actions_service.dart';
 import '../../services/circle_service.dart';
@@ -122,6 +123,29 @@ class SilentFunctionalityCoordinator {
     }
 
     if (!context.mounted) return;
+
+    // ════════════════════════════════════════════════════════════
+    // [FIX] Persistir estado pre-silencio antes de activar
+    // Fecha: 2026-05-05
+    // PROBLEMA: Tras ~12h en background, el Worker sobreescribe
+    //           flutter.manual_status_id con otro status. Al abrir
+    //           el modal en Modo Silencio, el testigo muestra emoji incorrecto.
+    // SOLUCIÓN: Guardar manual_status_id → pre_silent_status_id antes de
+    //           invocar 'activate'. in_circle_view lee pre_silent_status_id
+    //           cuando is_silent_mode_active == true.
+    // ════════════════════════════════════════════════════════════
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final manualId = prefs.getString('manual_status_id');
+      if (manualId != null) {
+        await prefs.setString('pre_silent_status_id', manualId);
+        debugPrint('[SilentCoordinator] 💾 pre_silent_status_id guardado: $manualId');
+      }
+      await prefs.setBool('is_silent_mode_active', true);
+      debugPrint('[SilentCoordinator] 💾 is_silent_mode_active=true guardado en Flutter SharedPreferences');
+    } catch (e) {
+      debugPrint('[SilentCoordinator] ⚠️ Error guardando pre_silent_status_id: $e');
+    }
 
     try {
       await _channel.invokeMethod('activate');

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -772,7 +772,22 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                                           // SOLUCIÓN: Leer manual_status_id, que solo escribe
                                           //           StatusService.updateUserStatus() (Dart).
                                           // ════════════════════════════════════════════════════════════
-                                          activeStatusId = prefs.getString('manual_status_id');
+                                          // ════════════════════════════════════════════════════════════
+                                          // [FIX] En Modo Silencio usar pre_silent_status_id
+                                          // Fecha: 2026-05-05
+                                          // PROBLEMA: Tras ~12h en background, el Worker sobreescribe
+                                          //           manual_status_id. El modal muestra emoji incorrecto.
+                                          // SOLUCIÓN: Si is_silent_mode_active == true, usar
+                                          //           pre_silent_status_id (snapshot guardado antes de
+                                          //           activar el Modo Silencio).
+                                          // ════════════════════════════════════════════════════════════
+                                          final silentPrefs = await SharedPreferences.getInstance();
+                                          final isSilentActive = silentPrefs.getBool('is_silent_mode_active') ?? false;
+                                          if (isSilentActive) {
+                                            activeStatusId = prefs.getString('pre_silent_status_id');
+                                          } else {
+                                            activeStatusId = prefs.getString('manual_status_id');
+                                          }
                                         } catch (_) {}
                                         if (context.mounted) {
                                           showEmojiStatusBottomSheet(


### PR DESCRIPTION
## Fix AUTH-20260505-003

Persistencia de estado pre-Modo Silencio en Flutter SharedPreferences.

- `SilentFunctionalityCoordinator.activateSilentMode()` persiste `pre_silent_status_id` e `is_silent_mode_active` en SharedPreferences antes de activar el modo silencio.
- `in_circle_view.dart` prioriza `pre_silent_status_id` para el indicador del modal cuando el Modo Silencio está activo.
- `MainActivity.kt` limpia ambas claves al desactivar el Modo Silencio, dejando el estado consistente.

## Pruebas
- Confirmadas PASS en dispositivo por @implementer.

🤖 Merge ejecutado por @merger [Sonnet-4.6]