### PR TITLE
refactor(presence): PresenceViewModel + DI wiring + Sem 2 close

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-5.md
+++ b/docs/dev/refactor-arch-2026-q2/02-semana-2-Dia-5.md
@@ -1,0 +1,238 @@
+# Sem 2 - Día 5 — `PresenceViewModel` + DI wiring + cierre de Sem 2
+
+**Rama:** `refactor/sem2-vm-di-close`
+
+**PR:** `refactor(presence): PresenceViewModel + DI wiring + Sem 2 close`
+
+**Fecha:** 2026-05-08
+
+**Base:** PR #158 → commit `0111e91`
+
+---
+
+## Contexto
+
+Día final de Sem 2. Se completa el Presence context con:
+
+1. `PresenceViewModel` — expone `Stream<PresenceState>` a la capa de presentación (sin
+   conectar a ningún widget todavía — eso ocurre en Sem 5).
+2. `presence_module.dart` — el placeholder se reemplaza por el registro completo de todos
+   los objetos del contexto.
+3. Test de integración `presence_integration_test.dart` — ejercita el ciclo completo de
+   transiciones con fakes, sin dispositivo ni Firestore real.
+4. Cierre formal: `flutter test`, `flutter analyze`, tag `refactor-sem2-done`, memoria,
+   borrador `03-semana-3-native-bridge.md`.
+
+**Premisa invariante:** todo es aditivo. Los objetos nuevos están en el contenedor DI pero
+ningún código de producción los invoca todavía. `StatusService` y
+`SilentFunctionalityCoordinator` siguen siendo la ruta activa.
+
+---
+
+## Estado del repo al inicio
+
+| Archivo | Estado |
+|---------|--------|
+| `lib/contexts/presence/domain/presence_state.dart` | ✅ Día 1 |
+| `lib/contexts/presence/application/ports/presence_repository.dart` | ✅ Día 2 |
+| `lib/contexts/presence/infrastructure/shared_prefs_presence_repository.dart` | ✅ Día 2 |
+| `lib/contexts/presence/application/ports/presence_publisher.dart` | ✅ Día 3 |
+| `lib/contexts/presence/application/use_cases/set_manual_status.dart` | ✅ Día 3 |
+| `lib/contexts/presence/application/use_cases/enter_silent_mode.dart` | ✅ Día 3 |
+| `lib/contexts/presence/application/use_cases/exit_silent_mode.dart` | ✅ Día 4 |
+| `lib/contexts/presence/application/use_cases/raise_sos.dart` | ✅ Día 4 |
+| `lib/contexts/presence/infrastructure/firestore_presence_publisher.dart` | ✅ Día 4 |
+| `lib/app/di/modules/presence_module.dart` | ⚠️ placeholder (TODO Sem 2) |
+| `lib/app/di/modules/external_module.dart` | ✅ tiene `FirebaseFirestore.instance` |
+| `lib/app/di/modules/platform_module.dart` | ✅ tiene `KvStore` + `DomainEventBus` |
+
+---
+
+## Tarea 1 — `PresenceViewModel`
+
+**Archivo:** `lib/contexts/presence/presentation/view_models/presence_view_model.dart`
+
+Clase pura Dart — sin `StatefulWidget`, sin `ChangeNotifier`, sin Riverpod. La conexión
+al widget tree se hace en Sem 5 cuando `InCircleView` se descompone.
+
+```dart
+import 'dart:async';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+
+class PresenceViewModel {
+  final PresenceRepository _repository;
+  StreamSubscription<PresenceState>? _sub;
+  PresenceState? _current;
+
+  PresenceViewModel({required PresenceRepository repository})
+      : _repository = repository;
+
+  Future<void> init() async {
+    final result = await _repository.currentState();
+    _current = result.valueOrNull;
+    _sub = _repository.stateStream.listen((state) {
+      _current = state;
+    });
+  }
+
+  Stream<PresenceState> get stateStream => _repository.stateStream;
+  PresenceState? get currentSnapshot => _current;
+
+  void dispose() => _sub?.cancel();
+}
+```
+
+**Por qué clase pura y no ChangeNotifier:** Sem 5 decide el mecanismo reactivo definitivo
+(puede ser Riverpod, ValueNotifier, o simple Stream). Esta clase no impone nada.
+
+---
+
+## Tarea 2 — `presence_module.dart` completo
+
+**Archivo:** `lib/app/di/modules/presence_module.dart` — reemplaza el placeholder.
+
+Registra en orden: infrastructure → application (use cases) → presentation (view model).
+
+```dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get_it/get_it.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/enter_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/exit_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/raise_sos.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/set_manual_status.dart';
+import 'package:nunakin_app/contexts/presence/infrastructure/firestore_presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/infrastructure/shared_prefs_presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/presentation/view_models/presence_view_model.dart';
+import 'package:nunakin_app/platform/persistence/kv_store.dart';
+
+Future<void> registerPresenceModule(GetIt sl) async {
+  // Infrastructure
+  sl.registerLazySingleton<PresenceRepository>(
+    () => SharedPrefsPresenceRepository(sl<KvStore>()),
+  );
+  sl.registerLazySingleton<PresencePublisher>(
+    () => FirestorePresencePublisher(sl<FirebaseFirestore>()),
+  );
+
+  // Use cases (Factory: nueva instancia por solicitud, stateless)
+  sl.registerFactory(() => SetManualStatus(repository: sl(), publisher: sl()));
+  sl.registerFactory(() => EnterSilentMode(repository: sl()));
+  sl.registerFactory(() => ExitSilentMode(repository: sl()));
+  sl.registerFactory(() => RaiseSOS(repository: sl(), publisher: sl()));
+
+  // Presentation
+  sl.registerLazySingleton(() => PresenceViewModel(repository: sl()));
+}
+```
+
+**Nota:** `FirebaseFirestore` viene de `external_module.dart` (ya registrado).
+`KvStore` viene de `platform_module.dart` (ya registrado).
+Ambos módulos se inicializan antes que `presence_module` en `injection_container.dart`.
+
+---
+
+## Tarea 3 — Test de integración
+
+**Archivo:** `test/contexts/presence/presence_integration_test.dart`
+
+Ejercita el ciclo completo de transiciones usando `FakePresenceRepository` y
+`FakePresencePublisher`. Sin dispositivo ni Firestore real.
+
+```
+Normal(fine)
+  → SetManualStatus('school')  → Normal(currentId: 'school', lastManualId: 'school')
+  → EnterSilentMode()          → SilentMode(preSilentId: 'school')
+  → ExitSilentMode()           → Normal(currentId: 'school', lastManualId: 'school')
+  → RaiseSOS(lat, lng)         → SOSActive(previousId: 'school')
+```
+
+Además verifica que `PresenceViewModel.stateStream` emite los estados en orden.
+
+**Gap documentado:** `SetManualStatus(statusId: 'sos')` no está bloqueado a nivel de use
+case (el bloqueo de zona activa viene de `StatusService._blockedZoneStatusIds`, que se
+migra en Sem 4). Se cubre en el test solo para confirmar que el path compila y devuelve
+`Success` — el significado semántico del bloqueo es deuda de Sem 4.
+
+---
+
+## Tarea 4 — Verificar `injection_container.dart`
+
+Confirmar que `registerPresenceModule` se llama en la secuencia correcta:
+
+```
+registerExternalModule  (SharedPreferences, FirebaseAuth, FirebaseFirestore)
+registerPlatformModule  (KvStore, DomainEventBus)
+registerPresenceModule  (PresenceRepository, use cases, PresenceViewModel)
+...
+```
+
+Si el orden no es correcto, o si `presence_module` no está en la lista, agregarlo.
+
+---
+
+## Tarea 5 — Cierre de semana
+
+### 5.1 Tests
+```
+flutter test
+```
+Todos en verde. El número sube respecto al baseline por los tests nuevos de Sem 2.
+
+### 5.2 Analyzer
+```
+flutter analyze
+```
+0 warnings nuevos vs. baseline 394 issues.
+
+### 5.3 Git
+```
+git add ...
+git commit -m "refactor(presence): PresenceViewModel + DI wiring + Sem 2 close"
+gh pr create ...
+gh pr merge ...
+git tag refactor-sem2-done
+git push origin refactor-sem2-done
+```
+
+### 5.4 Entregables de documentación
+- `memory/project_refactor_sem2_done.md` — memoria de cierre
+- `docs/dev/refactor-arch-2026-q2/03-semana-3-native-bridge.md` — borrador Sem 3
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo | Cambio |
+|---------|------|--------|
+| `lib/contexts/presence/presentation/view_models/presence_view_model.dart` | Nuevo | ViewModel sin widget |
+| `lib/app/di/modules/presence_module.dart` | Modificado | placeholder → registro completo |
+| `test/contexts/presence/presence_integration_test.dart` | Nuevo | ciclo completo de transiciones |
+
+**Archivos de producción activa no modificados** (criterio de Sem 2): `StatusService`,
+`SilentFunctionalityCoordinator`, `in_circle_view.dart`, ni ningún widget.
+
+---
+
+## Criterios de done
+
+| Criterio | Verificación |
+|----------|-------------|
+| `PresenceViewModel` registrado en DI | `registerPresenceModule` compila, app arranca |
+| App funciona idéntico al baseline | Smoke test 6 pasos en device físico |
+| `flutter test` en verde | Salida del comando |
+| `flutter analyze` 0 warnings nuevos | Salida del comando vs. baseline 394 |
+| Test de integración ciclo completo verde | `flutter test test/contexts/presence/presence_integration_test.dart` |
+| Tag `refactor-sem2-done` en remoto | `git tag -l refactor-sem2-done` |
+| Memoria de cierre publicada | Archivo en `memory/` |
+| Borrador Sem 3 publicado | Archivo en `docs/dev/refactor-arch-2026-q2/` |
+
+---
+
+**Pendiente post-Sem 2 (no bloquea el cierre):**
+- `fake_cloud_firestore` en dev_dependencies para activar los 2 tests en skip de
+  `FirestorePresencePublisher`. Proponer al desarrollador al inicio de Sem 3.
+- `PresenceViewModel.init()` debe llamarse post-login. Se documenta como deuda; el
+  call real se hace en Sem 5 cuando la UI consume el VM.

