### PR TITLE
refactor(platform): shared Dart/Kotlin keys + StatusIds constants

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -112,7 +112,7 @@ class EmojiDialogActivity : Activity() {
 
         // [FIX] Leer estado activo desde SharedPreferences (escrito por StatusService en Flutter)
         val flutterPrefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
-        activeStatusId = flutterPrefs.getString("flutter.current_status_id", null)
+        activeStatusId = flutterPrefs.getString(SharedKeys.flutter(SharedKeys.CURRENT_STATUS_ID), null)
         Log.d(TAG, "[ACTIVE-STATUS] activeStatusId=$activeStatusId")
 
         val ws = getSharedPreferences("worker_state", Context.MODE_PRIVATE)

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -111,7 +111,7 @@ class MainActivity: FlutterActivity() {
 
         // G2.C1: Restaurar isSilentModeActive desde SharedPrefs (sobrevive al swipe/kill del proceso)
         val silentPrefs = getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
-        isSilentModeActive = silentPrefs.getBoolean("is_silent_mode_active", false)
+        isSilentModeActive = silentPrefs.getBoolean(SharedKeys.IS_SILENT_MODE_ACTIVE, false)
         Log.d(TAG, "🌙 [SILENT] onCreate — isSilentModeActive restaurado: $isSilentModeActive")
 
         // ========================================================================
@@ -137,7 +137,7 @@ class MainActivity: FlutterActivity() {
             // Limpiar flags de Modo Silencio. pre_silent_status_type removido —
             // mecanismo obsoleto desde PR #117 (Silent ya no escribe do_not_disturb).
             silentPrefs.edit()
-                .putBoolean("is_silent_mode_active", false)
+                .putBoolean(SharedKeys.IS_SILENT_MODE_ACTIVE, false)
                 .remove("pre_silent_status_type")
                 .apply()
 
@@ -145,8 +145,8 @@ class MainActivity: FlutterActivity() {
             // para que in_circle_view.dart no lea is_silent_mode_active=true al reabrir.
             applicationContext.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
                 .edit()
-                .remove("flutter.is_silent_mode_active")
-                .remove("flutter.pre_silent_status_id")
+                .remove(SharedKeys.flutter(SharedKeys.IS_SILENT_MODE_ACTIVE))
+                .remove(SharedKeys.flutter(SharedKeys.PRE_SILENT_STATUS_ID))
                 .apply()
 
             Log.d(TAG, "✅ [SILENT] onCreate — ícono 'i' eliminado, isSilentModeActive=false")
@@ -531,7 +531,7 @@ class MainActivity: FlutterActivity() {
 
                     getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
                         .edit()
-                        .putBoolean("is_silent_mode_active", true)
+                        .putBoolean(SharedKeys.IS_SILENT_MODE_ACTIVE, true)
                         .apply()
 
                     Log.d(TAG, "🌙 [SILENT] isSilentModeActive=true — cerrando app (Regla 2)")
@@ -545,12 +545,12 @@ class MainActivity: FlutterActivity() {
                     isSilentModeActive = false
                     // G2.C1: Limpiar flag persistido en Kotlin SharedPreferences
                     getSharedPreferences("zync_silent_mode", Context.MODE_PRIVATE)
-                        .edit().putBoolean("is_silent_mode_active", false).apply()
+                        .edit().putBoolean(SharedKeys.IS_SILENT_MODE_ACTIVE, false).apply()
                     // [FIX-003] Limpiar también los flags escritos por Flutter SharedPreferences
                     applicationContext.getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
                         .edit()
-                        .remove("flutter.is_silent_mode_active")
-                        .remove("flutter.pre_silent_status_id")
+                        .remove(SharedKeys.flutter(SharedKeys.IS_SILENT_MODE_ACTIVE))
+                        .remove(SharedKeys.flutter(SharedKeys.PRE_SILENT_STATUS_ID))
                         .apply()
                     result.success(true)
                 }

--- a/android/app/src/main/kotlin/com/datainfers/zync/SharedKeys.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/SharedKeys.kt
@@ -1,0 +1,30 @@
+package com.datainfers.zync
+
+/**
+ * Claves de SharedPreferences que cruzan la frontera Dart↔Kotlin.
+ *
+ * IMPORTANTE: cualquier cambio aquí debe reflejarse en
+ * lib/platform/persistence/native_keys.dart
+ *
+ * Las claves escritas desde Flutter se almacenan con prefijo "flutter."
+ * (comportamiento del plugin). Usar [flutter] para construir la clave
+ * con prefijo al leer desde Kotlin.
+ */
+object SharedKeys {
+    private const val FLUTTER_PREFIX = "flutter."
+
+    // Presence
+    const val CURRENT_STATUS_ID = "current_status_id"
+    const val MANUAL_STATUS_ID = "manual_status_id"
+    const val PRE_SILENT_STATUS_ID = "pre_silent_status_id"
+    const val IS_SILENT_MODE_ACTIVE = "is_silent_mode_active"
+
+    // Geofence
+    const val SUPPRESS_NEXT_GEOFENCE_CHECK = "suppress_next_geofence_check"
+
+    // Native cache
+    const val PREDEFINED_EMOJIS = "predefined_emojis"
+    const val CONFIGURED_ZONE_TYPES = "configured_zone_types"
+
+    fun flutter(key: String): String = "$FLUTTER_PREFIX$key"
+}

--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusIds.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusIds.kt
@@ -1,0 +1,20 @@
+package com.datainfers.zync
+
+/**
+ * IDs canónicos de estado de presencia.
+ *
+ * IMPORTANTE: cualquier cambio aquí debe reflejarse en
+ * lib/contexts/presence/domain/value_objects/status_id.dart
+ *
+ * Los IDs deben coincidir exactamente con los valores en Firestore.
+ */
+object StatusIds {
+    const val FINE             = "fine"
+    const val HOME             = "home"
+    const val SCHOOL           = "school"
+    const val WORK             = "work"
+    const val UNIVERSITY       = "university"
+    const val SOS              = "sos"
+    const val DO_NOT_DISTURB   = "do_not_disturb"
+    const val PUBLIC_TRANSPORT = "public_transport"
+}

--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -145,8 +145,8 @@ class StatusUpdateWorker(
             applicationContext
                 .getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
                 .edit()
-                .putBoolean("flutter.suppress_next_geofence_check", true)
-                .putString("flutter.current_status_id", statusType)
+                .putBoolean(SharedKeys.flutter(SharedKeys.SUPPRESS_NEXT_GEOFENCE_CHECK), true)
+                .putString(SharedKeys.flutter(SharedKeys.CURRENT_STATUS_ID), statusType)
                 .apply()
 
             // Limpiar pending_status para que Flutter no lo reprocese al reabrir la app

--- a/lib/contexts/presence/domain/value_objects/status_id.dart
+++ b/lib/contexts/presence/domain/value_objects/status_id.dart
@@ -1,0 +1,22 @@
+/// IDs canónicos de estado de presencia.
+///
+/// Fuente única de verdad para Dart. Mirror en StatusIds.kt.
+/// Los IDs deben coincidir exactamente con los valores en Firestore.
+abstract final class StatusIds {
+  static const fine            = 'fine';
+  static const home            = 'home';
+  static const school          = 'school';
+  static const work            = 'work';
+  static const university      = 'university';
+  static const sos             = 'sos';
+  static const doNotDisturb    = 'do_not_disturb';
+  static const publicTransport = 'public_transport';
+
+  /// Estados que no pueden seleccionarse manualmente cuando hay
+  /// una zona de ese tipo configurada en el círculo.
+  static const Set<String> blockedManualSelectionIfZoneConfigured = {
+    home, school, work, university,
+  };
+
+  StatusIds._();
+}

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nunakin_app/platform/persistence/native_keys.dart';
 import '../../notifications/notification_service.dart';
 import '../../quick_actions/quick_actions_service.dart';
 import '../../services/circle_service.dart';
@@ -136,12 +137,12 @@ class SilentFunctionalityCoordinator {
     // ════════════════════════════════════════════════════════════
     try {
       final prefs = await SharedPreferences.getInstance();
-      final manualId = prefs.getString('manual_status_id');
+      final manualId = prefs.getString(NativeSharedKeys.manualStatusId);
       if (manualId != null) {
-        await prefs.setString('pre_silent_status_id', manualId);
+        await prefs.setString(NativeSharedKeys.preSilentStatusId, manualId);
         debugPrint('[SilentCoordinator] 💾 pre_silent_status_id guardado: $manualId');
       }
-      await prefs.setBool('is_silent_mode_active', true);
+      await prefs.setBool(NativeSharedKeys.isSilentModeActive, true);
       debugPrint('[SilentCoordinator] 💾 is_silent_mode_active=true guardado en Flutter SharedPreferences');
     } catch (e) {
       debugPrint('[SilentCoordinator] ⚠️ Error guardando pre_silent_status_id: $e');

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -2,6 +2,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/platform/persistence/native_keys.dart';
 import 'app_badge_service.dart';
 import 'gps_service.dart';
 import 'session_cache_service.dart';
@@ -16,10 +18,10 @@ class StatusService {
 
   static const String _zoneManualSelectionNotAllowedError = 'zone_manual_selection_not_allowed';
   static const Set<String> _blockedZoneStatusIds = {
-    'home',
-    'school',
-    'work',
-    'university',
+    StatusIds.home,
+    StatusIds.school,
+    StatusIds.work,
+    StatusIds.university,
   };
 
   /// Inicializar el listener de cambios de estado para badge
@@ -168,13 +170,13 @@ class StatusService {
       // Si salió de la zona, NO marcar locationUnknown para estados "fine" (Todo bien)
       final manualOverride = (wasInZone && (previousWasAutoUpdated || previousManualOverride));
       final locationUnknown =
-          (previousWasAutoUpdated || previousManualOverride) && !wasInZone && newStatus.id != 'fine';
+          (previousWasAutoUpdated || previousManualOverride) && !wasInZone && newStatus.id != StatusIds.fine;
 
       log('[StatusService] 📍 Usuario estaba en zona: $wasInZone${wasInZone ? ' ($previousZoneName)' : ''}');
 
       // Point 16: Obtener ubicación GPS si es estado SOS
       Coordinates? coordinates;
-      if (newStatus.id == 'sos') {
+      if (newStatus.id == StatusIds.sos) {
         log('[StatusService] 🆘 Estado SOS detectado - obteniendo ubicación GPS...');
         coordinates = await GPSService.getCurrentLocation();
         if (coordinates != null) {
@@ -263,7 +265,7 @@ class StatusService {
       // ════════════════════════════════════════════════════════════
       try {
         final prefs = await SharedPreferences.getInstance();
-        await prefs.setString('current_status_id', newStatus.id);
+        await prefs.setString(NativeSharedKeys.currentStatusId, newStatus.id);
         log('[StatusService] 💾 current_status_id guardado: ${newStatus.id}');
         // ════════════════════════════════════════════════════════════
         // [FIX] Persistir manual_status_id desacoplado del BN Worker
@@ -274,7 +276,7 @@ class StatusService {
         // SOLUCIÓN: Escribir también manual_status_id (solo este método lo escribe).
         //           in_circle_view leerá manual_status_id para el indicador del modal.
         // ════════════════════════════════════════════════════════════
-        await prefs.setString('manual_status_id', newStatus.id);
+        await prefs.setString(NativeSharedKeys.manualStatusId, newStatus.id);
         log('[StatusService] 💾 manual_status_id guardado: ${newStatus.id}');
       } catch (e) {
         log('[StatusService] ⚠️ Error guardando current_status_id: $e');

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nunakin_app/platform/persistence/native_keys.dart';
 import 'package:url_launcher/url_launcher.dart';
 // Asegúrate que las rutas de importación sean correctas para tu proyecto
 import '../../../../services/circle_service.dart';
@@ -784,7 +785,7 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                                           final silentPrefs = await SharedPreferences.getInstance();
                                           final isSilentActive = silentPrefs.getBool('is_silent_mode_active') ?? false;
                                           if (isSilentActive) {
-                                            activeStatusId = prefs.getString('pre_silent_status_id');
+                                            activeStatusId = prefs.getString(NativeSharedKeys.preSilentStatusId);
                                           } else {
                                             // Usar status del stream de Firestore — siempre
                                             // actualizado, evita stale de manual_status_id

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:nunakin_app/core/utils/performance_tracker.dart'; // PERFORMANCE
 import 'package:nunakin_app/core/services/session_cache_service.dart'; // FASE 2B: Session Cache (fallback)
 import 'package:nunakin_app/core/services/native_state_bridge.dart'; // FASE 3: Native State (primario) (fallback)
 import 'package:nunakin_app/core/services/silent_functionality_coordinator.dart'; // Point 2: Silent Functionality
+import 'package:nunakin_app/platform/persistence/native_keys.dart';
 import 'package:nunakin_app/core/services/status_service.dart'; // Para actualizar estado desde native
 import 'package:nunakin_app/core/services/emoji_service.dart'; // Para cargar emojis desde Firebase
 import 'package:nunakin_app/core/services/emoji_cache_service.dart'; // Para sincronizar emojis a cache nativo
@@ -59,9 +60,9 @@ void main() async {
   //   limpiamos el flag.
   // ════════════════════════════════════════════════════════════
   final flutterPrefs = await SharedPreferences.getInstance();
-  if (flutterPrefs.getBool('suppress_next_geofence_check') ?? false) {
+  if (flutterPrefs.getBool(NativeSharedKeys.suppressNextGeofenceCheck) ?? false) {
     GeofencingService.suppressNextCheckOnReopen();
-    await flutterPrefs.remove('suppress_next_geofence_check');
+    await flutterPrefs.remove(NativeSharedKeys.suppressNextGeofenceCheck);
     print('🛡️ [main] Flag suppress_next_geofence_check leído — initial check será omitido');
   }
 

--- a/lib/platform/persistence/native_keys.dart
+++ b/lib/platform/persistence/native_keys.dart
@@ -1,0 +1,49 @@
+/// Claves de SharedPreferences que cruzan la frontera Dart↔Kotlin.
+///
+/// IMPORTANTE: cualquier cambio aquí debe reflejarse en
+/// android/app/src/main/kotlin/com/datainfers/zync/SharedKeys.kt
+///
+/// Las claves escritas desde Flutter se almacenan en disco con prefijo
+/// "flutter." (comportamiento del plugin). Usar [flutter] para construir
+/// la clave con prefijo cuando Kotlin las lee directamente.
+abstract final class NativeSharedKeys {
+  static const flutterPrefix = 'flutter.';
+
+  // ── Presence ──────────────────────────────────────────────────────────────
+  /// Estado de presencia activo. Escrito por: StatusService (Dart) y
+  /// StatusUpdateWorker.kt (Kotlin). Leído por: EmojiDialogActivity.kt.
+  static const currentStatusId = 'current_status_id';
+
+  /// Último estado seleccionado manualmente. Solo escrito por StatusService.
+  /// Leído por: SilentCoordinator, InCircleView.
+  static const manualStatusId = 'manual_status_id';
+
+  /// Snapshot del estado antes de entrar a Silent Mode.
+  /// Escrito por: SilentCoordinator. Leído por: InCircleView.
+  /// Eliminado por: MainActivity al desactivar Silent Mode.
+  static const preSilentStatusId = 'pre_silent_status_id';
+
+  /// Flag de Silent Mode activo (namespace Flutter).
+  /// Escrito por: SilentCoordinator. Leído/eliminado por: MainActivity.
+  /// NOTA: coexiste con zync_silent_mode.is_silent_mode_active en Kotlin — Sem 3.
+  static const isSilentModeActive = 'is_silent_mode_active';
+
+  // ── Geofence ───────────────────────────────────────────────────────────────
+  /// Flag para suprimir el siguiente check de geofence en cold start.
+  /// Escrito por: StatusUpdateWorker.kt. Leído/eliminado por: main.dart.
+  static const suppressNextGeofenceCheck = 'suppress_next_geofence_check';
+
+  // ── Native cache (Flutter → Kotlin) ───────────────────────────────────────
+  /// JSON de emojis predefinidos. Escrito por EmojiCacheService.
+  /// Leído por EmojiDialogActivity.
+  static const predefinedEmojis = 'predefined_emojis';
+
+  /// JSON de tipos de zona configurados. Escrito por EmojiCacheService.
+  /// Leído por EmojiDialogActivity.
+  static const configuredZoneTypes = 'configured_zone_types';
+
+  /// Retorna la clave con prefijo Flutter (como la almacena el plugin en disco).
+  static String flutter(String key) => '$flutterPrefix$key';
+
+  NativeSharedKeys._();
+}


### PR DESCRIPTION
## Summary
- **NativeSharedKeys** (Dart) + **SharedKeys.kt** (Kotlin): fuente única de verdad para claves de SharedPreferences que cruzan la frontera Dart↔Kotlin
- **StatusIds** (Dart) + **StatusIds.kt** (Kotlin): IDs canónicos de presencia, reemplazando literales en status_service, main, InCircleView, EmojiDialogActivity, MainActivity, StatusUpdateWorker
- 0 literales sueltos de presencia/geofence en rutas críticas (excepción documentada: silentPrefs.getBool en in_circle_view:786 — namespace Kotlin, Sem 3)

## Test plan
- [x] flutter test 43/43
- [x] flutter analyze 394 issues (baseline, 0 nuevos)
- [ ] Smoke test dispositivo físico post-merge

🤖 Generated with Claude Code