### PR TITLE
refactor(presence): PresenceRepository port + SharedPrefsPresenceRepository

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/SharedKeys.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/SharedKeys.kt
@@ -18,6 +18,7 @@ object SharedKeys {
     const val MANUAL_STATUS_ID = "manual_status_id"
     const val PRE_SILENT_STATUS_ID = "pre_silent_status_id"
     const val IS_SILENT_MODE_ACTIVE = "is_silent_mode_active"
+    const val SILENT_ENTERED_AT = "silent_entered_at"
 
     // Geofence
     const val SUPPRESS_NEXT_GEOFENCE_CHECK = "suppress_next_geofence_check"

--- a/lib/contexts/presence/application/ports/presence_repository.dart
+++ b/lib/contexts/presence/application/ports/presence_repository.dart
@@ -1,0 +1,21 @@
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+/// Puerto de acceso al estado de presencia persistido.
+///
+/// La impl lee/escribe las 5 claves de SharedPreferences que
+/// hoy gestiona StatusService y SilentFunctionalityCoordinator
+/// de forma incoherente entre sí.
+abstract class PresenceRepository {
+  /// Reconstruye el estado actual desde SharedPreferences.
+  /// Si no hay datos, devuelve [Normal] con [StatusIds.fine].
+  Future<Result<PresenceState>> currentState();
+
+  /// Persiste coherentemente todas las claves necesarias para [state].
+  Future<Result<Unit>> saveState(PresenceState state);
+
+  /// Emite cada vez que se llama a [saveState] con éxito.
+  /// Solo activo mientras el proceso Flutter esté en foreground.
+  Stream<PresenceState> get stateStream;
+}

--- a/lib/contexts/presence/infrastructure/shared_prefs_presence_repository.dart
+++ b/lib/contexts/presence/infrastructure/shared_prefs_presence_repository.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/platform/persistence/kv_store.dart';
+import 'package:nunakin_app/platform/persistence/native_keys.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class SharedPrefsPresenceRepository implements PresenceRepository {
+  final KvStore _kv;
+  final _stateController = StreamController<PresenceState>.broadcast();
+
+  SharedPrefsPresenceRepository(this._kv);
+
+  @override
+  Stream<PresenceState> get stateStream => _stateController.stream;
+
+  @override
+  Future<Result<PresenceState>> currentState() async {
+    try {
+      final isSilent = await _kv.getBool(NativeSharedKeys.isSilentModeActive) ?? false;
+      if (isSilent) {
+        final preSilentId = await _kv.getString(NativeSharedKeys.preSilentStatusId);
+        final enteredAtMs = await _kv.getInt(NativeSharedKeys.silentEnteredAt);
+        final enteredAt = enteredAtMs != null
+            ? DateTime.fromMillisecondsSinceEpoch(enteredAtMs)
+            : DateTime.now(); // fallback: activado antes de Sem 2
+        return Success(SilentMode(
+          preSilentId: preSilentId ?? StatusIds.fine,
+          enteredAt: enteredAt,
+        ));
+      }
+      final currentId    = await _kv.getString(NativeSharedKeys.currentStatusId);
+      final lastManualId = await _kv.getString(NativeSharedKeys.manualStatusId);
+      return Success(Normal(
+        currentId:    currentId    ?? StatusIds.fine,
+        lastManualId: lastManualId,
+      ));
+    } catch (e, st) {
+      return FailureResult(UnexpectedFailure(
+        message: 'Error leyendo estado de presencia: $e',
+        cause: e,
+        stackTrace: st,
+      ));
+    }
+  }
+
+  @override
+  Future<Result<Unit>> saveState(PresenceState state) async {
+    try {
+      switch (state) {
+        case Normal(:final currentId, :final lastManualId):
+          await _kv.setString(NativeSharedKeys.currentStatusId, currentId);
+          if (lastManualId != null) {
+            await _kv.setString(NativeSharedKeys.manualStatusId, lastManualId);
+          }
+          await _kv.remove(NativeSharedKeys.isSilentModeActive);
+          await _kv.remove(NativeSharedKeys.preSilentStatusId);
+          await _kv.remove(NativeSharedKeys.silentEnteredAt);
+
+        case SilentMode(:final preSilentId, :final enteredAt):
+          await _kv.setBool(NativeSharedKeys.isSilentModeActive, true);
+          await _kv.setString(NativeSharedKeys.preSilentStatusId, preSilentId);
+          await _kv.setInt(
+            NativeSharedKeys.silentEnteredAt,
+            enteredAt.millisecondsSinceEpoch,
+          );
+
+        case BackgroundNotificationActive(:final notifStatusId):
+          await _kv.setString(NativeSharedKeys.currentStatusId, notifStatusId);
+
+        case SOSActive():
+          await _kv.setString(NativeSharedKeys.currentStatusId, StatusIds.sos);
+      }
+      _stateController.add(state);
+      return Success(Unit.instance);
+    } catch (e, st) {
+      return FailureResult(UnexpectedFailure(
+        message: 'Error guardando estado de presencia: $e',
+        cause: e,
+        stackTrace: st,
+      ));
+    }
+  }
+
+  void dispose() => _stateController.close();
+}

