### PR TITLE
refactor(platform): add KvStore abstraction + centralize storage keys

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/storage-keys-audit.md
+++ b/docs/dev/refactor-arch-2026-q2/storage-keys-audit.md
@@ -1,0 +1,111 @@
+# Auditoría de SharedPreferences — Nunakin App
+
+> Fecha: 2026-05-08
+> Propósito: inventario previo a la centralización (StorageKeys Día 4 + NativeSharedKeys/SharedKeys.kt en Día 5).
+
+---
+
+## Resumen ejecutivo
+
+| Namespace | Origen | Claves | Acceso cross-boundary |
+|-----------|--------|--------|-----------------------|
+| `FlutterSharedPreferences` | SharedPreferences plugin (Flutter) | 12 | Kotlin lee/escribe 7 de ellas |
+| `zync_silent_mode` | Kotlin nativo | 3 | Solo Kotlin |
+| `pending_status` | Kotlin nativo | 2 | Solo Kotlin |
+| `worker_state` | Kotlin nativo | 2 | Solo Kotlin |
+| `HomeWidgetPlugin` | home_widget plugin | (gestionadas por plugin) | No |
+
+---
+
+## FlutterSharedPreferences — claves Dart
+
+> Las claves escritas desde Flutter se almacenan en disco con prefijo `flutter.`
+> (comportamiento del plugin). En código Dart se usan **sin** el prefijo.
+
+### Claves de presencia — ruta crítica de bugs
+
+| Clave Dart | Clave en disco | Escritor(es) | Lector(es) | Anomalía |
+|------------|---------------|--------------|------------|---------|
+| `current_status_id` | `flutter.current_status_id` | `status_service.dart` ✍️, `StatusUpdateWorker.kt` ✍️ | `EmojiDialogActivity.kt` 👁️ | **2 escritores — fragmentación crítica** |
+| `manual_status_id` | `flutter.manual_status_id` | `status_service.dart` ✍️ | `silent_functionality_coordinator.dart` 👁️, `in_circle_view.dart` 👁️ | — |
+| `pre_silent_status_id` | `flutter.pre_silent_status_id` | `silent_functionality_coordinator.dart` ✍️ | `in_circle_view.dart` 👁️, `MainActivity.kt` 🗑️ | — |
+| `is_silent_mode_active` | `flutter.is_silent_mode_active` | `silent_functionality_coordinator.dart` ✍️ | `in_circle_view.dart` 👁️, `MainActivity.kt` 🗑️ | **Duplicado con `zync_silent_mode`** |
+| `suppress_next_geofence_check` | `flutter.suppress_next_geofence_check` | `StatusUpdateWorker.kt` ✍️ | `main.dart` 👁️ | — |
+
+### Claves de cache nativo (Flutter → Kotlin)
+
+| Clave Dart | Clave en disco | Escritor | Lector |
+|------------|---------------|----------|--------|
+| `predefined_emojis` | `flutter.predefined_emojis` | `emoji_cache_service.dart` ✍️ | `EmojiDialogActivity.kt` 👁️ |
+| `configured_zone_types` | `flutter.configured_zone_types` | `emoji_cache_service.dart` ✍️ | `EmojiDialogActivity.kt` 👁️ |
+
+### Claves Flutter-only
+
+| Clave Dart | Archivo | Tipo | Notas |
+|------------|---------|------|-------|
+| `CACHED_USER` | `auth_local_data_source_impl.dart` | String (JSON) | User serializado |
+| `zync_cached_user_id` | `session_cache_service.dart` | String | UID Firebase |
+| `zync_cached_user_email` | `session_cache_service.dart` | String | Email del usuario |
+| `zync_cached_circle_id` | `session_cache_service.dart` | String | ID del círculo activo |
+| `zync_cached_last_save` | `session_cache_service.dart` | String | ISO 8601 timestamp |
+| `quick_actions_preferences` | `quick_actions_preferences_service.dart` | String (JSON) | IDs de quick actions configuradas |
+| `app_badge_last_seen` | `app_badge_service.dart` | Int | Unix ms del último badge visto |
+| `cache_nicknames` | `persistent_cache.dart` | String (JSON) | Nicknames de miembros |
+| `cache_member_data` | `persistent_cache.dart` | String (JSON) | Datos de miembros |
+| `cache_circle_<circleId>` | `persistent_cache.dart` | String (JSON) | Clave dinámica por círculo |
+| `last_update_<key>` | `persistent_cache.dart` | String (ISO 8601) | Timestamp de cache por clave dinámica |
+
+---
+
+## Kotlin-only namespaces
+
+> Estas claves no se acceden desde Dart. No tienen representación en `StorageKeys`.
+
+### `zync_silent_mode`
+
+| Clave | Escritor | Lector | Notas |
+|-------|----------|--------|-------|
+| `is_silent_mode_active` | `MainActivity.kt` ✍️ | `MainActivity.kt` 👁️ | Duplica `flutter.is_silent_mode_active` — Anomalía #1 |
+| `pre_silent_status_type` | — | `MainActivity.kt` 🗑️ (solo remove) | Nunca se escribe, solo se elimina |
+| `modal_was_open` | `NotificationTapReceiver.kt` ✍️ | — | Solo escritura visible |
+
+### `pending_status`
+
+| Clave | Escritor(es) | Lector(es) |
+|-------|-------------|-----------|
+| `statusType` | `EmojiDialogActivity.kt`, `MainActivity.kt`, `QuickActionActivity.kt`, `QuickActionReceiver.kt` | `StatusUpdateWorker.kt`, `MainActivity.kt` |
+| `emoji` | `EmojiDialogActivity.kt` ✍️ | — |
+
+### `worker_state`
+
+| Clave | Escritor | Lector |
+|-------|----------|--------|
+| `userId` | `MainActivity.kt` ✍️ | `StatusUpdateWorker.kt` 👁️ |
+| `circleId` | `MainActivity.kt` ✍️ | `StatusUpdateWorker.kt` 👁️, `EmojiDialogActivity.kt` 👁️ |
+
+### `HomeWidgetPlugin`
+
+| Clave | Escritor | Lector | Notas |
+|-------|----------|--------|-------|
+| (plugin-managed) | `ZyncStatusWidgetProvider.kt` | plugin | No requiere constantes propias |
+
+---
+
+## Hallazgos — duplicaciones y anomalías
+
+| # | Hallazgo | Impacto | Semana de resolución |
+|---|----------|---------|---------------------|
+| 1 | `is_silent_mode_active` existe en dos namespaces: `FlutterSharedPreferences` (escrito por Dart) y `zync_silent_mode` (escrito por Kotlin nativo) | **Alto** — fuente confirmada de bugs PRs #77, #106, #113 | Sem 3 (Native Bridge) |
+| 2 | `current_status_id` tiene 2 escritores independientes: `StatusService.dart` + `StatusUpdateWorker.kt` sin coordinación | **Alto** — race condition documentada, raíz de AUTH-20260505-002 | Sem 2 (Presence state machine) |
+| 3 | `pre_silent_status_type` (Kotlin `zync_silent_mode`) vs `pre_silent_status_id` (Dart `FlutterSharedPreferences`) — sufijos distintos para el mismo concepto | **Medio** — inconsistencia de naming cross-boundary | Sem 3 |
+| 4 | `pending_status.statusType` escrito por 4 archivos Kotlin distintos sin dueño único | **Medio** — sin coordinación, riesgo de escrituras concurrentes | Sem 3 |
+
+---
+
+## Cobertura en StorageKeys
+
+Las 12 claves del namespace `FlutterSharedPreferences` están cubiertas en
+`lib/platform/persistence/storage_keys.dart`. Los namespaces Kotlin-only
+(`zync_silent_mode`, `pending_status`, `worker_state`) se documentan aquí
+pero no tienen representación Dart — se centralizan en Sem 3 junto con el
+Native Bridge unificado.