--- a/lib/app/di/modules/presence_module.dart
+++ b/lib/app/di/modules/presence_module.dart
@@ -1,6 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get_it/get_it.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/enter_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/exit_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/raise_sos.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/set_manual_status.dart';
+import 'package:nunakin_app/contexts/presence/infrastructure/firestore_presence_publisher.dart';
+import 'package:nunakin_app/contexts/presence/infrastructure/shared_prefs_presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/presentation/view_models/presence_view_model.dart';
+import 'package:nunakin_app/platform/persistence/kv_store.dart';
 
-/// Placeholder — se puebla en Sem 2.
 Future<void> registerPresenceModule(GetIt sl) async {
-  // TODO Sem 2: PresenceRepository, presence use cases
+  // Infrastructure
+  sl.registerLazySingleton<PresenceRepository>(
+    () => SharedPrefsPresenceRepository(sl<KvStore>()),
+  );
+  sl.registerLazySingleton<PresencePublisher>(
+    () => FirestorePresencePublisher(sl<FirebaseFirestore>()),
+  );
+
+  // Use cases — Factory: nueva instancia por solicitud (stateless)
+  sl.registerFactory(() => SetManualStatus(repository: sl(), publisher: sl()));
+  sl.registerFactory(() => EnterSilentMode(repository: sl()));
+  sl.registerFactory(() => ExitSilentMode(repository: sl()));
+  sl.registerFactory(() => RaiseSOS(repository: sl(), publisher: sl()));
+
+  // Presentation
+  sl.registerLazySingleton(() => PresenceViewModel(repository: sl()));
 }

