### PR TITLE
refactor(presence): ExitSilentMode + RaiseSOS + FirestorePresencePublisher

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-4.md
+++ b/docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-4.md
@@ -1,0 +1,129 @@
+# Sem 2 - Día 4 — `ExitSilentMode` + `RaiseSOS` + `FirestorePresencePublisher`
+
+**Rama:** `refactor/sem2-use-cases-exit-sos-publisher`
+
+**PR:** `refactor(presence): ExitSilentMode + RaiseSOS + FirestorePresencePublisher`
+
+**Fecha planificada:** 2026-05-22 (jueves)
+
+**Base:** PR #157 → commit `e00aed1`
+
+---
+
+## Contexto
+
+Día 4 de Sem 2. Se completan las 4 transiciones del state machine de presencia con los use cases `ExitSilentMode` y `RaiseSOS`, y se extrae la lógica de escritura Firestore en `FirestorePresencePublisher`. Todo el código nuevo es aditivo — **no se invoca desde producción**. `StatusService` y `SilentFunctionalityCoordinator` siguen siendo la ruta activa.
+
+**Estado del repo al inicio:**
+- `lib/contexts/presence/application/use_cases/set_manual_status.dart` ✅ (Día 3)
+- `lib/contexts/presence/application/use_cases/enter_silent_mode.dart` ✅ (Día 3)
+- `lib/contexts/presence/application/ports/presence_publisher.dart` ✅ (Día 3)
+- `test/helpers/presence/fake_presence_repository.dart` ✅ (Día 3)
+- `test/helpers/presence/fake_presence_publisher.dart` ✅ (Día 3)
+
+---
+
+## Tarea 1 — `lib/contexts/presence/application/use_cases/exit_silent_mode.dart`
+
+Use case para salir del Modo Silencio. Restaura el `preSilentId` como estado activo.
+
+**Garantías:**
+- Idempotencia: si ya está en `Normal`, devuelve `Success` sin escribir.
+- `restoredId` usa `SilentMode.preSilentId`; para cualquier otro estado fallback a `StatusIds.fine`.
+- postcondición implícita: si `saveState` devuelve `Success`, SharedPrefs quedará en `Normal`.
+
+---
+
+## Tarea 2 — `lib/contexts/presence/application/use_cases/raise_sos.dart`
+
+Use case para activar SOS. Captura `visibleStatusId` del estado actual como `previousId`
+y publica a Firestore vía `PresencePublisher`.
+
+**Garantías:**
+- `previousId` = `currentState().visibleStatusId` (no un campo manual).
+- Si `saveState` falla → no llama al publisher.
+- Funciona correctamente desde cualquier estado previo (Normal, SilentMode, etc.).
+
+---
+
+## Tarea 3 — `lib/contexts/presence/infrastructure/firestore_presence_publisher.dart`
+
+Extrae la lógica de batch write de `StatusService.updateUserStatus`.
+
+**Nota sobre zona context:** `StatusService.updateUserStatus` lee el estado anterior de Firestore
+para preservar `zoneId`, `zoneName`, `customEmoji` al hacer override dentro de una zona.
+Esta lógica se completa en Sem 4 (Geofencing context). En Sem 2, la publicación omite
+los campos de zona (el campo queda null). Es aceptable porque el publisher no se usa en producción.
+
+**En Sem 2, esta clase no se invoca desde código de producción.**
+
+---
+
+## Tarea 4 — Tests
+
+### `test/contexts/presence/application/exit_silent_mode_test.dart` — 3 tests
+
+| # | Escenario | Verificación |
+|---|-----------|-------------|
+| 1 | `SilentMode(preSilentId: 'work')` → `Normal(currentId: 'work', lastManualId: 'work')` | `repo.lastSavedState` campos correctos |
+| 2 | Idempotencia: ya en `Normal` → `Success` sin escribir | `repo.saveCallCount == 0` |
+| 3 | `Contract.requires` lanza cuando `userId` está vacío | `throwsA(isA<ContractViolation>())` |
+
+### `test/contexts/presence/application/raise_sos_test.dart` — 7 tests
+
+| # | Escenario | Verificación |
+|---|-----------|-------------|
+| 1 | `previousId` captura `visibleStatusId` del estado actual | `sos.previousId == 'school'` |
+| 2 | Invoca `publisher.publish` con `SOSActive` | `publisher.publishCallCount == 1`, `lastPublishedState is SOSActive` |
+| 3 | Si `saveState` falla → no llama al publisher | `publisher.publishCallCount == 0` |
+| 4 | Desde `SilentMode` → `previousId = preSilentId` | `sos.previousId == 'work'` |
+| 5 | `Contract.requires` lanza cuando `userId` está vacío | `throwsA(isA<ContractViolation>())` |
+| 6 | `Contract.requires` lanza cuando `circleId` está vacío | `throwsA(isA<ContractViolation>())` |
+| 7 | Desde cold start → `previousId = StatusIds.fine` | `sos.previousId == 'fine'` |
+
+### `test/contexts/presence/infrastructure/firestore_presence_publisher_test.dart` — SKIP
+
+⚠️ **Pendiente:** requiere `fake_cloud_firestore` en `dev_dependencies`.
+
+```yaml
+dev_dependencies:
+  fake_cloud_firestore: ^3.0.4   # verificar última versión compatible
+```
+
+Escenarios a implementar una vez agregada la dependencia:
+1. `Normal` state → batch escribe en `circles/{id}/memberStatus/{uid}` y `statusEvents/` sin `coordinates`.
+2. `SOSActive` state → batch incluye `coordinates` en ambas escrituras.
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo | Cambio |
+|---------|------|--------|
+| `lib/contexts/presence/application/use_cases/exit_silent_mode.dart` | Nuevo | Use case |
+| `lib/contexts/presence/application/use_cases/raise_sos.dart` | Nuevo | Use case |
+| `lib/contexts/presence/infrastructure/firestore_presence_publisher.dart` | Nuevo | Adaptador de salida Firestore |
+| `test/contexts/presence/application/exit_silent_mode_test.dart` | Nuevo | 3 tests |
+| `test/contexts/presence/application/raise_sos_test.dart` | Nuevo | 7 tests |
+| `test/contexts/presence/infrastructure/firestore_presence_publisher_test.dart` | Nuevo | 1 skip (pendiente dep) |
+
+**Archivos de producción activa no modificados:** `StatusService`, `SilentFunctionalityCoordinator`,
+`presence_module.dart` (placeholder intacto — se puebla en Día 5), ningún widget.
+
+---
+
+## Criterios de done
+
+| Criterio | Estado |
+|----------|--------|
+| `ExitSilentMode` y `RaiseSOS` cubren las 4 transiciones del state machine | ✅ |
+| `FirestorePresencePublisher` compila sin warnings | ✅ |
+| Use cases no importan nada de `features/`, `core/services/`, ni `platform/` | ✅ |
+| 10 tests en verde (3 + 7) + 1 skip documentado | ✅ |
+| `flutter analyze` 394 issues (baseline, 0 nuevos) | ✅ |
+
+---
+
+**Pendiente para Sem 2 Día 5:** `PresenceViewModel` + DI wiring + cierre de semana.
+
+**Deuda registrada:** `fake_cloud_firestore` en dev_dependencies para activar tests de `FirestorePresencePublisher`.

