### PR TITLE
fix(bridge): fallback zync/keep_alive cuando nunakin/bridge sin handler (AUTH-20260512-001)

### DIFF
--- a/lib/platform/bridge/android_native_bridge.dart
+++ b/lib/platform/bridge/android_native_bridge.dart
@@ -24,14 +24,29 @@ class AndroidNativeBridge implements NativeBridge {
   @override
   Stream<NativeEvent> get events => _eventController.stream;
 
+  @visibleForTesting
+  static const legacyChannelName = 'zync/keep_alive';
+
   @override
   Future<T> invoke<T>(NativeCommand<T> cmd) async {
     switch (cmd) {
       case ActivateSilentMode():
-        await _channel.invokeMethod<void>('activateSilentMode');
+        await _channel
+            .invokeMethod<void>('activateSilentMode')
+            .timeout(
+              const Duration(seconds: 3),
+              onTimeout: () => const MethodChannel(legacyChannelName)
+                  .invokeMethod<void>('activate'),
+            );
         return null as T;
       case DeactivateSilentMode():
-        await _channel.invokeMethod<void>('deactivateSilentMode');
+        await _channel
+            .invokeMethod<void>('deactivateSilentMode')
+            .timeout(
+              const Duration(seconds: 3),
+              onTimeout: () => const MethodChannel(legacyChannelName)
+                  .invokeMethod<void>('deactivate'),
+            );
         return null as T;
       // TODO(sem3-día3+): GetCurrentLocation, SetUserSession, ClearSession
       default:


### PR DESCRIPTION
## Summary
- `AndroidNativeBridge.invoke(ActivateSilentMode/DeactivateSilentMode)` llamaba a `MethodChannel('nunakin/bridge')` que no tiene handler Kotlin cuando `USE_LEGACY_BRIDGE=true` — el Future quedaba suspendido indefinidamente
- Fix: timeout de 3s + fallback al canal legacy `zync/keep_alive` con métodos `activate`/`deactivate` que sí tienen handler registrado
- Regresión introducida por PR #163 (Sem 3 Día 2)

## Test plan
- [x] `flutter test` — 103 ✅ / 1 skip pre-existente
- [ ] Prueba manual en dispositivo: Modo Silencio activa/desactiva en ≤3s

🤖 Generated with Claude Code