### PR TITLE
fix(circle): use set+merge instead of update when writing circleId to user doc

### DIFF
--- a/lib/services/circle_service.dart
+++ b/lib/services/circle_service.dart
@@ -129,7 +129,11 @@ class CircleService {
     // Usar batch para operación atómica
     final batch = _firestore.batch();
     batch.set(circleRef, circleData);
-    batch.update(_firestore.collection('users').doc(user.uid), {'circleId': circleRef.id});
+    batch.set(
+      _firestore.collection('users').doc(user.uid),
+      {'circleId': circleRef.id},
+      SetOptions(merge: true),
+    );
 
     await batch.commit();
     log('[CircleService] ✅ Círculo creado exitosamente: ${circleRef.id}');


### PR DESCRIPTION
## Summary
- `batch.update()` en `users/{uid}` lanza `cloud_firestore/not-found` cuando el documento del usuario no existe
- Reemplazado con `batch.set(..., SetOptions(merge: true))` — crea el doc si no existe, parchea `circleId` si ya existe
- Archivo afectado: `lib/services/circle_service.dart:132`

## Test plan
- [ ] Crear círculo con usuario sin documento en `users/{uid}` → debe crear círculo sin error
- [ ] Crear círculo con usuario que sí tiene documento (sin circleId) → debe actualizar `circleId` correctamente
- [ ] Verificar que los demás campos del documento existente no son sobreescritos (merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)