--- a/lib/app/di/modules/platform_module.dart
+++ b/lib/app/di/modules/platform_module.dart
@@ -1,7 +1,9 @@
 import 'package:get_it/get_it.dart';
+import 'package:nunakin_app/platform/persistence/kv_store.dart';
+import 'package:nunakin_app/platform/persistence/shared_prefs_kv_store.dart';
 
-/// Placeholder — se puebla en Día 4 (KvStore) y Sem 2 (DomainEventBus).
+/// Platform infrastructure: persistencia local y (Sem 2) DomainEventBus.
 Future<void> registerPlatformModule(GetIt sl) async {
-  // TODO Día 4: KvStore (SharedPrefsKvStore)
+  sl.registerLazySingleton<KvStore>(() => SharedPrefsKvStore(sl()));
   // TODO Sem 2: DomainEventBus
 }

--- a/lib/platform/persistence/kv_store.dart
+++ b/lib/platform/persistence/kv_store.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+
+abstract class KvStore {
+  Future<String?> getString(String key);
+  Future<void> setString(String key, String value);
+  Future<bool?> getBool(String key);
+  Future<void> setBool(String key, bool value);
+  Future<int?> getInt(String key);
+  Future<void> setInt(String key, int value);
+  Future<void> remove(String key);
+  Future<bool> containsKey(String key);
+}