--- a/lib/contexts/presence/application/use_cases/exit_silent_mode.dart
+++ b/lib/contexts/presence/application/use_cases/exit_silent_mode.dart
@@ -1,0 +1,36 @@
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class ExitSilentMode {
+  final PresenceRepository _repository;
+
+  ExitSilentMode({required PresenceRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call({required String userId}) async {
+    Contract.requires(userId.isNotEmpty, 'userId debe ser no vacío');
+
+    final currentResult = await _repository.currentState();
+    if (currentResult.isFailure) return currentResult as Result<Unit>;
+    final current = currentResult.valueOrNull!;
+
+    // Idempotencia: ya está en Normal, nada que hacer.
+    if (current is Normal) return Success(Unit.instance);
+
+    final restoredId = switch (current) {
+      SilentMode(:final preSilentId) => preSilentId,
+      _                              => StatusIds.fine,
+    };
+
+    // postcondición implícita: saveState(Normal(...)) garantiza
+    // que SharedPrefs quedará en Normal si devuelve Success.
+    return _repository.saveState(Normal(
+      currentId:    restoredId,
+      lastManualId: restoredId,
+    ));
+  }
+}

--- a/lib/contexts/presence/application/use_cases/raise_sos.dart
+++ b/lib/contexts/presence/application/use_cases/raise_sos.dart
@@ -1,0 +1,46 @@
+import 'package:nunakin_app/contexts/presence/application/ports/presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class RaiseSOS {
+  final PresenceRepository _repository;
+  final PresencePublisher  _publisher;
+
+  RaiseSOS({
+    required PresenceRepository repository,
+    required PresencePublisher  publisher,
+  })  : _repository = repository,
+        _publisher  = publisher;
+
+  Future<Result<Unit>> call({
+    required String userId,
+    required String circleId,
+    required double latitude,
+    required double longitude,
+  }) async {
+    Contract.requires(userId.isNotEmpty,   'userId debe ser no vacío');
+    Contract.requires(circleId.isNotEmpty, 'circleId debe ser no vacío');
+
+    final currentResult = await _repository.currentState();
+    if (currentResult.isFailure) return currentResult as Result<Unit>;
+    final previousId = currentResult.valueOrNull!.visibleStatusId;
+
+    final sosState = SOSActive(
+      previousId: previousId,
+      latitude:   latitude,
+      longitude:  longitude,
+    );
+
+    final saveResult = await _repository.saveState(sosState);
+    if (saveResult.isFailure) return saveResult;
+
+    return _publisher.publish(
+      state:    sosState,
+      userId:   userId,
+      circleId: circleId,
+    );
+  }
+}

--- a/lib/contexts/presence/infrastructure/firestore_presence_publisher.dart
+++ b/lib/contexts/presence/infrastructure/firestore_presence_publisher.dart
@@ -1,0 +1,77 @@
+import 'dart:developer';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+/// Adaptador de salida: publica cambios de presencia en Firestore.
+///
+/// Extrae la lógica de batch write de StatusService para que la
+/// ruta de producción (Sem 5+) use use cases en vez del servicio estático.
+///
+/// En Sem 2, esta clase no se invoca desde código de producción.
+class FirestorePresencePublisher implements PresencePublisher {
+  final FirebaseFirestore _firestore;
+
+  FirestorePresencePublisher(this._firestore);
+
+  @override
+  Future<Result<Unit>> publish({
+    required PresenceState state,
+    required String userId,
+    required String circleId,
+  }) async {
+    try {
+      final statusId = state.visibleStatusId;
+      final batch    = _firestore.batch();
+
+      final statusData = <String, dynamic>{
+        'userId':          userId,
+        'statusType':      statusId,
+        'timestamp':       FieldValue.serverTimestamp(),
+        'autoUpdated':     false,
+        'manualOverride':  false,
+        'locationUnknown': false,
+      };
+
+      if (state is SOSActive) {
+        statusData['coordinates'] = {
+          'latitude':  state.latitude,
+          'longitude': state.longitude,
+        };
+      }
+
+      batch.update(
+        _firestore.collection('circles').doc(circleId),
+        {'memberStatus.$userId': statusData},
+      );
+
+      final historyRef = _firestore
+          .collection('circles').doc(circleId)
+          .collection('statusEvents').doc();
+      batch.set(historyRef, {
+        'uid':        userId,
+        'statusType': statusId,
+        'createdAt':  FieldValue.serverTimestamp(),
+        if (state is SOSActive) 'coordinates': {
+          'latitude':  state.latitude,
+          'longitude': state.longitude,
+        },
+      });
+
+      await batch.commit().timeout(const Duration(seconds: 10));
+      log('[FirestorePresencePublisher] ✅ Publicado: $statusId');
+      return Success(Unit.instance);
+    } catch (e, st) {
+      log('[FirestorePresencePublisher] ❌ Error: $e');
+      return FailureResult(NetworkFailure(
+        message:    'Error publicando presencia: $e',
+        cause:      e,
+        stackTrace: st,
+      ));
+    }
+  }
+}

--- a/test/contexts/presence/application/exit_silent_mode_test.dart
+++ b/test/contexts/presence/application/exit_silent_mode_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/exit_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import '../../../helpers/presence/fake_presence_repository.dart';
+
+void main() {
+  late FakePresenceRepository repo;
+  late ExitSilentMode useCase;
+
+  setUp(() {
+    repo    = FakePresenceRepository();
+    useCase = ExitSilentMode(repository: repo);
+  });
+
+  tearDown(() => repo.dispose());
+
+  group('ExitSilentMode', () {
+    test('1 — SilentMode(preSilentId: work) → Normal(currentId: work, lastManualId: work)',
+        () async {
+      repo.setState(SilentMode(
+        preSilentId: 'work',
+        enteredAt:   DateTime(2026, 5, 20),
+      ));
+
+      final result = await useCase.call(userId: 'u1');
+
+      expect(result.isSuccess, isTrue);
+      expect(repo.lastSavedState, isA<Normal>());
+      final saved = repo.lastSavedState as Normal;
+      expect(saved.currentId,    'work');
+      expect(saved.lastManualId, 'work');
+    });
+
+    test('2 — idempotencia: ya en Normal → Success sin escribir', () async {
+      repo.setState(const Normal(currentId: 'school', lastManualId: 'school'));
+
+      final result = await useCase.call(userId: 'u1');
+
+      expect(result.isSuccess,   isTrue);
+      expect(repo.saveCallCount, 0);
+    });
+
+    test('3 — Contract.requires lanza cuando userId está vacío', () async {
+      await expectLater(
+        useCase.call(userId: ''),
+        throwsA(isA<ContractViolation>()),
+      );
+    });
+  });
+}

--- a/test/contexts/presence/application/raise_sos_test.dart
+++ b/test/contexts/presence/application/raise_sos_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/raise_sos.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import '../../../helpers/presence/fake_presence_publisher.dart';
+import '../../../helpers/presence/fake_presence_repository.dart';
+
+void main() {
+  late FakePresenceRepository repo;
+  late FakePresencePublisher  publisher;
+  late RaiseSOS               useCase;
+
+  setUp(() {
+    repo      = FakePresenceRepository();
+    publisher = FakePresencePublisher();
+    useCase   = RaiseSOS(repository: repo, publisher: publisher);
+  });
+
+  tearDown(() => repo.dispose());
+
+  group('RaiseSOS', () {
+    test('1 — previousId captura visibleStatusId del estado actual', () async {
+      repo.setState(const Normal(currentId: 'school', lastManualId: 'school'));
+
+      await useCase.call(
+        userId:    'u1',
+        circleId:  'c1',
+        latitude:  19.43,
+        longitude: -99.13,
+      );
+
+      expect(repo.lastSavedState, isA<SOSActive>());
+      final sos = repo.lastSavedState as SOSActive;
+      expect(sos.previousId, 'school');
+      expect(sos.latitude,   19.43);
+      expect(sos.longitude,  -99.13);
+    });
+
+    test('2 — invoca publisher.publish con SOSActive', () async {
+      await useCase.call(
+        userId:    'u1',
+        circleId:  'c1',
+        latitude:  19.43,
+        longitude: -99.13,
+      );
+
+      expect(publisher.publishCallCount,   1);
+      expect(publisher.lastPublishedState, isA<SOSActive>());
+      expect(publisher.lastUserId,         'u1');
+      expect(publisher.lastCircleId,       'c1');
+    });
+
+    test('3 — si saveState falla → no llama al publisher', () async {
+      repo.saveStateOverride = FailureResult(
+        const UnexpectedFailure(message: 'disk full'),
+      );
+
+      final result = await useCase.call(
+        userId:    'u1',
+        circleId:  'c1',
+        latitude:  0.0,
+        longitude: 0.0,
+      );
+
+      expect(result.isFailure,           isTrue);
+      expect(publisher.publishCallCount, 0);
+    });
+
+    test('4 — previousId desde SilentMode usa visibleStatusId (preSilentId)', () async {
+      repo.setState(SilentMode(
+        preSilentId: 'work',
+        enteredAt:   DateTime(2026, 5, 20),
+      ));
+
+      await useCase.call(
+        userId:    'u1',
+        circleId:  'c1',
+        latitude:  0.0,
+        longitude: 0.0,
+      );
+
+      final sos = repo.lastSavedState as SOSActive;
+      expect(sos.previousId, 'work');
+    });
+
+    test('5 — Contract.requires lanza cuando userId está vacío', () async {
+      await expectLater(
+        useCase.call(userId: '', circleId: 'c1', latitude: 0.0, longitude: 0.0),
+        throwsA(isA<ContractViolation>()),
+      );
+    });
+
+    test('6 — Contract.requires lanza cuando circleId está vacío', () async {
+      await expectLater(
+        useCase.call(userId: 'u1', circleId: '', latitude: 0.0, longitude: 0.0),
+        throwsA(isA<ContractViolation>()),
+      );
+    });
+
+    test('7 — desde cold start (fine) previousId = fine', () async {
+      // Estado por defecto del fake: Normal(currentId: StatusIds.fine)
+      await useCase.call(
+        userId:    'u1',
+        circleId:  'c1',
+        latitude:  0.0,
+        longitude: 0.0,
+      );
+
+      final sos = repo.lastSavedState as SOSActive;
+      expect(sos.previousId, StatusIds.fine);
+    });
+  });
+}

--- a/test/contexts/presence/infrastructure/firestore_presence_publisher_test.dart
+++ b/test/contexts/presence/infrastructure/firestore_presence_publisher_test.dart
@@ -1,0 +1,24 @@
+// TODO(sem2-day4): estos tests requieren `fake_cloud_firestore` en dev_dependencies.
+// Agregar a pubspec.yaml antes de activar:
+//
+//   dev_dependencies:
+//     fake_cloud_firestore: ^3.0.4   # verificar última versión compatible
+//
+// Una vez agregado, descomentar los tests y remover el @Skip.
+//
+// Escenarios a cubrir:
+//   1. Normal state → batch escribe en circles/{id}/memberStatus/{uid}
+//      y en circles/{id}/statusEvents/ sin campo 'coordinates'.
+//   2. SOSActive state → batch incluye 'coordinates' en memberStatus y statusEvents.
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FirestorePresencePublisher', () {
+    test(
+      'pendiente: requiere fake_cloud_firestore en dev_dependencies',
+      () {},
+      skip: 'Agregar fake_cloud_firestore a pubspec.yaml para activar estos tests',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **ExitSilentMode**: restaura `preSilentId` como `Normal`; idempotente cuando ya está en `Normal`
- **RaiseSOS**: captura `visibleStatusId` del estado actual, persiste `SOSActive` y publica via `PresencePublisher`
- **FirestorePresencePublisher**: extrae la lógica de batch write de `StatusService` — no invocado en producción en Sem 2
- 10 tests nuevos (3 + 7); 1 skip documentado pendiente `fake_cloud_firestore`
- `flutter analyze`: 394 issues (baseline, 0 nuevos)

## Archivos nuevos

| Archivo | Descripción |
|---------|-------------|
| `lib/contexts/presence/application/use_cases/exit_silent_mode.dart` | Use case |
| `lib/contexts/presence/application/use_cases/raise_sos.dart` | Use case |
| `lib/contexts/presence/infrastructure/firestore_presence_publisher.dart` | Adaptador Firestore |
| `test/.../exit_silent_mode_test.dart` | 3 tests |
| `test/.../raise_sos_test.dart` | 7 tests |
| `test/.../firestore_presence_publisher_test.dart` | Skip (pendiente dep) |
| `docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-4.md` | Documento del día |

## Deuda registrada

`fake_cloud_firestore` no está en `dev_dependencies`. Los tests de `FirestorePresencePublisher` están en skip con instrucciones para activarlos.

## Premisa de Sem 2 mantenida

- Cero cambios en archivos de producción activa (`StatusService`, `SilentFunctionalityCoordinator`, widgets)
- Los 4 use cases completan el state machine: `SetManualStatus` → `EnterSilentMode` → `ExitSilentMode` → `RaiseSOS`

## Test plan

- [x] `flutter test test/contexts/presence/` — 10 PASS, 1 SKIP
- [x] `flutter analyze` — 394 issues (0 nuevos vs baseline)
- [ ] Smoke test en dispositivo físico (al cierre de Día 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)