### PR TITLE
refactor(presence): PresenceState sealed class + DomainEventBus

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-1.md
+++ b/docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-1.md
@@ -1,0 +1,253 @@
+# Sem 2 - Día 1 — `PresenceState` sealed + `DomainEventBus`
+
+**Rama:** `refactor/sem2-presence-state`
+
+**PR:** `refactor(presence): PresenceState sealed class + DomainEventBus`
+
+**Fecha planificada:** 2026-05-18 (lunes)
+
+**Base:** tag `refactor-sem1-done` → commit `3a9d34a`
+
+---
+
+## Contexto
+
+Primer día de Sem 2 (Presence Context). Toda la semana es aditiva: el código nuevo **no se cablea a la UI**. `StatusService` y `SilentFunctionalityCoordinator` continúan como ruta de producción. `main` siempre verde.
+
+---
+
+## Tarea 1 — `lib/contexts/presence/domain/presence_state.dart`
+
+Modelo canónico sealed que reemplaza los 5 flags dispersos en SharedPrefs:
+`current_status_id`, `manual_status_id`, `pre_silent_status_id`, `is_silent_mode_active`, `suppress_next_geofence_check`.
+
+```dart
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+
+/// Estado canónico de presencia del usuario.
+///
+/// Un único valor de este tipo reemplaza las 5 claves de SharedPreferences que
+/// hoy dispersan el estado: current_status_id, manual_status_id,
+/// pre_silent_status_id, is_silent_mode_active, suppress_next_geofence_check.
+sealed class PresenceState {
+  const PresenceState();
+
+  /// ID del estado visible a los miembros del círculo en este momento.
+  String get visibleStatusId;
+
+  bool get isSilent => this is SilentMode;
+  bool get isSOS    => this is SOSActive;
+}
+
+/// Estado normal: el usuario está disponible e interactuando.
+/// [currentId]     — estado que se muestra al círculo (puede ser auto-actualizado
+///                   por geofencing o por selección manual).
+/// [lastManualId]  — último estado elegido por el usuario. Necesario para
+///                   restaurarlo al salir del Modo Silencio y para el testigo
+///                   del modal de selección. Null si el usuario nunca eligió uno.
+final class Normal extends PresenceState {
+  final String  currentId;
+  final String? lastManualId;
+  const Normal({required this.currentId, this.lastManualId});
+
+  @override
+  String get visibleStatusId => currentId;
+
+  Normal copyWith({String? currentId, String? lastManualId}) => Normal(
+        currentId:    currentId    ?? this.currentId,
+        lastManualId: lastManualId ?? this.lastManualId,
+      );
+}
+
+/// El usuario activó Modo Silencio. La app está en background.
+/// [preSilentId] — estado que tenía justo antes de activar Silent Mode.
+///                 El círculo ve este estado mientras dura el silencio.
+/// [enteredAt]   — timestamp para detectar silencio prolongado (> N horas)
+///                 en futuros checks automáticos.
+final class SilentMode extends PresenceState {
+  final String   preSilentId;
+  final DateTime enteredAt;
+  const SilentMode({required this.preSilentId, required this.enteredAt});
+
+  @override
+  String get visibleStatusId => preSilentId;
+}
+
+/// Una notificación desde la barra de estado activó un nuevo estado.
+/// [notifStatusId]   — estado enviado desde la notificación.
+/// [manualBeneathId] — estado manual que el usuario tenía antes de la notificación;
+///                     se restaura al descartar la notificación.
+final class BackgroundNotificationActive extends PresenceState {
+  final String  notifStatusId;
+  final String? manualBeneathId;
+  const BackgroundNotificationActive({
+    required this.notifStatusId,
+    this.manualBeneathId,
+  });
+
+  @override
+  String get visibleStatusId => manualBeneathId ?? notifStatusId;
+}
+
+/// El usuario activó SOS.
+/// [previousId]  — estado que tenía antes del SOS (para restaurar post-resolución).
+/// [latitude], [longitude] — coordenadas GPS capturadas al activar.
+final class SOSActive extends PresenceState {
+  final String previousId;
+  final double latitude;
+  final double longitude;
+  const SOSActive({
+    required this.previousId,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  @override
+  String get visibleStatusId => StatusIds.sos;
+}
+```
+
+**Por qué `String` en lugar de `StatusType`:** `StatusType` (con emoji, label, order) es una preocupación de presentación que vive en `lib/core/models/`. El dominio solo necesita la identidad semántica del estado. La capa de infraestructura/presentación mapea `statusId → StatusType` cuando lo necesita para mostrar emoji o enviar a Firestore.
+
+---
+
+## Tarea 2 — `lib/shared/events/domain_event.dart`
+
+```dart
+/// Eventos de dominio publicados por bounded contexts vía DomainEventBus.
+/// Los BCs no se importan mutuamente; se comunican solo a través de estos eventos.
+sealed class DomainEvent {
+  const DomainEvent();
+}
+
+// ── Geofencing ──────────────────────────────────────────────────────────────
+
+class ZoneEntered extends DomainEvent {
+  final String zoneId;
+  final String userId;
+  const ZoneEntered({required this.zoneId, required this.userId});
+}
+
+class ZoneExited extends DomainEvent {
+  final String zoneId;
+  final String userId;
+  const ZoneExited({required this.zoneId, required this.userId});
+}
+
+// ── Identity ─────────────────────────────────────────────────────────────────
+
+class SessionEnded extends DomainEvent {
+  final String userId;
+  const SessionEnded({required this.userId});
+}
+
+// ── Notifications ─────────────────────────────────────────────────────────────
+
+class NotificationStatusSelected extends DomainEvent {
+  final String statusId;
+  const NotificationStatusSelected({required this.statusId});
+}
+```
+
+---
+
+## Tarea 3 — `lib/shared/events/domain_event_bus.dart`
+
+```dart
+import 'dart:async';
+import 'domain_event.dart';
+
+/// Bus de eventos de dominio. Singleton registrado en DI (platform_module).
+/// Nunca como static global — inyectar siempre desde GetIt.
+class DomainEventBus {
+  final _controller = StreamController<DomainEvent>.broadcast();
+
+  Stream<DomainEvent> get events => _controller.stream;
+
+  /// Stream filtrado por tipo de evento.
+  Stream<T> on<T extends DomainEvent>() =>
+      _controller.stream.whereType<T>();
+
+  void publish(DomainEvent event) => _controller.add(event);
+
+  void dispose() => _controller.close();
+}
+```
+
+---
+
+## Tarea 4 — Modificar `lib/app/di/modules/platform_module.dart`
+
+Agregar registro del `DomainEventBus`:
+
+```dart
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
+// ... imports existentes ...
+
+Future<void> registerPlatformModule(GetIt sl) async {
+  sl.registerLazySingleton<KvStore>(() => SharedPrefsKvStore(sl()));
+  sl.registerLazySingleton<DomainEventBus>(DomainEventBus.new);  // ← NUEVO
+}
+```
+
+---
+
+## Tarea 5 — Tests: `test/contexts/presence/domain/presence_state_test.dart`
+
+Cubrir (7 tests):
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 1 | `Normal.visibleStatusId` | Devuelve `currentId` |
+| 2 | `SilentMode.visibleStatusId` | Devuelve `preSilentId` |
+| 3 | `BackgroundNotificationActive` con `manualBeneathId` | `manualBeneathId` tiene precedencia |
+| 4 | `BackgroundNotificationActive` sin `manualBeneathId` | Devuelve `notifStatusId` |
+| 5 | `SOSActive.visibleStatusId` | Siempre devuelve `StatusIds.sos` |
+| 6 | `isSilent` / `isSOS` por subtipo | Flags correctos para los 4 estados |
+| 7 | `Normal.copyWith` | Produce nueva instancia con campos actualizados |
+
+---
+
+## Tarea 6 — Tests: `test/shared/events/domain_event_bus_test.dart`
+
+Cubrir (4 tests):
+
+| # | Escenario |
+|---|-----------|
+| 1 | `publish` → suscriptor recibe el evento |
+| 2 | `on<T>` filtra por tipo: `ZoneEntered` no llega al listener de `SessionEnded` |
+| 3 | Múltiples suscriptores reciben el mismo evento (broadcast) |
+| 4 | `dispose` cierra el stream sin excepción |
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo | Cambio |
+|---------|------|--------|
+| `lib/contexts/presence/domain/presence_state.dart` | Nuevo | Modelo sealed completo |
+| `lib/shared/events/domain_event.dart` | Nuevo | Eventos de dominio inter-BC |
+| `lib/shared/events/domain_event_bus.dart` | Nuevo | Bus de eventos |
+| `lib/app/di/modules/platform_module.dart` | Modificado | + registro `DomainEventBus` |
+| `test/contexts/presence/domain/presence_state_test.dart` | Nuevo | 7 tests |
+| `test/shared/events/domain_event_bus_test.dart` | Nuevo | 4 tests |
+
+**Archivos de producción activa no modificados** (StatusService, SilentFunctionalityCoordinator, in_circle_view.dart, etc.).
+
+---
+
+## Criterios de done
+
+| Criterio | Verificación |
+|----------|-------------|
+| `PresenceState` compila | `flutter analyze` |
+| `PresenceState` no importa nada fuera de `domain/` y `shared/` | Revisar imports |
+| Tests de `PresenceState` en verde (7/7) | `flutter test` |
+| Tests de `DomainEventBus` en verde (4/4) | `flutter test` |
+| `DomainEventBus` registrado en DI y accesible via `GetIt` | Verificar en test |
+| `flutter analyze` sin warnings nuevos vs. baseline (394) | `flutter analyze` |
+| Cero cambios funcionales — app se comporta idéntica | Arrancar app y verificar |
+
+---
+
+**Siguiente: Día 2 — `PresenceRepository` port + `SharedPrefsPresenceRepository`**