--- a/lib/platform/persistence/shared_prefs_kv_store.dart
+++ b/lib/platform/persistence/shared_prefs_kv_store.dart
@@ -1,0 +1,40 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'kv_store.dart';
+
+class SharedPrefsKvStore implements KvStore {
+  final SharedPreferences _prefs;
+
+  const SharedPrefsKvStore(this._prefs);
+
+  @override
+  Future<String?> getString(String key) async => _prefs.getString(key);
+
+  @override
+  Future<void> setString(String key, String value) async {
+    await _prefs.setString(key, value);
+  }
+
+  @override
+  Future<bool?> getBool(String key) async => _prefs.getBool(key);
+
+  @override
+  Future<void> setBool(String key, bool value) async {
+    await _prefs.setBool(key, value);
+  }
+
+  @override
+  Future<int?> getInt(String key) async => _prefs.getInt(key);
+
+  @override
+  Future<void> setInt(String key, int value) async {
+    await _prefs.setInt(key, value);
+  }
+
+  @override
+  Future<void> remove(String key) async {
+    await _prefs.remove(key);
+  }
+
+  @override
+  Future<bool> containsKey(String key) async => _prefs.containsKey(key);
+}

--- a/lib/platform/persistence/storage_keys.dart
+++ b/lib/platform/persistence/storage_keys.dart
@@ -1,0 +1,62 @@
+/// Single source of truth para claves de SharedPreferences en Dart.
+///
+/// Organización por dominio. Las claves marcadas [CROSS-BOUNDARY] son
+/// leídas/escritas también desde Kotlin — ver NativeSharedKeys (Día 5).
+abstract final class StorageKeys {
+  // ── Presence (CROSS-BOUNDARY) ──────────────────────────────────────────
+  /// Estado de presencia activo. Escrito por StatusService y StatusUpdateWorker.
+  /// Leído por EmojiDialogActivity vía "flutter.current_status_id". [CROSS-BOUNDARY]
+  static const currentStatusId = 'current_status_id';
+
+  /// Último estado seleccionado manualmente. Escrito por StatusService.
+  /// Leído por SilentCoordinator e InCircleView. [CROSS-BOUNDARY]
+  static const manualStatusId = 'manual_status_id';
+
+  /// Estado guardado antes de entrar a Silent Mode. Escrito por SilentCoordinator.
+  /// Leído por InCircleView; eliminado por MainActivity al desactivar. [CROSS-BOUNDARY]
+  static const preSilentStatusId = 'pre_silent_status_id';
+
+  /// Flag de Silent Mode activo. Escrito por SilentCoordinator.
+  /// Leído por InCircleView; eliminado por MainActivity al desactivar. [CROSS-BOUNDARY]
+  /// NOTA: coexiste con "zync_silent_mode".is_silent_mode_active en Kotlin — raíz histórica de bugs.
+  static const isSilentModeActive = 'is_silent_mode_active';
+
+  /// Flag para suprimir el siguiente check de geofence. Escrito por StatusUpdateWorker (Kotlin).
+  /// Leído por main.dart en cold start. [CROSS-BOUNDARY]
+  static const suppressNextGeofenceCheck = 'suppress_next_geofence_check';
+
+  // ── Native cache (CROSS-BOUNDARY) ──────────────────────────────────────
+  /// JSON de emojis predefinidos. Escrito por EmojiCacheService.
+  /// Leído por EmojiDialogActivity vía "flutter.predefined_emojis". [CROSS-BOUNDARY]
+  static const predefinedEmojis = 'predefined_emojis';
+
+  /// JSON de tipos de zona configurados. Escrito por EmojiCacheService.
+  /// Leído por EmojiDialogActivity vía "flutter.configured_zone_types". [CROSS-BOUNDARY]
+  static const configuredZoneTypes = 'configured_zone_types';
+
+  // ── Session cache (Flutter-only) ────────────────────────────────────────
+  static const sessionUserId   = 'zync_cached_user_id';
+  static const sessionEmail    = 'zync_cached_user_email';
+  static const sessionCircleId = 'zync_cached_circle_id';
+  static const sessionLastSave = 'zync_cached_last_save';
+
+  // ── Identity (Flutter-only) ─────────────────────────────────────────────
+  /// JSON del usuario autenticado (Clean arch local datasource).
+  static const cachedUser = 'CACHED_USER';
+
+  // ── Quick Actions (Flutter-only) ────────────────────────────────────────
+  static const quickActionsPreferences = 'quick_actions_preferences';
+
+  // ── Badge (Flutter-only) ────────────────────────────────────────────────
+  static const appBadgeLastSeen = 'app_badge_last_seen';
+
+  // ── Persistent cache (Flutter-only, dynamic keys) ───────────────────────
+  static const cacheNicknames  = 'cache_nicknames';
+  static const cacheMemberData = 'cache_member_data';
+  /// Clave dinámica — patrón: `cache_circle_<circleId>`
+  static String cacheCircle(String circleId) => 'cache_circle_$circleId';
+  /// Clave dinámica — patrón: `last_update_<key>`
+  static String lastUpdate(String key) => 'last_update_$key';
+
+  StorageKeys._();
+}

