### PR TITLE
refactor(presence): SetManualStatus + EnterSilentMode use cases

### DIFF
--- a/lib/contexts/presence/application/ports/presence_publisher.dart
+++ b/lib/contexts/presence/application/ports/presence_publisher.dart
@@ -1,0 +1,14 @@
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+/// Puerto de publicación: propaga cambios de presencia a sistemas externos.
+/// La impl concreta (FirestorePresencePublisher) vive en infrastructure/ — Día 4.
+abstract class PresencePublisher {
+  /// Publica un cambio de estado al círculo vía Firestore.
+  Future<Result<Unit>> publish({
+    required PresenceState state,
+    required String userId,
+    required String circleId,
+  });
+}

--- a/lib/contexts/presence/application/use_cases/enter_silent_mode.dart
+++ b/lib/contexts/presence/application/use_cases/enter_silent_mode.dart
@@ -1,0 +1,38 @@
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class EnterSilentMode {
+  final PresenceRepository _repository;
+
+  EnterSilentMode({required PresenceRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call({required String userId}) async {
+    Contract.requires(userId.isNotEmpty, 'userId debe ser no vacío');
+
+    final currentResult = await _repository.currentState();
+    if (currentResult.isFailure) return currentResult as Result<Unit>;
+    final current = currentResult.valueOrNull!;
+
+    // Guardia de idempotencia: ya está en Silent Mode, nada que hacer.
+    if (current is SilentMode) return Success(Unit.instance);
+
+    // Pre-silencio = último estado manual, o current si no hay manual.
+    // postcondición implícita: saveState(SilentMode(...)) garantiza
+    // que SharedPrefs quedará en SilentMode si devuelve Success.
+    final preSilentId = switch (current) {
+      Normal(:final lastManualId, :final currentId) =>
+          lastManualId ?? currentId,
+      _ => StatusIds.fine,
+    };
+
+    return _repository.saveState(SilentMode(
+      preSilentId: preSilentId,
+      enteredAt:   DateTime.now(),
+    ));
+  }
+}

--- a/lib/contexts/presence/application/use_cases/set_manual_status.dart
+++ b/lib/contexts/presence/application/use_cases/set_manual_status.dart
@@ -1,0 +1,38 @@
+import 'package:nunakin_app/contexts/presence/application/ports/presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class SetManualStatus {
+  final PresenceRepository _repository;
+  final PresencePublisher  _publisher;
+
+  SetManualStatus({
+    required PresenceRepository repository,
+    required PresencePublisher  publisher,
+  })  : _repository = repository,
+        _publisher  = publisher;
+
+  Future<Result<Unit>> call({
+    required String statusId,
+    required String userId,
+    required String circleId,
+  }) async {
+    Contract.requires(statusId.isNotEmpty,  'statusId debe ser no vacío');
+    Contract.requires(userId.isNotEmpty,    'userId debe ser no vacío');
+    Contract.requires(circleId.isNotEmpty,  'circleId debe ser no vacío');
+
+    final newState = Normal(currentId: statusId, lastManualId: statusId);
+
+    final saveResult = await _repository.saveState(newState);
+    if (saveResult.isFailure) return saveResult;
+
+    return _publisher.publish(
+      state:    newState,
+      userId:   userId,
+      circleId: circleId,
+    );
+  }
+}

--- a/test/contexts/presence/application/enter_silent_mode_test.dart
+++ b/test/contexts/presence/application/enter_silent_mode_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/enter_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import '../../../helpers/presence/fake_presence_repository.dart';
+
+void main() {
+  late FakePresenceRepository repo;
+  late EnterSilentMode useCase;
+
+  setUp(() {
+    repo    = FakePresenceRepository();
+    useCase = EnterSilentMode(repository: repo);
+  });
+
+  tearDown(() => repo.dispose());
+
+  group('EnterSilentMode', () {
+    test('1 — Normal con lastManualId → preSilentId = lastManualId', () async {
+      repo.setState(const Normal(currentId: 'school', lastManualId: 'school'));
+      final before = DateTime.now();
+
+      await useCase.call(userId: 'u1');
+
+      final after = DateTime.now();
+      expect(repo.lastSavedState, isA<SilentMode>());
+      final saved = repo.lastSavedState as SilentMode;
+      expect(saved.preSilentId, 'school');
+      expect(
+        saved.enteredAt.millisecondsSinceEpoch,
+        inInclusiveRange(
+          before.millisecondsSinceEpoch,
+          after.millisecondsSinceEpoch,
+        ),
+      );
+    });
+
+    test('2 — Normal sin lastManualId → preSilentId = currentId', () async {
+      repo.setState(const Normal(currentId: 'work'));
+
+      await useCase.call(userId: 'u1');
+
+      final saved = repo.lastSavedState as SilentMode;
+      expect(saved.preSilentId, 'work');
+    });
+
+    test('3 — idempotencia: ya en SilentMode → Success sin escribir', () async {
+      repo.setState(SilentMode(
+        preSilentId: 'work',
+        enteredAt:   DateTime(2026, 5, 20),
+      ));
+
+      final result = await useCase.call(userId: 'u1');
+
+      expect(result.isSuccess,    isTrue);
+      expect(repo.saveCallCount,  0);
+    });
+
+    test('4 — Contract.requires lanza cuando userId está vacío', () async {
+      await expectLater(
+        useCase.call(userId: ''),
+        throwsA(isA<ContractViolation>()),
+      );
+    });
+  });
+}

--- a/test/contexts/presence/application/set_manual_status_test.dart
+++ b/test/contexts/presence/application/set_manual_status_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/set_manual_status.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import '../../../helpers/presence/fake_presence_repository.dart';
+import '../../../helpers/presence/fake_presence_publisher.dart';
+
+void main() {
+  late FakePresenceRepository repo;
+  late FakePresencePublisher publisher;
+  late SetManualStatus useCase;
+
+  setUp(() {
+    repo      = FakePresenceRepository();
+    publisher = FakePresencePublisher();
+    useCase   = SetManualStatus(repository: repo, publisher: publisher);
+  });
+
+  tearDown(() => repo.dispose());
+
+  group('SetManualStatus', () {
+    test('1 — guarda Normal con currentId = lastManualId = statusId', () async {
+      await useCase.call(statusId: 'school', userId: 'u1', circleId: 'c1');
+
+      expect(repo.lastSavedState, isA<Normal>());
+      final saved = repo.lastSavedState as Normal;
+      expect(saved.currentId,    'school');
+      expect(saved.lastManualId, 'school');
+    });
+
+    test('2 — invoca publisher con userId y circleId correctos', () async {
+      await useCase.call(statusId: 'work', userId: 'u1', circleId: 'c1');
+
+      expect(publisher.publishCallCount,    1);
+      expect(publisher.lastUserId,          'u1');
+      expect(publisher.lastCircleId,        'c1');
+      expect(publisher.lastPublishedState,  isA<Normal>());
+    });
+
+    test('3 — si saveState falla no llama al publisher y retorna FailureResult',
+        () async {
+      repo.saveStateOverride = FailureResult(
+        UnexpectedFailure(message: 'disk full'),
+      );
+
+      final result = await useCase.call(
+        statusId: 'fine', userId: 'u1', circleId: 'c1',
+      );
+
+      expect(result.isFailure,           isTrue);
+      expect(publisher.publishCallCount, 0);
+    });
+
+    test('4 — Contract.requires lanza cuando statusId está vacío', () async {
+      await expectLater(
+        useCase.call(statusId: '', userId: 'u1', circleId: 'c1'),
+        throwsA(isA<ContractViolation>()),
+      );
+    });
+
+    test('5 — Contract.requires lanza cuando circleId está vacío', () async {
+      await expectLater(
+        useCase.call(statusId: 'fine', userId: 'u1', circleId: ''),
+        throwsA(isA<ContractViolation>()),
+      );
+    });
+  });
+}

--- a/test/helpers/presence/fake_presence_publisher.dart
+++ b/test/helpers/presence/fake_presence_publisher.dart
@@ -1,0 +1,25 @@
+import 'package:nunakin_app/contexts/presence/application/ports/presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class FakePresencePublisher implements PresencePublisher {
+  Result<Unit> publishResult = Success(Unit.instance);
+  int publishCallCount = 0;
+  PresenceState? lastPublishedState;
+  String? lastUserId;
+  String? lastCircleId;
+
+  @override
+  Future<Result<Unit>> publish({
+    required PresenceState state,
+    required String userId,
+    required String circleId,
+  }) async {
+    publishCallCount++;
+    lastPublishedState = state;
+    lastUserId   = userId;
+    lastCircleId = circleId;
+    return publishResult;
+  }
+}