--- a/lib/app/di/modules/platform_module.dart
+++ b/lib/app/di/modules/platform_module.dart
@@ -1,9 +1,10 @@
 import 'package:get_it/get_it.dart';
 import 'package:nunakin_app/platform/persistence/kv_store.dart';
 import 'package:nunakin_app/platform/persistence/shared_prefs_kv_store.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
 
-/// Platform infrastructure: persistencia local y (Sem 2) DomainEventBus.
+/// Platform infrastructure: persistencia local y DomainEventBus.
 Future<void> registerPlatformModule(GetIt sl) async {
   sl.registerLazySingleton<KvStore>(() => SharedPrefsKvStore(sl()));
-  // TODO Sem 2: DomainEventBus
+  sl.registerLazySingleton<DomainEventBus>(DomainEventBus.new);
 }

--- a/lib/contexts/presence/domain/presence_state.dart
+++ b/lib/contexts/presence/domain/presence_state.dart
@@ -1,0 +1,83 @@
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+
+/// Estado canónico de presencia del usuario.
+///
+/// Un único valor de este tipo reemplaza las 5 claves de SharedPreferences que
+/// hoy dispersan el estado: current_status_id, manual_status_id,
+/// pre_silent_status_id, is_silent_mode_active, suppress_next_geofence_check.
+sealed class PresenceState {
+  const PresenceState();
+
+  /// ID del estado visible a los miembros del círculo en este momento.
+  String get visibleStatusId;
+
+  bool get isSilent => this is SilentMode;
+  bool get isSOS    => this is SOSActive;
+}
+
+/// Estado normal: el usuario está disponible e interactuando.
+/// [currentId]     — estado que se muestra al círculo (puede ser auto-actualizado
+///                   por geofencing o por selección manual).
+/// [lastManualId]  — último estado elegido por el usuario. Necesario para
+///                   restaurarlo al salir del Modo Silencio y para el testigo
+///                   del modal de selección. Null si el usuario nunca eligió uno.
+final class Normal extends PresenceState {
+  final String  currentId;
+  final String? lastManualId;
+  const Normal({required this.currentId, this.lastManualId});
+
+  @override
+  String get visibleStatusId => currentId;
+
+  Normal copyWith({String? currentId, String? lastManualId}) => Normal(
+        currentId:    currentId    ?? this.currentId,
+        lastManualId: lastManualId ?? this.lastManualId,
+      );
+}
+
+/// El usuario activó Modo Silencio. La app está en background.
+/// [preSilentId] — estado que tenía justo antes de activar Silent Mode.
+///                 El círculo ve este estado mientras dura el silencio.
+/// [enteredAt]   — timestamp para detectar silencio prolongado (> N horas)
+///                 en futuros checks automáticos.
+final class SilentMode extends PresenceState {
+  final String   preSilentId;
+  final DateTime enteredAt;
+  const SilentMode({required this.preSilentId, required this.enteredAt});
+
+  @override
+  String get visibleStatusId => preSilentId;
+}
+
+/// Una notificación desde la barra de estado activó un nuevo estado.
+/// [notifStatusId]   — estado enviado desde la notificación.
+/// [manualBeneathId] — estado manual que el usuario tenía antes de la notificación;
+///                     se restaura al descartar la notificación.
+final class BackgroundNotificationActive extends PresenceState {
+  final String  notifStatusId;
+  final String? manualBeneathId;
+  const BackgroundNotificationActive({
+    required this.notifStatusId,
+    this.manualBeneathId,
+  });
+
+  @override
+  String get visibleStatusId => manualBeneathId ?? notifStatusId;
+}
+
+/// El usuario activó SOS.
+/// [previousId]  — estado que tenía antes del SOS (para restaurar post-resolución).
+/// [latitude], [longitude] — coordenadas GPS capturadas al activar.
+final class SOSActive extends PresenceState {
+  final String previousId;
+  final double latitude;
+  final double longitude;
+  const SOSActive({
+    required this.previousId,
+    required this.latitude,
+    required this.longitude,
+  });
+
+  @override
+  String get visibleStatusId => StatusIds.sos;
+}