--- a/test/platform/persistence/shared_prefs_kv_store_test.dart
+++ b/test/platform/persistence/shared_prefs_kv_store_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nunakin_app/platform/persistence/shared_prefs_kv_store.dart';
+
+void main() {
+  late SharedPrefsKvStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    store = SharedPrefsKvStore(prefs);
+  });
+
+  group('getString / setString', () {
+    test('retorna null si la clave no existe', () async {
+      expect(await store.getString('missing'), isNull);
+    });
+
+    test('persiste y recupera el valor', () async {
+      await store.setString('key', 'value');
+      expect(await store.getString('key'), 'value');
+    });
+  });
+
+  group('getBool / setBool', () {
+    test('retorna null si la clave no existe', () async {
+      expect(await store.getBool('missing'), isNull);
+    });
+
+    test('persiste true', () async {
+      await store.setBool('flag', true);
+      expect(await store.getBool('flag'), isTrue);
+    });
+
+    test('persiste false', () async {
+      await store.setBool('flag', false);
+      expect(await store.getBool('flag'), isFalse);
+    });
+  });
+
+  group('getInt / setInt', () {
+    test('retorna null si la clave no existe', () async {
+      expect(await store.getInt('missing'), isNull);
+    });
+
+    test('persiste el valor entero', () async {
+      await store.setInt('count', 42);
+      expect(await store.getInt('count'), 42);
+    });
+  });
+
+  group('remove', () {
+    test('elimina la clave existente', () async {
+      await store.setString('to_remove', 'x');
+      await store.remove('to_remove');
+      expect(await store.getString('to_remove'), isNull);
+    });
+
+    test('no lanza si la clave no existe', () async {
+      expect(() => store.remove('ghost'), returnsNormally);
+    });
+  });
+
+  group('containsKey', () {
+    test('retorna false si la clave no existe', () async {
+      expect(await store.containsKey('missing'), isFalse);
+    });
+
+    test('retorna true después de setString', () async {
+      await store.setString('exists', 'y');
+      expect(await store.containsKey('exists'), isTrue);
+    });
+
+    test('retorna false después de remove', () async {
+      await store.setString('temp', 'z');
+      await store.remove('temp');
+      expect(await store.containsKey('temp'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- KvStore interface + SharedPrefsKvStore impl en lib/platform/persistence/
- StorageKeys: fuente unica de verdad para todas las claves SharedPreferences (12 Flutter + 2 dinamicas)
- platform_module.dart: KvStore registrado como LazySingleton en GetIt
- storage-keys-audit.md: inventario completo con 4 anomalias documentadas
- 11 tests unitarios para SharedPrefsKvStore - flutter test: 42/42
- flutter analyze: 394 issues (mismo baseline Dia 3, cero warnings nuevos)

## Archivos

| Accion | Archivo |
|--------|---------|
| Crear | lib/platform/persistence/kv_store.dart |
| Crear | lib/platform/persistence/shared_prefs_kv_store.dart |
| Crear | lib/platform/persistence/storage_keys.dart |
| Crear | docs/dev/refactor-arch-2026-q2/storage-keys-audit.md |
| Modificar | lib/app/di/modules/platform_module.dart |
| Crear | test/platform/persistence/shared_prefs_kv_store_test.dart |

## Referencia

Sem 1 Dia 4 - docs/dev/refactor-arch-2026-q2/01-semana-1-cimientos.md

Generated with Claude Code