### PR TITLE
fix(status): use Firestore cache read to eliminate post-Doze latency

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -144,14 +144,16 @@ class StatusService {
         }
       }
 
-      // Leer el estado actual del usuario para verificar si estaba en una zona.
-      // Timeout de 8s: si la conexión está fría, usar fallback null (wasInZone=false).
+      // Leer estado actual desde caché local (InCircleView mantiene .snapshots() activo).
+      // Source.cache evita reconexión WebSocket tras Doze — fallback wasInZone=false si no hay caché.
       Map<String, dynamic>? currentMemberStatus;
       try {
         final circleDoc = await FirebaseFirestore.instance
-            .collection('circles').doc(circleId).get()
-            .timeout(const Duration(seconds: 8));
+            .collection('circles').doc(circleId).get(const GetOptions(source: Source.cache))
+            .timeout(const Duration(seconds: 2));
         currentMemberStatus = circleDoc.data()?['memberStatus'] as Map<String, dynamic>?;
+      } on FirebaseException {
+        log('[StatusService] ⚠️ circleDoc no en caché — usando fallback wasInZone=false');
       } on TimeoutException {
         log('[StatusService] ⚠️ circleDoc.get() timeout — usando fallback wasInZone=false');
       }


### PR DESCRIPTION
## Summary
- `StatusService.updateUserStatus` leía `circleDoc` sin `Source.cache`, forzando reconexión TCP+TLS+WebSocket tras Android Doze
- Reemplazado por `get(const GetOptions(source: Source.cache))` — seguro porque `InCircleView._listenToStatusChanges()` mantiene el caché SQLite local siempre actualizado
- Timeout reducido de 8s → 2s; se agrega catch de `FirebaseException` (documento no en caché) con fallback `wasInZone=false`

## Bug
**AUTH-20260509-001** — Selección de emoji congela la UI 5–6s tras largo tiempo en Silent Mode

## Test plan
- [ ] Dejar la app en Silent Mode por ≥15 minutos (pantalla apagada)
- [ ] Reabrir la app y seleccionar un emoji/estado desde el modal del Círculo
- [ ] Verificar que el modal se cierra en ≤1s (sin lag visible)
- [ ] Verificar que el estado nuevo aparece en Firestore correctamente
- [ ] Verificar que el flujo con zona activa (geofencing) sigue preservando `zoneId`/`zoneName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)