### PR TITLE
chore: ignore local artifacts (memory/, screenshots, ad-hoc scripts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,16 @@ nul
 # Documentos de planificación efímera (work plans, análisis de impacto)
 WORK_PLAN_*.md
 IMPACT_*.md
+ANALYSIS_BRIEF.md
+
+# Memoria local de Claude Code (no se versiona)
+memory/
+
+# Screenshots ad-hoc en raíz (capturas de debugging)
+/image.png
+/image-*.png
+
+# Scripts ad-hoc en raíz (deuda técnica §13 — mover a scripts/ post-validación)
+/clean_and_run.ps1
+/launch_emulator.ps1
+/run_devices.ps1


### PR DESCRIPTION
## Summary
- Add .gitignore entries to prevent versioning of local Claude Code artifacts (`memory/`, `ANALYSIS_BRIEF.md`).
- Ignore ad-hoc debugging screenshots in repo root (`image.png`, `image-*.png`).
- Ignore root-level PowerShell helper scripts pending relocation per CLAUDE.md §13 tech debt note (`clean_and_run.ps1`, `launch_emulator.ps1`, `run_devices.ps1`).

## Why
Working tree had accumulated 6+ untracked local artifacts that were polluting `git status` and at risk of being accidentally committed. This is a pre-step before starting Sem 3 Día 5 to ensure a clean baseline.

## Test plan
- [x] `git status` no longer shows the ignored files after the change
- [x] No tracked file is removed (the .ps1 scripts and screenshots were never tracked, only excluded from future tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)