--- a/test/helpers/presence/fake_presence_repository.dart
+++ b/test/helpers/presence/fake_presence_repository.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class FakePresenceRepository implements PresenceRepository {
+  PresenceState _state = const Normal(currentId: StatusIds.fine);
+  Result<Unit>? saveStateOverride; // null → Success por defecto
+  int saveCallCount = 0;
+  PresenceState? lastSavedState;
+
+  final _controller = StreamController<PresenceState>.broadcast();
+
+  void setState(PresenceState state) => _state = state;
+
+  @override
+  Stream<PresenceState> get stateStream => _controller.stream;
+
+  @override
+  Future<Result<PresenceState>> currentState() async => Success(_state);
+
+  @override
+  Future<Result<Unit>> saveState(PresenceState state) async {
+    saveCallCount++;
+    lastSavedState = state;
+    final result = saveStateOverride ?? Success(Unit.instance);
+    if (result.isSuccess) {
+      _state = state;
+      _controller.add(state);
+    }
+    return result;
+  }
+
+  void dispose() => _controller.close();
+}


### PR DESCRIPTION
## Summary
- Add `PresencePublisher` abstract port (`application/ports/`)
- Add `SetManualStatus` use case: persiste `Normal` + publica a Firestore. DbC preconditions en `statusId`, `userId`, `circleId`
- Add `EnterSilentMode` use case: guarda `SilentMode` con guard de idempotencia. `preSilentId = lastManualId ?? currentId`
- Add `FakePresenceRepository` + `FakePresencePublisher` en `test/helpers/presence/` — reutilizables en Día 4

## Archivos de producción activa no modificados
`StatusService`, `SilentFunctionalityCoordinator`, `presence_module.dart` (placeholder intacto) — sin tocar.

## Verificaciones
- `flutter analyze`: 394 issues (baseline sin cambio)
- `flutter test --concurrency=1`: 73/73 ✅

## Test plan
- [x] 9/9 tests nuevos en verde (5 SetManualStatus, 4 EnterSilentMode)
- [x] Suite completa 73/73
- [x] `flutter analyze` 394 (sin warnings nuevos)

**Base:** PR #156 → `f6965d3`
**Siguiente:** Día 4 — ExitSilentMode + RaiseSOS + FirestorePresencePublisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)