### PR TITLE
refactor(sem3-día3): status/SOS event channel + PresenceRepository sync

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/BridgeRouter.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/BridgeRouter.kt
@@ -8,6 +8,7 @@ import android.os.PowerManager
 import android.provider.Settings
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
@@ -103,12 +104,26 @@ class BridgeRouter(private val activity: Activity) {
         }
     }
 
-    /** Día 3 — updateStatus (StatusUpdateWorker → bridge) */
+    /**
+     * Emite un evento de estado actualizado hacia Flutter via `nunakin/bridge`.
+     *
+     * Llamado desde los 3 puntos de emisión en MainActivity (BroadcastReceiver,
+     * onResume, onNewIntent) cuando USE_LEGACY_BRIDGE = false.
+     * Con el flag en true los callers usan com.datainfers.zync/status_update directamente.
+     */
+    fun emitStatusEvent(messenger: BinaryMessenger, statusId: String) {
+        MethodChannel(messenger, "nunakin/bridge").invokeMethod(
+            "nativeEvent",
+            mapOf("type" to "statusUpdated", "statusId" to statusId)
+        )
+    }
+
+    /** Día 3 — Flutter→Kotlin: stub. La implementación real (actualizar notif) es Día 4. */
     fun handleStatus(call: MethodCall, result: MethodChannel.Result) {
         result.notImplemented()
     }
 
-    /** Día 3 — raiseSOS */
+    /** Día 3 — Flutter→Kotlin: stub. La lógica real de GPS y Worker se migra en Día 4. */
     fun handleSOS(call: MethodCall, result: MethodChannel.Result) {
         result.notImplemented()
     }

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -24,6 +24,7 @@ import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.embedding.engine.FlutterEngineCache
 import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
