### PR TITLE
fix(circle): use Firestore stream status as testigo instead of manual_status_id

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -786,7 +786,10 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                                           if (isSilentActive) {
                                             activeStatusId = prefs.getString('pre_silent_status_id');
                                           } else {
-                                            activeStatusId = prefs.getString('manual_status_id');
+                                            // Usar status del stream de Firestore — siempre
+                                            // actualizado, evita stale de manual_status_id
+                                            // tras actualización desde modal SM.
+                                            activeStatusId = status == 'loading' ? null : status;
                                           }
                                         } catch (_) {}
                                         if (context.mounted) {


### PR DESCRIPTION
## Summary
- El testigo (emoji activo en el modal del círculo) mostraba el estado pre-Silent Mode en lugar del emoji elegido desde el modal SM
- Causa: `manual_status_id` en SharedPrefs es stale — `_updateStatusFromNative()` es async y puede no haber terminado cuando el usuario abre el modal
- Fix: usar `status` del stream de Firestore (`memberData['status']`), que siempre refleja el estado actual
- La rama Silent Mode (`pre_silent_status_id`) queda sin cambios
- Archivo afectado: `lib/features/circle/presentation/widgets/in_circle_view.dart:789`

## Test plan
- [ ] Activar Silent Mode con estado "En clase"
- [ ] Desde notificación SM, cambiar a otro emoji (ej. "university")
- [ ] Abrir la app → abre modal del círculo → testigo debe mostrar "university" ✅
- [ ] Sin Silent Mode: seleccionar emoji → abrir modal → testigo debe mostrar ese emoji ✅
- [ ] En Silent Mode activo: abrir modal → testigo debe mostrar `pre_silent_status_id` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)