--- a/lib/contexts/presence/presentation/view_models/presence_view_model.dart
+++ b/lib/contexts/presence/presentation/view_models/presence_view_model.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+
+/// Expone el estado de presencia como stream para la capa de presentación.
+///
+/// No se conecta a la UI todavía — la conexión ocurre en Sem 5 cuando
+/// InCircleView se descompone en widgets que consumen este VM.
+class PresenceViewModel {
+  final PresenceRepository _repository;
+  StreamSubscription<PresenceState>? _sub;
+  PresenceState? _current;
+
+  PresenceViewModel({required PresenceRepository repository})
+      : _repository = repository;
+
+  /// Carga el estado actual y suscribe al stream del repositorio.
+  /// Debe llamarse post-login (Sem 5).
+  Future<void> init() async {
+    final result = await _repository.currentState();
+    _current = result.valueOrNull;
+    _sub = _repository.stateStream.listen((state) {
+      _current = state;
+    });
+  }
+
+  /// Stream de cambios: emite cada vez que el repositorio persiste un estado.
+  Stream<PresenceState> get stateStream => _repository.stateStream;
+
+  /// Última snapshot en memoria. Null antes de llamar a [init].
+  PresenceState? get currentSnapshot => _current;
+
+  void dispose() => _sub?.cancel();
+}

