### PR TITLE
fix(AUTH-20260513-002): MissingPluginException fallback a zync/keep_alive en NativeBridge

### DIFF
--- a/lib/platform/bridge/android_native_bridge.dart
+++ b/lib/platform/bridge/android_native_bridge.dart
@@ -31,22 +31,27 @@ class AndroidNativeBridge implements NativeBridge {
   Future<T> invoke<T>(NativeCommand<T> cmd) async {
     switch (cmd) {
       case ActivateSilentMode():
-        await _channel
-            .invokeMethod<void>('activateSilentMode')
-            .timeout(
-              const Duration(seconds: 3),
-              onTimeout: () => const MethodChannel(legacyChannelName)
-                  .invokeMethod<void>('activate'),
-            );
+        // ════════════════════════════════════════════════════════════
+        // [FIX AUTH-20260513-002] Fallback correcto para NativeBridge en transición
+        // Fecha: 2026-05-13
+        // PROBLEMA: PR #164 usó .timeout() asumiendo que nunakin/bridge se colgaba.
+        //   En realidad, sin handler registrado (USE_LEGACY_BRIDGE=true), Flutter
+        //   lanza MissingPluginException inmediatamente — el onTimeout nunca se ejecuta.
+        // SOLUCIÓN: try/catch(MissingPluginException) → fallback a zync/keep_alive.
+        //   Cubre también el stub BridgeRouter (result.notImplemented → mismo exception).
+        // ════════════════════════════════════════════════════════════
+        try {
+          await _channel.invokeMethod<void>('activateSilentMode');
+        } on MissingPluginException {
+          await const MethodChannel(legacyChannelName).invokeMethod<void>('activate');
+        }
         return null as T;
       case DeactivateSilentMode():
-        await _channel
-            .invokeMethod<void>('deactivateSilentMode')
-            .timeout(
-              const Duration(seconds: 3),
-              onTimeout: () => const MethodChannel(legacyChannelName)
-                  .invokeMethod<void>('deactivate'),
-            );
+        try {
+          await _channel.invokeMethod<void>('deactivateSilentMode');
+        } on MissingPluginException {
+          await const MethodChannel(legacyChannelName).invokeMethod<void>('deactivate');
+        }
         return null as T;
       // TODO(sem3-día3+): GetCurrentLocation, SetUserSession, ClearSession
       default:


### PR DESCRIPTION
## Summary
- Reemplaza `.timeout(3s, onTimeout: legacy)` por `try/catch(MissingPluginException)` en `AndroidNativeBridge.invoke()`
- PR #164 asumía que `nunakin/bridge` se colgaba; en realidad lanza `MissingPluginException` inmediatamente cuando no hay handler registrado (USE_LEGACY_BRIDGE=true)
- El `onTimeout` de PR #164 nunca se ejecutaba → Silent Mode nunca llegaba al fallback `zync/keep_alive`
- Fix cubre también el estado de transición: `result.notImplemented()` en BridgeRouter también produce `MissingPluginException`

## Root cause
`nunakin/bridge` sin handler → `MissingPluginException` inmediato → `.timeout()` irrelevante → `SilentFunctionalityCoordinator.catch(e)` lo tragaba → Silent Mode no activado.

## Test plan
- [x] `flutter test` — 103 PASS / 0 FAIL / 1 skip pre-existente
- [ ] Dispositivo físico: activar Modo Silencio → app se cierra + ícono en barra de notificaciones

🤖 Generated with Claude Code