--- a/lib/shared/events/domain_event.dart
+++ b/lib/shared/events/domain_event.dart
@@ -1,0 +1,33 @@
+/// Eventos de dominio publicados por bounded contexts vía DomainEventBus.
+/// Los BCs no se importan mutuamente; se comunican solo a través de estos eventos.
+sealed class DomainEvent {
+  const DomainEvent();
+}
+
+// ── Geofencing ──────────────────────────────────────────────────────────────
+
+class ZoneEntered extends DomainEvent {
+  final String zoneId;
+  final String userId;
+  const ZoneEntered({required this.zoneId, required this.userId});
+}
+
+class ZoneExited extends DomainEvent {
+  final String zoneId;
+  final String userId;
+  const ZoneExited({required this.zoneId, required this.userId});
+}
+
+// ── Identity ─────────────────────────────────────────────────────────────────
+
+class SessionEnded extends DomainEvent {
+  final String userId;
+  const SessionEnded({required this.userId});
+}
+
+// ── Notifications ─────────────────────────────────────────────────────────────
+
+class NotificationStatusSelected extends DomainEvent {
+  final String statusId;
+  const NotificationStatusSelected({required this.statusId});
+}

--- a/lib/shared/events/domain_event_bus.dart
+++ b/lib/shared/events/domain_event_bus.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+import 'package:nunakin_app/shared/events/domain_event.dart';
+
+/// Bus de eventos de dominio. Singleton registrado en DI (platform_module).
+/// Nunca como static global — inyectar siempre desde GetIt.
+class DomainEventBus {
+  final _controller = StreamController<DomainEvent>.broadcast();
+
+  Stream<DomainEvent> get events => _controller.stream;
+
+  /// Stream filtrado por tipo de evento.
+  Stream<T> on<T extends DomainEvent>() =>
+      _controller.stream.where((e) => e is T).cast<T>();
+
+  void publish(DomainEvent event) => _controller.add(event);
+
+  void dispose() => _controller.close();
+}