--- a/test/contexts/presence/presence_integration_test.dart
+++ b/test/contexts/presence/presence_integration_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/enter_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/exit_silent_mode.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/raise_sos.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/set_manual_status.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/contexts/presence/presentation/view_models/presence_view_model.dart';
+import '../../helpers/presence/fake_presence_publisher.dart';
+import '../../helpers/presence/fake_presence_repository.dart';
+
+void main() {
+  late FakePresenceRepository repo;
+  late FakePresencePublisher publisher;
+  late SetManualStatus setManual;
+  late EnterSilentMode enterSilent;
+  late ExitSilentMode exitSilent;
+  late RaiseSOS raiseSos;
+  late PresenceViewModel vm;
+
+  setUp(() {
+    repo      = FakePresenceRepository();
+    publisher = FakePresencePublisher();
+    setManual  = SetManualStatus(repository: repo, publisher: publisher);
+    enterSilent = EnterSilentMode(repository: repo);
+    exitSilent  = ExitSilentMode(repository: repo);
+    raiseSos    = RaiseSOS(repository: repo, publisher: publisher);
+    vm = PresenceViewModel(repository: repo);
+  });
+
+  tearDown(() {
+    repo.dispose();
+    vm.dispose();
+  });
+
+  test('ciclo completo Normal→Manual→Silent→Normal→SOS', () async {
+    // Recolectar estados emitidos por el VM
+    final emitted = <PresenceState>[];
+    await vm.init();
+    vm.stateStream.listen(emitted.add);
+
+    // Estado inicial
+    expect(vm.currentSnapshot, isA<Normal>());
+    expect((vm.currentSnapshot as Normal).currentId, StatusIds.fine);
+
+    // SetManualStatus
+    final r1 = await setManual.call(
+      statusId: 'school',
+      userId:   'u1',
+      circleId: 'c1',
+    );
+    expect(r1.isSuccess, isTrue);
+    expect(repo.lastSavedState, isA<Normal>());
+    final n1 = repo.lastSavedState as Normal;
+    expect(n1.currentId,    'school');
+    expect(n1.lastManualId, 'school');
+
+    // EnterSilentMode
+    final r2 = await enterSilent.call(userId: 'u1');
+    expect(r2.isSuccess, isTrue);
+    expect(repo.lastSavedState, isA<SilentMode>());
+    expect((repo.lastSavedState as SilentMode).preSilentId, 'school');
+
+    // ExitSilentMode
+    final r3 = await exitSilent.call(userId: 'u1');
+    expect(r3.isSuccess, isTrue);
+    expect(repo.lastSavedState, isA<Normal>());
+    final n3 = repo.lastSavedState as Normal;
+    expect(n3.currentId,    'school');
+    expect(n3.lastManualId, 'school');
+
+    // RaiseSOS
+    final r4 = await raiseSos.call(
+      userId:    'u1',
+      circleId:  'c1',
+      latitude:  4.7110,
+      longitude: -74.0721,
+    );
+    expect(r4.isSuccess, isTrue);
+    expect(repo.lastSavedState, isA<SOSActive>());
+    final sos = repo.lastSavedState as SOSActive;
+    expect(sos.previousId, 'school');
+    expect(sos.latitude,   4.7110);
+    expect(sos.longitude,  -74.0721);
+
+    // El publisher fue llamado por SetManualStatus + RaiseSOS (2 veces)
+    expect(publisher.publishCallCount, 2);
+
+    // El VM recibió 4 estados (uno por cada transición)
+    await Future.microtask(() {});
+    expect(emitted.length, 4);
+    expect(emitted[0], isA<Normal>());
+    expect(emitted[1], isA<SilentMode>());
+    expect(emitted[2], isA<Normal>());
+    expect(emitted[3], isA<SOSActive>());
+  });
+
+  test('PresenceViewModel.currentSnapshot se actualiza tras cada transición', () async {
+    await vm.init();
+
+    await setManual.call(statusId: 'work', userId: 'u1', circleId: 'c1');
+    await Future.microtask(() {});
+    expect((vm.currentSnapshot as Normal).currentId, 'work');
+
+    await enterSilent.call(userId: 'u1');
+    await Future.microtask(() {});
+    expect(vm.currentSnapshot, isA<SilentMode>());
+
+    await exitSilent.call(userId: 'u1');
+    await Future.microtask(() {});
+    expect((vm.currentSnapshot as Normal).currentId, 'work');
+  });
+
+  test('SetManualStatus con statusId=sos compila y devuelve Success (bloqueo es deuda Sem 4)', () async {
+    // El bloqueo de zona activa viene de StatusService._blockedZoneStatusIds
+    // y se migra al dominio en Sem 4. En Sem 2 el use case no bloquea.
+    final r = await setManual.call(
+      statusId: StatusIds.sos,
+      userId:   'u1',
+      circleId: 'c1',
+    );
+    expect(r.isSuccess, isTrue);
+  });
+
+  test('PresenceViewModel antes de init — currentSnapshot es null', () {
+    expect(vm.currentSnapshot, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- `PresenceViewModel` — expone `Stream<PresenceState>` a la capa de presentación; clase pura Dart, sin widget ni ChangeNotifier (conexión a UI en Sem 5)
- `presence_module.dart` — reemplaza placeholder con registro completo: `PresenceRepository`, `PresencePublisher`, 4 use cases (`SetManualStatus`, `EnterSilentMode`, `ExitSilentMode`, `RaiseSOS`), y `PresenceViewModel`
- Test de integración `presence_integration_test.dart` — ciclo completo de transiciones con fakes (Normal → Manual → Silent → Normal → SOS) + verificación de `PresenceViewModel.stateStream`
- Documento `02-semana-2-Dia-5.md` — plan y criterios de done para este día

## Estado
- 87 tests ✅ / 1 skip (FirestorePresencePublisher — pendiente `fake_cloud_firestore`)
- `flutter analyze` 394 issues (baseline, 0 nuevos)
- Ningún archivo de producción activa modificado (StatusService, SilentFunctionalityCoordinator, widgets intactos)

## Referencia
Sem 2 Día 5 de [02-semana-2-presence.md](docs/dev/refactor-arch-2026-q2/02-semana-2-presence.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)