### PR TITLE
fix(status): add Firestore timeouts to prevent UI freeze after background

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
 import 'app_badge_service.dart';
 import 'gps_service.dart';
+import 'session_cache_service.dart';
 import 'dart:async';
 import 'dart:developer';
 
@@ -119,11 +120,17 @@ class StatusService {
         throw Exception('Usuario no autenticado');
       }
 
-      // Obtener el circleId del usuario
-      final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
-
-      final circleId = userDoc.data()?['circleId'] as String?;
+      // Obtener circleId — preferir SessionCache (memoria, 0ms) para evitar GET
+      // a Firestore en estado frío después de horas en background.
+      final cachedId = SessionCacheService.restoreSessionSync()?['circleId'];
+      String? circleId = (cachedId != null && cachedId.isNotEmpty) ? cachedId : null;
       if (circleId == null) {
+        final userDoc = await FirebaseFirestore.instance
+            .collection('users').doc(user.uid).get()
+            .timeout(const Duration(seconds: 8));
+        circleId = userDoc.data()?['circleId'] as String?;
+      }
+      if (circleId == null || circleId.isEmpty) {
         throw Exception('Usuario no está en ningún círculo');
       }
 
@@ -135,10 +142,17 @@ class StatusService {
         }
       }
 
-      // Leer el estado actual del usuario para verificar si estaba en una zona
-      final circleDoc = await FirebaseFirestore.instance.collection('circles').doc(circleId).get();
-
-      final currentMemberStatus = circleDoc.data()?['memberStatus'] as Map<String, dynamic>?;
+      // Leer el estado actual del usuario para verificar si estaba en una zona.
+      // Timeout de 8s: si la conexión está fría, usar fallback null (wasInZone=false).
+      Map<String, dynamic>? currentMemberStatus;
+      try {
+        final circleDoc = await FirebaseFirestore.instance
+            .collection('circles').doc(circleId).get()
+            .timeout(const Duration(seconds: 8));
+        currentMemberStatus = circleDoc.data()?['memberStatus'] as Map<String, dynamic>?;
+      } on TimeoutException {
+        log('[StatusService] ⚠️ circleDoc.get() timeout — usando fallback wasInZone=false');
+      }
       final currentUserStatus = currentMemberStatus?[user.uid] as Map<String, dynamic>?;
 
       // Verificar si el usuario estaba en una zona (solo si tiene zoneId)
@@ -228,7 +242,16 @@ class StatusService {
 
       batch.set(historyRef, historyData);
 
-      await batch.commit();
+      // ════════════════════════════════════════════════════════════
+      // [FIX] Timeout en batch.commit() — conexión Firestore fría
+      // PROBLEMA: Después de horas en background (Android Doze mode), el
+      //   WebSocket de Firestore se cierra. batch.commit() con
+      //   FieldValue.serverTimestamp() espera confirmación del servidor
+      //   indefinidamente → modal no cierra, botones quedan bloqueados.
+      // SOLUCIÓN: Timeout de 10s. TimeoutException capturada abajo →
+      //   StatusUpdateResult.error() → callers cierran el modal.
+      // ════════════════════════════════════════════════════════════
+      await batch.commit().timeout(const Duration(seconds: 10));
       log('[StatusService] ✅ Estado actualizado exitosamente${coordinates != null ? ' con GPS' : ''}');
 
       // ════════════════════════════════════════════════════════════

--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -83,7 +83,9 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
       final user = FirebaseAuth.instance.currentUser;
       if (user == null) throw Exception('Usuario no autenticado');
 
-      final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+      final userDoc = await FirebaseFirestore.instance
+          .collection('users').doc(user.uid).get()
+          .timeout(const Duration(seconds: 8));
 
       final circleId = userDoc.data()?['circleId'] as String?;
       if (circleId == null) throw Exception('Usuario sin círculo');
@@ -101,7 +103,8 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay> with Sing
 
       // Verificar zonas predefinidas configuradas para dimming de botones
       final zonesSnapshot =
-          await FirebaseFirestore.instance.collection('circles').doc(circleId).collection('zones').get();
+          await FirebaseFirestore.instance.collection('circles').doc(circleId).collection('zones').get()
+          .timeout(const Duration(seconds: 8));
 
       final predefinedZones = zonesSnapshot.docs.where((doc) {
         final type = doc.data()['type'] as String?;


### PR DESCRIPTION
## Problema

Después de varias horas en Silent Mode, Android Doze mode cierra la conexión WebSocket de Firestore. Al abrir la app y seleccionar un estado:

- `batch.commit()` con `FieldValue.serverTimestamp()` espera confirmación del servidor **indefinidamente**
- `_isUpdatingStatus` queda en `true` → botones "Modo Silencio" y "Todo Bien" deshabilitados
- El modal de selección nunca llama `Navigator.pop()` → queda abierto
- El mismo comportamiento se repite al cerrar y reabrir (la conexión fría persiste hasta que el OS mata el proceso)

## Cambios

### `lib/core/services/status_service.dart`
- `circleId`: lee primero de `SessionCacheService` (memoria, 0ms); solo hace `get()` con timeout 8s si no hay cache
- `circleDoc.get()`: timeout 8s + fallback `null` (equivale a `wasInZone=false`, comportamiento seguro)
- `batch.commit()`: timeout 10s → `TimeoutException` capturada por `catch(e)` existente → retorna `StatusUpdateResult.error()` → callers cierran el modal y desbloquean botones

### `lib/widgets/status_selector_overlay.dart`
- `userDoc.get()`: timeout 8s en `_loadStatusGrid()`
- `zones.get()`: timeout 8s en `_loadStatusGrid()`
- El `catch(e)` existente ya tiene fallback a `StatusType.fallbackPredefined` → overlay abre con emojis en lugar de spinner infinito

## Test plan

- [ ] `flutter test` 43/43 ✅
- [ ] Verificar en dispositivo: seleccionar emoji desde modal del círculo → modal cierra normalmente
- [ ] Verificar escenario de regresión: dejar app en Silent Mode ≥1h → abrir → seleccionar emoji → modal cierra en ≤10s (con o sin error de red)
- [ ] Verificar botones "Modo Silencio" y "Todo Bien" se habilitan después de timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)