--- a/test/contexts/presence/domain/presence_state_test.dart
+++ b/test/contexts/presence/domain/presence_state_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+
+void main() {
+  group('PresenceState', () {
+    group('Normal', () {
+      test('visibleStatusId devuelve currentId', () {
+        const state = Normal(currentId: 'school', lastManualId: 'school');
+        expect(state.visibleStatusId, 'school');
+      });
+
+      test('copyWith actualiza campos correctamente', () {
+        const original = Normal(currentId: 'fine', lastManualId: null);
+        final updated = original.copyWith(currentId: 'work', lastManualId: 'work');
+        expect(updated.currentId, 'work');
+        expect(updated.lastManualId, 'work');
+      });
+
+      test('isSilent es false, isSOS es false', () {
+        const state = Normal(currentId: 'fine');
+        expect(state.isSilent, isFalse);
+        expect(state.isSOS, isFalse);
+      });
+    });
+
+    group('SilentMode', () {
+      test('visibleStatusId devuelve preSilentId', () {
+        final state = SilentMode(
+          preSilentId: 'work',
+          enteredAt: DateTime(2026, 5, 18),
+        );
+        expect(state.visibleStatusId, 'work');
+      });
+
+      test('isSilent es true, isSOS es false', () {
+        final state = SilentMode(
+          preSilentId: 'fine',
+          enteredAt: DateTime.now(),
+        );
+        expect(state.isSilent, isTrue);
+        expect(state.isSOS, isFalse);
+      });
+    });
+
+    group('BackgroundNotificationActive', () {
+      test('visibleStatusId usa manualBeneathId cuando está presente', () {
+        const state = BackgroundNotificationActive(
+          notifStatusId: 'home',
+          manualBeneathId: 'school',
+        );
+        expect(state.visibleStatusId, 'school');
+      });
+
+      test('visibleStatusId usa notifStatusId cuando manualBeneathId es null', () {
+        const state = BackgroundNotificationActive(notifStatusId: 'home');
+        expect(state.visibleStatusId, 'home');
+      });
+
+      test('isSilent es false, isSOS es false', () {
+        const state = BackgroundNotificationActive(notifStatusId: 'fine');
+        expect(state.isSilent, isFalse);
+        expect(state.isSOS, isFalse);
+      });
+    });
+
+    group('SOSActive', () {
+      test('visibleStatusId siempre devuelve StatusIds.sos', () {
+        const state = SOSActive(
+          previousId: 'school',
+          latitude: -33.4,
+          longitude: -70.6,
+        );
+        expect(state.visibleStatusId, StatusIds.sos);
+      });
+
+      test('isSOS es true, isSilent es false', () {
+        const state = SOSActive(
+          previousId: 'fine',
+          latitude: 0.0,
+          longitude: 0.0,
+        );
+        expect(state.isSOS, isTrue);
+        expect(state.isSilent, isFalse);
+      });
+    });
+  });
+}

