### PR TITLE
fix(AUTH-20260513-001): enableNetwork pre-commit + lastKnownStatusId fallback

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -264,7 +264,24 @@ class StatusService {
       // SOLUCIÓN: Timeout de 10s. TimeoutException capturada abajo →
       //   StatusUpdateResult.error() → callers cierran el modal.
       // ════════════════════════════════════════════════════════════
-      await batch.commit().timeout(const Duration(seconds: 10));
+      // ════════════════════════════════════════════════════════════
+      // [FIX] Forzar reapertura de WebSocket antes de batch.commit (AUTH-20260513-001)
+      // Fecha: 2026-05-13
+      // PROBLEMA: Tras Android Doze / background prolongado, el WebSocket de
+      //   Firestore queda cerrado. batch.commit() con serverTimestamp() bloquea
+      //   porque no hay canal abierto para confirmar la escritura.
+      // SOLUCIÓN: enableNetwork() fuerza reconexión del WebSocket antes del
+      //   commit. Timeout de 3s para no retrasar el happy path. Errores ignorados:
+      //   si la red no está disponible, el commit fallará igualmente con su propio
+      //   timeout (ahora 20s), que el catch existente ya maneja.
+      // ════════════════════════════════════════════════════════════
+      try {
+        await FirebaseFirestore.instance.enableNetwork().timeout(const Duration(seconds: 3));
+        log('[StatusService] 🔌 enableNetwork() completado antes de batch.commit');
+      } catch (e) {
+        log('[StatusService] ⚠️ enableNetwork() ignorado: $e');
+      }
+      await batch.commit().timeout(const Duration(seconds: 20));
       log('[StatusService] ✅ Estado actualizado exitosamente${coordinates != null ? ' con GPS' : ''}');
 
       // ════════════════════════════════════════════════════════════
@@ -298,7 +315,11 @@ class StatusService {
 
       return StatusUpdateResult.success(newStatus, coordinates);
     } catch (e) {
-      log('[StatusService] Error actualizando estado: $e');
+      if (e is TimeoutException) {
+        log('[StatusService] ⏱️ batch.commit timeout post-Doze: $e');
+      } else {
+        log('[StatusService] Error actualizando estado: $e');
+      }
       return StatusUpdateResult.error(e.toString());
     }
   }

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -112,6 +112,16 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
   bool _isLoadingNicknames = true;
   List<StatusType>? _predefinedEmojis;
 
+  // ════════════════════════════════════════════════════════════
+  // [FIX] Último estado conocido desde SharedPreferences (AUTH-20260513-001)
+  // Fecha: 2026-05-13
+  // PROBLEMA: El modal mostraba caption "loading" en cold start antes de que
+  //   llegara el primer snapshot de Firestore.
+  // SOLUCIÓN: Leer manual_status_id → current_status_id → 'fine' al inicio
+  //   y usar ese valor como fallback en lugar del literal 'loading'.
+  // ════════════════════════════════════════════════════════════
+  String? _lastKnownStatusId;
+
   // --- INICIO DE LA MODIFICACIÓN ---
   // StreamSubscription para poder cancelarlo en dispose()
   StreamSubscription<DocumentSnapshot>? _circleListenerSubscription;
@@ -130,6 +140,7 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
   void initState() {
     super.initState();
     _loadPredefinedEmojis();
+    _loadLastKnownStatusId(); // Leer último estado conocido desde SharedPreferences
     _listenToCustomEmojis(); // Escuchar cambios en emojis personalizados
 
     // ==================== CACHE-FIRST PATTERN ====================
@@ -258,6 +269,25 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
     _geofencingService.stopMonitoring().catchError((error) {
       print('[InCircleView] ❌ Error deteniendo geofencing: $error');
     });
+  }
+
+  /// Lee el último estado conocido desde SharedPreferences para evitar mostrar
+  /// 'loading' como caption del modal en cold start (AUTH-20260513-001).
+  /// Orden de lectura: manual_status_id → current_status_id → 'fine'.
+  Future<void> _loadLastKnownStatusId() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final manualId = prefs.getString(NativeSharedKeys.manualStatusId);
+      final currentId = prefs.getString(NativeSharedKeys.currentStatusId);
+      final resolved = manualId ?? currentId ?? 'fine';
+      if (mounted) {
+        setState(() {
+          _lastKnownStatusId = resolved;
+        });
+      }
+    } catch (e) {
+      // Ignorar — el fallback 'fine' se aplica en los puntos de uso
+    }
   }
 
   /// Carga TODOS los emojis (predefinidos + personalizados) desde Firebase
@@ -732,15 +762,17 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                             // --- INICIO DE LA MODIFICACIÓN ---
                             // Obtener datos del caché. Si aún no ha llegado el primer snapshot,
                             // usa valores por defecto para evitar errores null.
+                            // [FIX AUTH-20260513-001] Usar _lastKnownStatusId como fallback
+                            // en lugar de 'loading' para evitar caption incorrecto en cold start.
                             final memberData = _memberDataCache[memberId] ??
                                 {
                                   'emoji': '⏳', // Emoji de espera inicial
-                                  'status': 'loading',
+                                  'status': _lastKnownStatusId ?? 'fine',
                                   'hasGPS': false,
                                   'coordinates': null,
                                   'lastUpdate': null,
                                 };
-                            final status = memberData['status'] ?? 'loading';
+                            final status = memberData['status'] ?? (_lastKnownStatusId ?? 'fine');
                             // --- FIN DE LA MODIFICACIÓN ---
 
                             return Padding(
@@ -790,7 +822,11 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
                                             // Usar status del stream de Firestore — siempre
                                             // actualizado, evita stale de manual_status_id
                                             // tras actualización desde modal SM.
-                                            activeStatusId = status == 'loading' ? null : status;
+                                            // [FIX AUTH-20260513-001] Si status es 'loading',
+                                            // usar _lastKnownStatusId antes de pasar null.
+                                            activeStatusId = status == 'loading'
+                                                ? _lastKnownStatusId
+                                                : status;
                                           }
                                         } catch (_) {}
                                         if (context.mounted) {


### PR DESCRIPTION
## Summary
- Bug A: Invoca `enableNetwork()` con timeout 3s antes de `batch.commit()` para pre-calentar el WebSocket de Firestore tras Doze mode; eleva timeout de commit de 10s → 20s
- Bug B: Reemplaza literal `'loading'` en memberData fallback por `_lastKnownStatusId` leído de SharedPreferences en `initState`; caption del modal nunca muestra "loading"

## Test plan
- [x] `flutter test` — 103 PASS / 0 FAIL / 1 skip pre-existente
- [ ] Dispositivo físico: app en background ≥30s → reabrir → seleccionar emoji → modal cierra <3s
- [ ] Dispositivo físico: cold start → abrir modal inmediatamente → caption muestra estado real, no "loading"

🤖 Generated with Claude Code