--- a/lib/platform/persistence/native_keys.dart
+++ b/lib/platform/persistence/native_keys.dart
@@ -28,6 +28,12 @@ abstract final class NativeSharedKeys {
   /// NOTA: coexiste con zync_silent_mode.is_silent_mode_active en Kotlin — Sem 3.
   static const isSilentModeActive = 'is_silent_mode_active';
 
+  /// Timestamp (ms epoch) de cuándo se activó Silent Mode.
+  /// Escrito por: EnterSilentMode use case.
+  /// Leído por: SharedPrefsPresenceRepository.
+  /// Eliminado por: ExitSilentMode use case (y MainActivity al desactivar Silent Mode).
+  static const silentEnteredAt = 'silent_entered_at';
+
   // ── Geofence ───────────────────────────────────────────────────────────────
   /// Flag para suprimir el siguiente check de geofence en cold start.
   /// Escrito por: StatusUpdateWorker.kt. Leído/eliminado por: main.dart.

--- a/test/contexts/presence/infrastructure/shared_prefs_presence_repository_test.dart
+++ b/test/contexts/presence/infrastructure/shared_prefs_presence_repository_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/contexts/presence/infrastructure/shared_prefs_presence_repository.dart';
+import 'package:nunakin_app/platform/persistence/shared_prefs_kv_store.dart';
+import 'package:nunakin_app/shared/result.dart';
+
+void main() {
+  group('SharedPrefsPresenceRepository', () {
+    late SharedPrefsPresenceRepository repo;
+
+    Future<SharedPrefsPresenceRepository> build(
+        Map<String, Object> initialValues) async {
+      SharedPreferences.setMockInitialValues(initialValues);
+      final prefs = await SharedPreferences.getInstance();
+      return SharedPrefsPresenceRepository(SharedPrefsKvStore(prefs));
+    }
+
+    tearDown(() => repo.dispose());
+
+    // ── currentState ──────────────────────────────────────────────────────────
+
+    test('1 — cold start vacío devuelve Normal(fine, null)', () async {
+      repo = await build({});
+      final result = await repo.currentState();
+      expect(result, isA<Success<PresenceState>>());
+      final state = (result as Success<PresenceState>).value;
+      expect(state, isA<Normal>());
+      expect((state as Normal).currentId, StatusIds.fine);
+      expect(state.lastManualId, isNull);
+    });
+
+    test('2 — Normal con historial devuelve currentId y lastManualId', () async {
+      repo = await build({
+        'flutter.current_status_id': 'school',
+        'flutter.manual_status_id': 'school',
+      });
+      final result = await repo.currentState();
+      final state = (result as Success<PresenceState>).value as Normal;
+      expect(state.currentId, 'school');
+      expect(state.lastManualId, 'school');
+    });
+
+    test('3 — SilentMode activo con timestamp reconstituye correctamente',
+        () async {
+      final ts = DateTime(2026, 5, 19, 10, 0).millisecondsSinceEpoch;
+      repo = await build({
+        'flutter.is_silent_mode_active': true,
+        'flutter.pre_silent_status_id': 'work',
+        'flutter.silent_entered_at': ts,
+      });
+      final result = await repo.currentState();
+      final state = (result as Success<PresenceState>).value as SilentMode;
+      expect(state.preSilentId, 'work');
+      expect(state.enteredAt.millisecondsSinceEpoch, ts);
+    });
+
+    test('4 — SilentMode sin entered_at (legado) usa DateTime.now()', () async {
+      final before = DateTime.now();
+      repo = await build({
+        'flutter.is_silent_mode_active': true,
+        'flutter.pre_silent_status_id': 'home',
+      });
+      final result = await repo.currentState();
+      final after = DateTime.now();
+      final state = (result as Success<PresenceState>).value as SilentMode;
+      expect(state.preSilentId, 'home');
+      expect(
+        state.enteredAt.millisecondsSinceEpoch,
+        inInclusiveRange(
+          before.millisecondsSinceEpoch,
+          after.millisecondsSinceEpoch,
+        ),
+      );
+    });
+
+    // ── saveState ─────────────────────────────────────────────────────────────
+
+    test('5 — saveState(Normal) limpia todas las claves de Silent Mode',
+        () async {
+      final ts = DateTime(2026, 5, 19).millisecondsSinceEpoch;
+      repo = await build({
+        'flutter.is_silent_mode_active': true,
+        'flutter.pre_silent_status_id': 'work',
+        'flutter.silent_entered_at': ts,
+      });
+      final result =
+          await repo.saveState(const Normal(currentId: 'fine'));
+      expect(result, isA<Success>());
+
+      // Verify by reading back
+      final stateResult = await repo.currentState();
+      final state = (stateResult as Success<PresenceState>).value;
+      expect(state, isA<Normal>());
+      expect((state as Normal).currentId, 'fine');
+    });
+
+    test('6 — saveState(SilentMode) escribe las 3 claves de Silent Mode',
+        () async {
+      repo = await build({});
+      final enteredAt = DateTime(2026, 5, 19, 12, 0);
+      final result = await repo.saveState(
+        SilentMode(preSilentId: 'school', enteredAt: enteredAt),
+      );
+      expect(result, isA<Success>());
+
+      // Verify by reading back
+      final stateResult = await repo.currentState();
+      final state = (stateResult as Success<PresenceState>).value as SilentMode;
+      expect(state.preSilentId, 'school');
+      expect(state.enteredAt.millisecondsSinceEpoch,
+          enteredAt.millisecondsSinceEpoch);
+    });
+
+    // ── stateStream ───────────────────────────────────────────────────────────
+
+    test('7 — stateStream emite el estado tras saveState exitoso', () async {
+      repo = await build({});
+      final emitted = <PresenceState>[];
+      repo.stateStream.listen(emitted.add);
+
+      await repo.saveState(const Normal(currentId: 'work', lastManualId: 'work'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, hasLength(1));
+      expect(emitted.first, isA<Normal>());
+      expect((emitted.first as Normal).currentId, 'work');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `NativeSharedKeys.silentEnteredAt` (Dart) + `SharedKeys.SILENT_ENTERED_AT` (Kotlin) — sincronizados con valor `silent_entered_at`
- Add `PresenceRepository` abstract port in `lib/contexts/presence/application/ports/`
- Add `SharedPrefsPresenceRepository` concrete impl in `lib/contexts/presence/infrastructure/`
- Add 7 unit tests covering all `currentState`/`saveState`/`stateStream` scenarios (cold start, Normal, SilentMode+ts, SilentMode legado, saveState limpia Silent, saveState escribe Silent, stream emite)

## Archivos de producción activa no modificados
`StatusService`, `SilentFunctionalityCoordinator`, `MainActivity`, `InCircleView` — sin tocar.

## Verificaciones
- `flutter analyze`: 394 issues (baseline sin cambio)
- `flutter test --concurrency=1`: 64/64 ✅

## Test plan
- [x] 7/7 tests nuevos en verde
- [x] Suite completa 64/64
- [x] `flutter analyze` 394 (sin warnings nuevos)
- [ ] App arranca sin error — verificar en dispositivo (DI intacto, no se registra aún en módulo)

**Base:** PR #155 → `cde91c1`
**Siguiente:** Día 3 — Use cases `SetManualStatus` + `EnterSilentMode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)