@@ -36,6 +37,10 @@ class MainActivity: FlutterActivity() {
     
     // Silent Mode — única fuente de verdad del estado. Kotlin es el dueño.
     private var isSilentModeActive = false
+
+    // Bridge path — seteados en setupBridgeRouter; null cuando USE_LEGACY_BRIDGE = true.
+    private var bridgeBinaryMessenger: BinaryMessenger? = null
+    private var activeBridgeRouter: BridgeRouter? = null
 
     // Current user (sincronizado con Flutter)
     private var currentUserId: String? = null
@@ -652,15 +657,17 @@ class MainActivity: FlutterActivity() {
 
     private fun setupBridgeRouter(flutterEngine: FlutterEngine) {
         val router = BridgeRouter(activity = this)
-        MethodChannel(
-            flutterEngine.dartExecutor.binaryMessenger,
-            "nunakin/bridge"
-        ).setMethodCallHandler { call, result ->
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+        activeBridgeRouter = router
+        bridgeBinaryMessenger = messenger
+        MethodChannel(messenger, "nunakin/bridge").setMethodCallHandler { call, result ->
             when (call.method) {
                 "activateSilentMode"   -> router.handleSilentMode(call, result)
                 "deactivateSilentMode" -> router.handleSilentMode(call, result)
                 "checkBattery"         -> router.handleSilentMode(call, result)
                 "requestBattery"       -> router.handleSilentMode(call, result)
+                "updateStatus"         -> router.handleStatus(call, result)
+                "raiseSOS"             -> router.handleSOS(call, result)
                 else                   -> result.notImplemented()
             }
         }

--- a/lib/app/di/modules/platform_module.dart
+++ b/lib/app/di/modules/platform_module.dart
@@ -9,5 +9,9 @@ import 'package:nunakin_app/shared/events/domain_event_bus.dart';
 Future<void> registerPlatformModule(GetIt sl) async {
   sl.registerLazySingleton<KvStore>(() => SharedPrefsKvStore(sl()));
   sl.registerLazySingleton<DomainEventBus>(DomainEventBus.new);
-  sl.registerLazySingleton<NativeBridge>(AndroidNativeBridge.new);
+  sl.registerLazySingleton<NativeBridge>(() {
+    final bridge = AndroidNativeBridge();
+    bridge.initialize();
+    return bridge;
+  });
 }

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -2,7 +2,11 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
+import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
+import 'package:nunakin_app/contexts/presence/application/use_cases/raise_sos.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
 import 'package:nunakin_app/contexts/presence/domain/value_objects/status_id.dart';
+import 'package:nunakin_app/app/di/injection_container.dart';
 import 'package:nunakin_app/platform/persistence/native_keys.dart';
 import 'app_badge_service.dart';
 import 'gps_service.dart';
@@ -112,6 +116,9 @@ class StatusService {
   /// - Usuario no está autenticado
   /// - Usuario no pertenece a ningún círculo
   /// - Error en Firebase
+  // TODO(sem4+): migrar callers a SetManualStatus / RaiseSOS directamente.
+  // Este método persiste como puente en Sem 3; los use cases sincronizan
+  // PresenceRepository después del batch.commit() ya existente.
   static Future<StatusUpdateResult> updateUserStatus(StatusType newStatus) async {
     try {
       log('[StatusService] Actualizando estado a: ${newStatus.description} ${newStatus.emoji}');
@@ -312,6 +319,33 @@ class StatusService {
 
       // Actualizar notificación persistente con nuevo estado
       await _updatePersistentNotification(newStatus);
+
+      // Sincronizar PresenceRepository (SharedPrefs) sin re-publicar a Firestore.
+      // El batch.commit() ya escribió el estado; aquí solo actualizamos la capa local.
+      try {
+        final repo = sl<PresenceRepository>();
+        await repo.saveState(Normal(currentId: newStatus.id, lastManualId: newStatus.id));
+        log('[StatusService] ✅ PresenceRepository sincronizado: ${newStatus.id}');
+      } catch (e) {
+        log('[StatusService] ⚠️ Error sync PresenceRepository: $e');
+      }
+
+      // Para SOS: ejecutar use case para persistir SOSActive con coordenadas GPS.
+      // NOTA: RaiseSOS llama a publisher.publish() → segunda escritura a Firestore
+      // con datos simplificados (sin zonas). Riesgo aceptado para Día 3; ver plan.
+      if (newStatus.id == StatusIds.sos && coordinates != null) {
+        try {
+          await sl<RaiseSOS>().call(
+            userId: user.uid,
+            circleId: circleId,
+            latitude: coordinates.latitude,
+            longitude: coordinates.longitude,
+          );
+          log('[StatusService] ✅ RaiseSOS use case ejecutado');
+        } catch (e) {
+          log('[StatusService] ⚠️ RaiseSOS use case error (no crítico): $e');
+        }
+      }
 
       return StatusUpdateResult.success(newStatus, coordinates);
     } catch (e) {

--- a/lib/platform/bridge/android_native_bridge.dart
+++ b/lib/platform/bridge/android_native_bridge.dart
@@ -27,6 +27,37 @@ class AndroidNativeBridge implements NativeBridge {
   @visibleForTesting
   static const legacyChannelName = 'zync/keep_alive';
 
+  /// Registra el handler para eventos entrantes desde el lado nativo (Kotlin→Dart).
+  ///
+  /// Debe llamarse una vez, después de que el FlutterEngine esté listo.
+  /// Mientras USE_LEGACY_BRIDGE = true este método se llama igualmente; el handler
+  /// queda registrado y activo cuando el flag se flipee en Día 5.
+  void initialize() {
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'nativeEvent') {
+        _handleNativeEvent(call.arguments as Map<dynamic, dynamic>);
+      }
+    });
+  }
+
+  void _handleNativeEvent(Map<dynamic, dynamic> args) {
+    final type = args['type'] as String?;
+    switch (type) {
+      case 'statusUpdated':
+        final statusId = args['statusId'] as String?;
+        if (statusId != null) {
+          _eventController.add(StatusUpdatedFromNotification(statusId));
+        }
+      case 'silentDeactivated':
+        _eventController.add(const SilentDeactivatedByUser());
+      case 'sessionCleared':
+        _eventController.add(const SessionCleared());
+      default:
+        // Evento desconocido — ignorar silenciosamente
+        break;
+    }
+  }
+
   @override
   Future<T> invoke<T>(NativeCommand<T> cmd) async {
     switch (cmd) {

--- a/test/platform/bridge/android_native_bridge_test.dart
+++ b/test/platform/bridge/android_native_bridge_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nunakin_app/platform/bridge/android_native_bridge.dart';
 import 'package:nunakin_app/platform/bridge/native_command.dart';
+import 'package:nunakin_app/platform/bridge/native_event.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -53,6 +54,75 @@ void main() {
 
     test('channelName is "nunakin/bridge"', () {
       expect(AndroidNativeBridge.channelName, 'nunakin/bridge');
+    });
+  });
+
+  group('AndroidNativeBridge events (Kotlin→Dart)', () {
+    late AndroidNativeBridge bridge;
+    const codec = StandardMethodCodec();
+
+    setUp(() {
+      bridge = AndroidNativeBridge();
+      bridge.initialize();
+    });
+
+    tearDown(() {
+      bridge.dispose();
+    });
+
+    test('statusUpdated event emits StatusUpdatedFromNotification', () async {
+      final expectation = expectLater(
+        bridge.events,
+        emits(isA<StatusUpdatedFromNotification>()
+            .having((e) => e.statusId, 'statusId', 'fine')),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        AndroidNativeBridge.channelName,
+        codec.encodeMethodCall(
+          const MethodCall('nativeEvent', {'type': 'statusUpdated', 'statusId': 'fine'}),
+        ),
+        (ByteData? _) {},
+      );
+
+      await expectation;
+    });
+
+    test('silentDeactivated event emits SilentDeactivatedByUser', () async {
+      final expectation = expectLater(
+        bridge.events,
+        emits(isA<SilentDeactivatedByUser>()),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        AndroidNativeBridge.channelName,
+        codec.encodeMethodCall(
+          const MethodCall('nativeEvent', {'type': 'silentDeactivated'}),
+        ),
+        (ByteData? _) {},
+      );
+
+      await expectation;
+    });
+
+    test('unknown event type does not emit anything', () async {
+      final events = <NativeEvent>[];
+      final sub = bridge.events.listen(events.add);
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        AndroidNativeBridge.channelName,
+        codec.encodeMethodCall(
+          const MethodCall('nativeEvent', {'type': 'unknown_xyz'}),
+        ),
+        (ByteData? _) {},
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+      expect(events, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Sem 3 Día 3: Migrar eventos status/SOS (Kotlin→Flutter)

**T1** BridgeRouter.emitStatusEvent() — emite nativeEvent via nunakin/bridge
**T2** MainActivity — campos bridge + rutas updateStatus/raiseSOS en setupBridgeRouter. Legacy emission (status_update) intacto x3.
**T3** AndroidNativeBridge.initialize() + _handleNativeEvent dispatch
**T3b** platform_module factory llama initialize()
**T4** StatusService — repo.saveState(Normal) + RaiseSOS tras batch.commit()
**T5** 3 tests nuevos (total 7/7 en verde)

Criterios: analyze 394 baseline, wc-l MainActivity 1026 ≤ 1029, build apk OK.

⚠️ Riesgo activo: USE_LEGACY_BRIDGE=true — emitStatusEvent() e initialize() listos pero inactivos hasta Día 5. Verificar flujo legacy en dispositivo antes del próximo PR.

🤖 Generated with Claude Code