--- a/test/shared/events/domain_event_bus_test.dart
+++ b/test/shared/events/domain_event_bus_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/shared/events/domain_event.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
+
+void main() {
+  group('DomainEventBus', () {
+    late DomainEventBus bus;
+
+    setUp(() => bus = DomainEventBus());
+    tearDown(() => bus.dispose());
+
+    test('publish entrega el evento al suscriptor', () async {
+      final received = <DomainEvent>[];
+      bus.events.listen(received.add);
+
+      bus.publish(const SessionEnded(userId: 'u1'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(received, hasLength(1));
+      expect(received.first, isA<SessionEnded>());
+    });
+
+    test('on<T> filtra por tipo — ZoneEntered no llega a listener de SessionEnded', () async {
+      final sessionEvents = <SessionEnded>[];
+      bus.on<SessionEnded>().listen(sessionEvents.add);
+
+      bus.publish(const ZoneEntered(zoneId: 'z1', userId: 'u1'));
+      bus.publish(const SessionEnded(userId: 'u2'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(sessionEvents, hasLength(1));
+      expect(sessionEvents.first.userId, 'u2');
+    });
+
+    test('múltiples suscriptores reciben el mismo evento', () async {
+      final a = <DomainEvent>[];
+      final b = <DomainEvent>[];
+      bus.events.listen(a.add);
+      bus.events.listen(b.add);
+
+      bus.publish(const ZoneExited(zoneId: 'z2', userId: 'u3'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(a, hasLength(1));
+      expect(b, hasLength(1));
+    });
+
+    test('dispose cierra el stream sin excepción', () {
+      expect(() => bus.dispose(), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `PresenceState` sealed class con 4 subtipos: `Normal`, `SilentMode`, `BackgroundNotificationActive`, `SOSActive`
- `DomainEvent` sealed class + `DomainEventBus` (broadcast stream, registrado en DI via `platform_module`)
- 14 unit tests nuevos (10 `PresenceState` + 4 `DomainEventBus`) — todos en verde
- 57/57 tests totales en verde (`flutter test --concurrency=1`)
- `flutter analyze` sin warnings nuevos vs. baseline (394)
- Cero cambios funcionales — código nuevo no cableado a producción

## Archivos modificados
- `lib/app/di/modules/platform_module.dart` — registra `DomainEventBus`
- `lib/contexts/presence/domain/presence_state.dart` — NUEVO
- `lib/shared/events/domain_event.dart` — NUEVO
- `lib/shared/events/domain_event_bus.dart` — NUEVO
- `test/contexts/presence/domain/presence_state_test.dart` — NUEVO (10 tests)
- `test/shared/events/domain_event_bus_test.dart` — NUEVO (4 tests)
- `docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-1.md` — plan de ejecución

## Sem 2 Día 1 — criterios cumplidos
- [x] `PresenceState` no importa nada fuera de `domain/` y `shared/`
- [x] Tests de `PresenceState` y `DomainEventBus` en verde
- [x] `DomainEventBus` registrado en DI y accesible via `GetIt`
- [x] `flutter analyze` 394 issues (baseline, 0 nuevos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)