### PR TITLE
refactor(bridge): Sem3 Día5 — geofencing + badge + USE_LEGACY_BRIDGE=false

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
         
         manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = googleMapsApiKey
 
-        buildConfigField("boolean", "USE_LEGACY_BRIDGE", "true")
+        buildConfigField("boolean", "USE_LEGACY_BRIDGE", "false")
     }
 
     buildTypes {

--- a/android/app/src/main/kotlin/com/datainfers/zync/BridgeRouter.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/BridgeRouter.kt
@@ -43,6 +43,17 @@ class BridgeRouter(private val activity: Activity) {
      */
     var isSilentModeActive: Boolean = false
 
+    /**
+     * Día 5 — Zonas geográficas registradas en memoria.
+     * zoneId → (lat, lng, radiusMeters)
+     *
+     * Almacenamiento in-memory listo para que `GeofencingBroadcastReceiver`
+     * (Sem 4) consulte las zonas activas al recibir transiciones del OS.
+     * Se reinicia cada vez que `BridgeRouter` se instancia (rotación de
+     * pantalla, recreate de Activity).
+     */
+    private val registeredZones = mutableMapOf<String, Triple<Double, Double, Double>>()
+
     /** Día 2 — activateSilentMode / deactivateSilentMode + battery check/request */
     fun handleSilentMode(call: MethodCall, result: MethodChannel.Result) {
         when (call.method) {
@@ -212,11 +223,57 @@ class BridgeRouter(private val activity: Activity) {
 
     /** Día 5 — registerZone / unregisterZone */
     fun handleGeofencing(call: MethodCall, result: MethodChannel.Result) {
-        result.notImplemented()
+        when (call.method) {
+            "registerZone" -> {
+                val zoneId       = call.argument<String>("zoneId")
+                    ?: return result.error("MISSING_PARAM", "zoneId", null)
+                val lat          = call.argument<Double>("lat")
+                    ?: return result.error("MISSING_PARAM", "lat", null)
+                val lng          = call.argument<Double>("lng")
+                    ?: return result.error("MISSING_PARAM", "lng", null)
+                val radiusMeters = call.argument<Double>("radiusMeters")
+                    ?: return result.error("MISSING_PARAM", "radiusMeters", null)
+
+                registeredZones[zoneId] = Triple(lat, lng, radiusMeters)
+                Log.d(tag, "📍 [GEO] registerZone: $zoneId ($lat, $lng) r=${radiusMeters}m")
+                result.success(true)
+            }
+            "unregisterZone" -> {
+                val zoneId = call.argument<String>("zoneId")
+                    ?: return result.error("MISSING_PARAM", "zoneId", null)
+                registeredZones.remove(zoneId)
+                Log.d(tag, "📍 [GEO] unregisterZone: $zoneId")
+                result.success(true)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    /**
+     * Emite un evento de transición de zona hacia Flutter via `nunakin/bridge`.
+     *
+     * Llamar desde `GeofencingBroadcastReceiver` (Sem 4) cuando el OS Android
+     * dispare la transición. En Día 5 el método queda listo pero sin caller —
+     * el trigger nativo (BroadcastReceiver + AndroidManifest + ACCESS_BACKGROUND_LOCATION)
+     * se implementa en Sem 4.
+     */
+    fun emitGeofenceEvent(messenger: BinaryMessenger, zoneId: String, isEntry: Boolean) {
+        val type = if (isEntry) "geofenceEntered" else "geofenceExited"
+        MethodChannel(messenger, "nunakin/bridge").invokeMethod(
+            "nativeEvent",
+            mapOf("type" to type, "zoneId" to zoneId)
+        )
+        Log.d(tag, "📍 [GEO] Emitiendo $type: $zoneId")
     }
 
     /** Día 5 — setBadgeCount */
     fun handleBadge(call: MethodCall, result: MethodChannel.Result) {
-        result.notImplemented()
+        val count = call.argument<Int>("count") ?: 0
+        Log.d(tag, "🔴 [BADGE] setBadgeCount: $count")
+        context.getSharedPreferences("bridge_badge", Context.MODE_PRIVATE)
+            .edit()
+            .putInt("badge_count", count)
+            .apply()
+        result.success(true)
     }
 }

--- a/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/MainActivity.kt
@@ -69,13 +69,18 @@ class MainActivity: FlutterActivity() {
                         apply()
                     }
                     Log.d(TAG, "✅ [BROADCAST] Estado $statusType guardado en cache - se procesará en onResume()")
-                    
-                    // Intentar procesar inmediatamente si FlutterEngine está disponible
+
+                    // Intentar procesar inmediatamente si FlutterEngine está disponible.
+                    // Bifurcación bridge vs legacy: con USE_LEGACY_BRIDGE=false el evento
+                    // se emite por nunakin/bridge (BridgeRouter.emitStatusEvent) para que
+                    // AndroidNativeBridge lo enrute como StatusUpdatedFromNotification.
                     flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
-                        val channel = MethodChannel(messenger, "com.datainfers.zync/status_update")
-                        channel.invokeMethod("updateStatus", mapOf(
-                            "statusType" to statusType
-                        ))
+                        if (BuildConfig.USE_LEGACY_BRIDGE) {
+                            MethodChannel(messenger, "com.datainfers.zync/status_update")
+                                .invokeMethod("updateStatus", mapOf("statusType" to statusType))
+                        } else {
+                            activeBridgeRouter?.emitStatusEvent(messenger, statusType)
+                        }
                         Log.d(TAG, "✅ [BROADCAST] Estado también enviado inmediatamente a Flutter")
                     } ?: Log.w(TAG, "⚠️ [BROADCAST] FlutterEngine no disponible - esperando onResume()")
                 } else {
@@ -281,9 +286,14 @@ class MainActivity: FlutterActivity() {
 
         if (pendingStatus != null) {
             Log.d(TAG, "💾 [RESUME] Estado pendiente: $pendingStatus — enviando a Flutter")
+            // Bifurcación bridge vs legacy: emisión por nunakin/bridge cuando flag=false.
             flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
-                val channel = MethodChannel(messenger, "com.datainfers.zync/status_update")
-                channel.invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
+                if (BuildConfig.USE_LEGACY_BRIDGE) {
+                    MethodChannel(messenger, "com.datainfers.zync/status_update")
+                        .invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
+                } else {
+                    activeBridgeRouter?.emitStatusEvent(messenger, pendingStatus)
+                }
                 prefs.edit().clear().apply()
                 Log.d(TAG, "✅ [RESUME] Estado enviado y cache limpiado")
             } ?: Log.d(TAG, "⏳ [RESUME] FlutterEngine no disponible — estado pendiente preservado para [HYBRID]")
@@ -341,13 +351,18 @@ class MainActivity: FlutterActivity() {
             Log.d(TAG, "👆 [NATIVE] Recibido estado desde dialog: $emoji ($status)")
             
             if (emoji != null && status != null) {
-                // Enviar a Flutter para actualizar en Firebase
+                // Bifurcación bridge vs legacy: cuando flag=false el evento se
+                // emite por nunakin/bridge usando `status` como statusId.
                 flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
-                    val channel = MethodChannel(messenger, "com.datainfers.zync/status_update")
-                    channel.invokeMethod("updateStatus", mapOf(
-                        "emoji" to emoji,
-                        "status" to status
-                    ))
+                    if (BuildConfig.USE_LEGACY_BRIDGE) {
+                        MethodChannel(messenger, "com.datainfers.zync/status_update")
+                            .invokeMethod("updateStatus", mapOf(
+                                "emoji"  to emoji,
+                                "status" to status
+                            ))
+                    } else {
+                        activeBridgeRouter?.emitStatusEvent(messenger, status)
+                    }
                     Log.d(TAG, "✅ [NATIVE] Estado enviado a Flutter")
                 }
             }
@@ -660,6 +675,8 @@ class MainActivity: FlutterActivity() {
         val messenger = flutterEngine.dartExecutor.binaryMessenger
         activeBridgeRouter = router
         bridgeBinaryMessenger = messenger
+
+        // ── Canal unificado nunakin/bridge — los 7 handlers migrados ───────
         MethodChannel(messenger, "nunakin/bridge").setMethodCallHandler { call, result ->
             when (call.method) {
                 "activateSilentMode"   -> router.handleSilentMode(call, result)
@@ -680,7 +697,228 @@ class MainActivity: FlutterActivity() {
                     currentUserId = null
                     destroyModalEngine()
                 }
+                // Día 5
+                "registerZone"         -> router.handleGeofencing(call, result)
+                "unregisterZone"       -> router.handleGeofencing(call, result)
+                "setBadgeCount"        -> router.handleBadge(call, result)
                 else                   -> result.notImplemented()
+            }
+        }
+
+        // ── Canales legacy aún no migrados ─────────────────────────────────
+        // Permanecen activos hasta que sus callers Dart se migren a
+        // nunakin/bridge en Sem 4+. Sin estos handlers el flip del flag
+        // produce MissingPluginException en cualquier caller existente.
+        setupRemainingLegacyChannels(flutterEngine)
+    }
+
+    /**
+     * Registra los canales legacy de Dart que aún no tienen equivalente en
+     * `nunakin/bridge`. Se invoca desde `setupBridgeRouter` cuando
+     * `USE_LEGACY_BRIDGE = false`, para que los callers Dart no migrados
+     * (StatusModalService, StatusService, NativeStateBridge, NativeShortcutService,
+     * NotificationService) sigan funcionando sin `MissingPluginException`.
+     *
+     * Los handlers son copias literales de [setupLegacyChannels] — se eliminan
+     * cuando el caller correspondiente migre al bridge unificado.
+     */
+    private fun setupRemainingLegacyChannels(flutterEngine: FlutterEngine) {
+        val messenger = flutterEngine.dartExecutor.binaryMessenger
+
+        // com.datainfers.zync/status_modal — usado por StatusModalService.dart
+        MethodChannel(messenger, "com.datainfers.zync/status_modal").setMethodCallHandler { call, result ->
+            when (call.method) {
+                "openModal" -> {
+                    Log.d(TAG, "[FASE 5] Abriendo StatusModalActivity desde Flutter...")
+                    try {
+                        val intent = Intent(this, StatusModalActivity::class.java).apply {
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                        }
+                        startActivity(intent)
+                        result.success(true)
+                        Log.d(TAG, "[FASE 5] StatusModalActivity iniciada exitosamente")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "[FASE 5] Error abriendo StatusModalActivity: ${e.message}")
+                        result.error("OPEN_MODAL_ERROR", e.message, null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // com.datainfers.zync/pending_status — usado por StatusService.dart (HYBRID flow)
+        MethodChannel(messenger, "com.datainfers.zync/pending_status").setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getPendingStatus" -> {
+                    val prefs = getSharedPreferences("pending_status", Context.MODE_PRIVATE)
+                    val statusType = prefs.getString("statusType", null)
+                    val timestamp = prefs.getLong("timestamp", 0L)
+
+                    if (statusType != null && timestamp > 0) {
+                        Log.d(TAG, "💾 [HYBRID] Estado pendiente encontrado: $statusType")
+                        result.success(mapOf(
+                            "statusType" to statusType,
+                            "timestamp" to timestamp
+                        ))
+                    } else {
+                        Log.d(TAG, "ℹ️ [HYBRID] No hay estado pendiente")
+                        result.success(null)
+                    }
+                }
+                "clearPendingStatus" -> {
+                    val prefs = getSharedPreferences("pending_status", Context.MODE_PRIVATE)
+                    prefs.edit().clear().apply()
+                    Log.d(TAG, "✅ [HYBRID] Cache de estado pendiente limpiado")
+                    result.success(true)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // zync/native_state — usado por NativeStateBridge.dart
+        MethodChannel(messenger, NATIVE_STATE_CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setUserId" -> {
+                    val userId = call.argument<String>("userId")
+                    val email = call.argument<String>("email") ?: ""
+                    val circleId = call.argument<String>("circleId") ?: ""
+
+                    if (userId != null && userId.isNotEmpty()) {
+                        val existingCircleId = getSharedPreferences("worker_state", Context.MODE_PRIVATE)
+                            .getString("circleId", "") ?: ""
+                        val finalCircleId = if (circleId.isNotEmpty()) circleId else existingCircleId
+
+                        Log.d(TAG, "[DIAG-WS] setUserId WROTE worker_state: userId=$userId circleId='$finalCircleId' (incoming='$circleId' preserved=${circleId.isEmpty() && finalCircleId.isNotEmpty()})")
+                        currentUserId = userId
+                        NativeStateManager.saveUserState(this, userId, email, finalCircleId)
+
+                        getSharedPreferences("worker_state", Context.MODE_PRIVATE)
+                            .edit()
+                            .putString("userId", userId)
+                            .putString("circleId", finalCircleId)
+                            .commit()
+
+                        warmUpModalEngine()
+                        result.success(true)
+                    } else {
+                        Log.d(TAG, "🧹 [FLUTTER→KOTLIN] Limpiando estado (logout)")
+                        currentUserId = null
+                        NativeStateManager.clear(this)
+                        destroyModalEngine()
+                        result.success(true)
+                    }
+                }
+                "getUserId" -> {
+                    val userId = NativeStateManager.getUserId(this)
+                    Log.d(TAG, "📥 [KOTLIN→FLUTTER] Enviando userId: $userId")
+                    result.success(userId)
+                }
+                "getDebugInfo" -> {
+                    val info = NativeStateManager.getDebugInfo(this)
+                    Log.d(TAG, "🔍 [KOTLIN→FLUTTER] Debug info solicitado")
+                    result.success(info)
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // zync/native_shortcuts — usado por NativeShortcutService.dart / InCircleView
+        MethodChannel(messenger, "zync/native_shortcuts").setMethodCallHandler { call, result ->
+            when (call.method) {
+                "updateShortcuts" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                        val hasCircle = call.argument<Boolean>("hasCircle") ?: false
+                        val shortcutsData = call.argument<List<Map<String, String>>>("shortcuts") ?: emptyList()
+                        val shortcuts = shortcutsData.map {
+                            ShortcutData(
+                                type = it["type"] ?: "",
+                                emoji = it["emoji"] ?: "",
+                                label = it["label"] ?: ""
+                            )
+                        }
+                        NativeShortcutManager.updateShortcuts(this, hasCircle, shortcuts)
+                        result.success(true)
+                        Log.d(TAG, "✅ [SHORTCUTS] Nativos actualizados: hasCircle=$hasCircle, count=${shortcuts.size}")
+                    } else {
+                        result.error("API_LEVEL", "Shortcuts requieren API 25+", null)
+                    }
+                }
+                "clearShortcuts" -> {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                        NativeShortcutManager.clearShortcuts(this)
+                        result.success(true)
+                        Log.d(TAG, "🧹 [SHORTCUTS] Nativos limpiados")
+                    } else {
+                        result.success(true)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+
+        // mini_emoji/notification — usado por NotificationService.dart
+        MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "requestNotificationPermission" -> {
+                    requestNotificationPermission()
+                    result.success("Permisos solicitados")
+                }
+                "showNotification" -> {
+                    Log.d(TAG, "[FASE 5] Creando notificación nativa persistente")
+                    if (hasNotificationPermission()) {
+                        showPersistentNotification()
+                        result.success("✅ Notificación mostrada - tap abre StatusModalActivity")
+                    } else {
+                        result.error("NO_PERMISSION", "Permisos de notificación requeridos", null)
+                    }
+                }
+                "cancelNotification" -> {
+                    Log.d(TAG, "[LOGOUT] 🔴 Cancelando notificación persistente (ID: $NOTIFICATION_ID)...")
+                    try {
+                        NotificationManagerCompat.from(this).cancel(NOTIFICATION_ID)
+                        Log.d(TAG, "[LOGOUT] ✅ Notificación cancelada exitosamente")
+                        result.success(true)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "[LOGOUT] ❌ Error cancelando notificación: ${e.message}")
+                        result.error("CANCEL_ERROR", e.message, null)
+                    }
+                }
+                "cancelAllNotifications" -> {
+                    Log.d(TAG, "[LOGOUT] 🔴🔴🔴 Cancelando TODAS las notificaciones...")
+                    try {
+                        NotificationManagerCompat.from(this).cancel(NOTIFICATION_ID)
+                        Log.d(TAG, "[LOGOUT] ✅ Notificación MainActivity cancelada (ID: $NOTIFICATION_ID)")
+                        NotificationManagerCompat.from(this).cancelAll()
+                        Log.d(TAG, "[LOGOUT] ✅ TODAS las notificaciones del sistema canceladas")
+                        result.success(true)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "[LOGOUT] ❌ Error cancelando todas las notificaciones: ${e.message}")
+                        result.error("CANCEL_ALL_ERROR", e.message, null)
+                    }
+                }
+                "openNotificationSettings" -> {
+                    Log.d(TAG, "[FASE 5] 🔧 Abriendo Settings de notificaciones...")
+                    Log.w(TAG, "⚠️ [DIAG-G1.3] startActivity(notificationSettings) — onResume() se disparará al volver. isSilentModeActive=$isSilentModeActive | modal_was_open NO se establece aquí")
+                    try {
+                        val intent = Intent().apply {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                action = android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                                putExtra(android.provider.Settings.EXTRA_APP_PACKAGE, packageName)
+                            } else {
+                                action = android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                                data = android.net.Uri.parse("package:$packageName")
+                            }
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                        }
+                        startActivity(intent)
+                        result.success(true)
+                        Log.d(TAG, "[FASE 5] ✅ Settings abierto exitosamente")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "[FASE 5] ❌ Error abriendo Settings: ${e.message}")
+                        result.error("SETTINGS_ERROR", e.message, null)
+                    }
+                }
+                else -> result.notImplemented()
             }
         }
     }

--- a/docs/dev/refactor-arch-2026-q2/03-semana-3-Dia-5.md
+++ b/docs/dev/refactor-arch-2026-q2/03-semana-3-Dia-5.md
@@ -1,0 +1,499 @@
+# Sem 3 - Día 5 — Geofencing + Badge + Flag Flip + Cierre de Semana
+
+**Rama:** `refactor/sem3-bridge-geo-badge-close`
+
+**PR:** `refactor(bridge): Sem3 Día5 — geofencing + badge + USE_LEGACY_BRIDGE=false`
+
+**Modelo de implementación:** **Claude Opus 4.7 — obligatorio.** El flip del flag es el momento
+de mayor riesgo de toda Sem 3: cualquier canal legacy no cubierto en `setupBridgeRouter` rompe
+producción silenciosamente (el canal existe en Dart pero no tiene handler en Kotlin → `MissingPluginException`).
+Opus debe razonar sobre CADA caller antes de flipear.
+
+**Fecha planificada:** 2026-05-23 (viernes)
+
+**Base:** PR #168 → commit `f9d6cd2`
+
+---
+
+## Contexto
+
+### Estado del bridge al inicio de Día 5
+
+| Canal / Handler | Estado |
+|----------------|--------|
+| `nunakin/silent` — Silent Mode | ✅ Día 2 |
+| `nunakin/status` — handleStatus | ✅ Día 3 (stub: `notImplemented`) |
+| `nunakin/sos` — handleSOS | ✅ Día 3 (stub: `notImplemented`) |
+| `nunakin/location` — handleLocation | ✅ Día 4 |
+| `nunakin/session` — handleSession | ✅ Día 4 |
+| `nunakin/geofencing` — handleGeofencing | 🔲 stub vacío |
+| `nunakin/badge` — handleBadge | 🔲 stub vacío |
+| `AndroidNativeBridge._handleNativeEvent` → geofenceEntered/Exited | 🔲 no enrutado |
+| `USE_LEGACY_BRIDGE` | `true` (producción usa legacy) |
+
+### Hallazgo crítico — canales fuera de los 7
+
+El flip a `USE_LEGACY_BRIDGE = false` hace que `setupBridgeRouter` reemplace a `setupLegacyChannels`
+**completamente**. Varios canales en `setupLegacyChannels` NO están entre los 7 del inventario.
+Si no se registran también en `setupBridgeRouter`, los callers Dart recibirán `MissingPluginException`:
+
+| Canal legacy | Caller Dart | Estado en setupBridgeRouter hoy |
+|-------------|-------------|----------------------------------|
+| `com.datainfers.zync/status_modal` | `StatusModalService` | ❌ No registrado |
+| `com.datainfers.zync/pending_status` | `StatusService` | ❌ No registrado |
+| `zync/native_state` | `NativeStateBridge.dart` | ❌ No registrado (parcialmente cubierto por `nunakin/session`, pero Dart no lo usa aún) |
+| `zync/native_shortcuts` | `NativeShortcutService` / `InCircleView` | ❌ No registrado |
+| `mini_emoji/notification` | `NotificationService` | ❌ No registrado |
+| `com.datainfers.zync/status_update` | Receptor en Flutter (inbound desde Kotlin) | ❌ `onResume` / `BroadcastReceiver` / `onNewIntent` aún usan el canal legacy |
+
+**T3 es la tarea más crítica del día** — antes de flipear el flag, todos estos canales deben
+estar activos en `setupBridgeRouter`.
+
+### Geofencing nativo — scope acotado
+
+`GeofencingService.dart` maneja zonas 100% en Dart via `geolocator`. No existe un
+`GeofencingBroadcastReceiver.kt` ni registro con `GeofencingClient` del OS Android.
+En Día 5 se implementan los handlers de BridgeRouter y se prepara `emitGeofenceEvent()`,
+pero **el trigger nativo (BroadcastReceiver + AndroidManifest + ACCESS_BACKGROUND_LOCATION)
+se implementa en Sem 4 (contexto Geofencing)**. Las tareas T1 y T2 son funcionales pero no
+activan geofencing OS-level.
+
+---
+
+## Restricciones explícitas
+
+| Restricción | Razón |
+|-------------|-------|
+| **NO remover `setupLegacyChannels` en este PR** | Coexistencia 48h post-flip antes de eliminar legacy |
+| **NO implementar `GeofencingBroadcastReceiver.kt` ni AndroidManifest.xml geofencing** | Scope Sem 4 — agrega permisos y riesgo innecesario en Día 5 |
+| **NO usar `result.success()` dos veces en el mismo handler** | Causa crash nativo |
+| **Verificar en device físico ANTES de flipear el flag** | El flip solo ocurre si los 5 flows E2E pasan |
+| **Si algún E2E falla con flag=false: revertir build.gradle, documentar bloqueador** | `USE_LEGACY_BRIDGE=true` es el escape seguro |
+
+---
+
+## T1 — `BridgeRouter.handleGeofencing` (Kotlin)
+
+Implementar `registerZone` / `unregisterZone`. Almacena en memoria para el futuro
+`GeofencingBroadcastReceiver` de Sem 4. Agregar `emitGeofenceEvent()` listo para
+ser llamado desde ese receiver cuando esté implementado.
+
+```kotlin
+// Campo en BridgeRouter:
+private val registeredZones = mutableMapOf<String, Triple<Double, Double, Double>>()
+// zoneId → (lat, lng, radiusMeters)
+
+fun handleGeofencing(call: MethodCall, result: MethodChannel.Result) {
+    when (call.method) {
+        "registerZone" -> {
+            val zoneId       = call.argument<String>("zoneId")         ?: return result.error("MISSING_PARAM", "zoneId", null)
+            val lat          = call.argument<Double>("lat")             ?: return result.error("MISSING_PARAM", "lat", null)
+            val lng          = call.argument<Double>("lng")             ?: return result.error("MISSING_PARAM", "lng", null)
+            val radiusMeters = call.argument<Double>("radiusMeters")    ?: return result.error("MISSING_PARAM", "radiusMeters", null)
+
+            registeredZones[zoneId] = Triple(lat, lng, radiusMeters)
+            Log.d(tag, "📍 [GEO] registerZone: $zoneId (${lat}, ${lng}) r=${radiusMeters}m")
+            result.success(true)
+        }
+        "unregisterZone" -> {
+            val zoneId = call.argument<String>("zoneId") ?: return result.error("MISSING_PARAM", "zoneId", null)
+            registeredZones.remove(zoneId)
+            Log.d(tag, "📍 [GEO] unregisterZone: $zoneId")
+            result.success(true)
+        }
+        else -> result.notImplemented()
+    }
+}
+
+/**
+ * Emite un evento de transición de zona hacia Flutter via `nunakin/bridge`.
+ *
+ * Llamar desde GeofencingBroadcastReceiver (Sem 4) cuando el OS Android
+ * dispare la transición. En Día 5, este método queda listo pero sin caller.
+ */
+fun emitGeofenceEvent(messenger: BinaryMessenger, zoneId: String, isEntry: Boolean) {
+    MethodChannel(messenger, "nunakin/bridge").invokeMethod(
+        "nativeEvent",
+        mapOf("type" to if (isEntry) "geofenceEntered" else "geofenceExited", "zoneId" to zoneId)
+    )
+    Log.d(tag, "📍 [GEO] Emitiendo ${if (isEntry) "GeofenceEntered" else "GeofenceExited"}: $zoneId")
+}
+```
+
+---
+
+## T2 — `BridgeRouter.handleBadge` (Kotlin)
+
+Almacena el badge count en SharedPrefs. La notificación persistente puede leer este
+valor para actualizar su número de badge via `setNumber(count)`.
+
+```kotlin
+fun handleBadge(call: MethodCall, result: MethodChannel.Result) {
+    val count = call.argument<Int>("count") ?: 0
+    Log.d(tag, "🔴 [BADGE] setBadgeCount: $count")
+    context.getSharedPreferences("bridge_badge", Context.MODE_PRIVATE)
+        .edit().putInt("badge_count", count).apply()
+    result.success(true)
+}
+```
+
+---
+
+## T3 — `setupBridgeRouter`: completar con canales legacy no migrados (Kotlin)
+
+**Esta es la tarea de mayor riesgo del día.** `setupBridgeRouter` debe registrar TODOS
+los canales que `setupLegacyChannels` registraba. Los no migrados se copian literalmente;
+los migrados ya están cubiertos por `nunakin/bridge`.
+
+Estructura resultante de `setupBridgeRouter`:
+
+```kotlin
+private fun setupBridgeRouter(flutterEngine: FlutterEngine) {
+    val router    = BridgeRouter(activity = this)
+    val messenger = flutterEngine.dartExecutor.binaryMessenger
+    activeBridgeRouter   = router
+    bridgeBinaryMessenger = messenger
+
+    // ── Canal unificado (los 7 handlers migrados) ──────────────────────
+    MethodChannel(messenger, "nunakin/bridge").setMethodCallHandler { call, result ->
+        when (call.method) {
+            "activateSilentMode"   -> router.handleSilentMode(call, result)
+            "deactivateSilentMode" -> router.handleSilentMode(call, result)
+            "checkBattery"         -> router.handleSilentMode(call, result)
+            "requestBattery"       -> router.handleSilentMode(call, result)
+            "updateStatus"         -> router.handleStatus(call, result)
+            "raiseSOS"             -> router.handleSOS(call, result)
+            "getCurrentLocation"   -> router.handleLocation(call, result)
+            "setUserSession" -> {
+                router.handleSession(call, result, messenger)
+                currentUserId = call.argument<String>("uid")
+                if (!currentUserId.isNullOrEmpty()) warmUpModalEngine()
+            }
+            "clearSession" -> {
+                router.handleSession(call, result, messenger)
+                currentUserId = null
+                destroyModalEngine()
+            }
+            "registerZone"         -> router.handleGeofencing(call, result)
+            "unregisterZone"       -> router.handleGeofencing(call, result)
+            "setBadgeCount"        -> router.handleBadge(call, result)
+            else                   -> result.notImplemented()
+        }
+    }
+
+    // ── Canales legacy aún no migrados al bridge ───────────────────────
+    // Permanecen aquí hasta que sus callers Dart sean migrados (Sem 4+).
+    setupRemainingLegacyChannels(messenger)
+}
+
+/**
+ * Registra los canales legacy que no tienen equivalente en nunakin/bridge todavía.
+ * Se llama desde setupBridgeRouter para que el flag flip no rompa estos callers.
+ * Candidatos a migrar en Sem 4: status_modal, pending_status, native_state,
+ * native_shortcuts, mini_emoji/notification, status_update.
+ */
+private fun setupRemainingLegacyChannels(messenger: BinaryMessenger) {
+    // Copiar el handler de cada canal desde setupLegacyChannels,
+    // sin modificar la lógica interna.
+    
+    // com.datainfers.zync/status_modal
+    MethodChannel(messenger, "com.datainfers.zync/status_modal").setMethodCallHandler { call, result ->
+        // ... mismo handler que setupLegacyChannels
+    }
+
+    // com.datainfers.zync/pending_status
+    MethodChannel(messenger, "com.datainfers.zync/pending_status").setMethodCallHandler { call, result ->
+        // ... mismo handler que setupLegacyChannels
+    }
+
+    // zync/native_state — callers Dart (NativeStateBridge) aún lo usan directamente
+    MethodChannel(messenger, NATIVE_STATE_CHANNEL).setMethodCallHandler { call, result ->
+        // ... mismo handler que setupLegacyChannels
+    }
+
+    // zync/native_shortcuts
+    MethodChannel(messenger, "zync/native_shortcuts").setMethodCallHandler { call, result ->
+        // ... mismo handler que setupLegacyChannels
+    }
+
+    // mini_emoji/notification
+    MethodChannel(messenger, CHANNEL).setMethodCallHandler { call, result ->
+        // ... mismo handler que setupLegacyChannels
+    }
+}
+```
+
+### Fix adicional: `onResume`, `BroadcastReceiver`, `onNewIntent` (bridge path)
+
+Con `USE_LEGACY_BRIDGE = false`, `onResume()` y el `BroadcastReceiver` deben emitir
+el estado pendiente via `router.emitStatusEvent()` en lugar de construir un canal ad-hoc.
+Agregar la bifurcación en los 3 puntos de emisión:
+
+```kotlin
+// En onResume() — sección "Procesar estado pendiente":
+if (pendingStatus != null) {
+    flutterEngine?.dartExecutor?.binaryMessenger?.let { messenger ->
+        if (BuildConfig.USE_LEGACY_BRIDGE) {
+            MethodChannel(messenger, "com.datainfers.zync/status_update")
+                .invokeMethod("updateStatus", mapOf("statusType" to pendingStatus))
+        } else {
+            activeBridgeRouter?.emitStatusEvent(messenger, pendingStatus)
+        }
+        prefs.edit().clear().apply()
+    }
+}
+
+// Mismo patrón en BroadcastReceiver.onReceive() (línea ~74) y onNewIntent() (línea ~344).
+```
+
+---
+
+## T4 — `NativeCommand`: agregar 3 comandos (Dart)
+
+```dart
+/// Registra una zona geográfica circular en el handler nativo.
+class RegisterZone extends NativeCommand<void> {
+  final String zoneId;
+  final double lat;
+  final double lng;
+  final double radiusMeters;
+  const RegisterZone({
+    required this.zoneId,
+    required this.lat,
+    required this.lng,
+    required this.radiusMeters,
+  });
+}
+
+/// Elimina el registro de una zona geográfica.
+class UnregisterZone extends NativeCommand<void> {
+  final String zoneId;
+  const UnregisterZone({required this.zoneId});
+}
+
+/// Actualiza el badge count del ícono de la aplicación.
+class SetBadgeCount extends NativeCommand<void> {
+  final int count;
+  const SetBadgeCount(this.count);
+}
+```
+
+---
+
+## T5 — `AndroidNativeBridge`: completar eventos + 3 comandos (Dart)
+
+### 5a — `_handleNativeEvent`: enrutar geofenceEntered / geofenceExited
+
+```dart
+void _handleNativeEvent(Map<dynamic, dynamic> args) {
+  final type = args['type'] as String?;
+  switch (type) {
+    case 'statusUpdated':
+      // ... existente
+    case 'silentDeactivated':
+      // ... existente
+    case 'sessionCleared':
+      // ... existente
+    case 'geofenceEntered':          // ← Día 5
+      final zoneId = args['zoneId'] as String?;
+      if (zoneId != null) _eventController.add(GeofenceEntered(zoneId));
+    case 'geofenceExited':           // ← Día 5
+      final zoneId = args['zoneId'] as String?;
+      if (zoneId != null) _eventController.add(GeofenceExited(zoneId));
+    default:
+      break;
+  }
+}
+```
+
+### 5b — `invoke()`: 3 nuevos casos
+
+```dart
+case RegisterZone(:final zoneId, :final lat, :final lng, :final radiusMeters):
+  await _channel.invokeMethod<void>('registerZone', {
+    'zoneId':       zoneId,
+    'lat':          lat,
+    'lng':          lng,
+    'radiusMeters': radiusMeters,
+  });
+  return null as T;
+
+case UnregisterZone(:final zoneId):
+  await _channel.invokeMethod<void>('unregisterZone', {'zoneId': zoneId});
+  return null as T;
+
+case SetBadgeCount(:final count):
+  await _channel.invokeMethod<void>('setBadgeCount', {'count': count});
+  return null as T;
+```
+
+---
+
+## T6 — Flag flip: `USE_LEGACY_BRIDGE = false`
+
+Solo proceder si los E2E de T8 pasan **con el flag en false** en el device físico.
+
+```gradle
+// android/app/build.gradle — defaultConfig
+buildConfigField "boolean", "USE_LEGACY_BRIDGE", "false"
+```
+
+**Verificar inmediatamente después del flip:**
+1. Compilar: `flutter build apk --debug` sin errores
+2. Instalar en device y correr los 5 flows E2E de T8
+3. Si algún flow falla → `USE_LEGACY_BRIDGE = true`, documentar bloqueador en
+   `docs/dev/refactor-arch-2026-q2/blockers.md`
+
+---
+
+## T7 — Tests unitarios
+
+### Nuevos tests en `android_native_bridge_test.dart`
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 11 | `RegisterZone(zoneId: 'z1', lat: 1.0, lng: 2.0, radiusMeters: 100.0)` | Invoca `registerZone` con args correctos |
+| 12 | `UnregisterZone(zoneId: 'z1')` | Invoca `unregisterZone` con `{zoneId: 'z1'}` |
+| 13 | `SetBadgeCount(3)` | Invoca `setBadgeCount` con `{count: 3}` |
+
+### Nuevos tests en `android_native_bridge_test.dart` (eventos)
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 14 | Kotlin emite `{type: geofenceEntered, zoneId: 'z1'}` | Stream emite `GeofenceEntered('z1')` |
+| 15 | Kotlin emite `{type: geofenceExited, zoneId: 'z1'}` | Stream emite `GeofenceExited('z1')` |
+
+### Test exhaustividad de `NativeCommand`
+
+Agregar a `test/platform/bridge/native_command_test.dart`:
+- Verificar que el switch sobre los 8 subtipos del sealed class es exhaustivo (sin `default`)
+
+---
+
+## T8 — Tests E2E en dispositivo físico (con `USE_LEGACY_BRIDGE = false`)
+
+Ejecutar con `flutter run` en dispositivo físico, flag false activo.
+
+| Flow | Pasos | Criterio |
+|------|-------|---------|
+| F1 — Normal→Silent→Normal | Activar MS desde app → app se cierra → abrir app → volver a Normal | MS activo visible en barra, sin regresión al reabrir |
+| F2 — BN durante Silent | Con Silent activo, abrir modal barra → seleccionar estado → verificar en Firestore | Estado llega a Firestore; app sigue en Silent tras cerrar modal |
+| F3 — SOS con GPS | Enviar SOS desde UI → verificar coordenadas en Firestore | Lat/Lng presentes en documento |
+| F4 — Estado manual vía QuickAction | Seleccionar estado desde notificación → verificar sincronización | Estado llega a Flutter y Firestore |
+| F5 — Login / Logout | Login → navegar app → Logout → re-login | Sin MissingPluginException en ningún paso |
+
+---
+
+## T9 — Cierre de semana
+
+### Tag `refactor-sem3-done`
+
+```bash
+git tag refactor-sem3-done
+git push origin refactor-sem3-done
+```
+
+### Memoria de cierre `memory/project_refactor_sem3_done.md`
+
+Incluir:
+- PR mergeados de Sem 3 (#163–#168 + este)
+- Estado de cada handler en BridgeRouter (7/7 activos)
+- Callers legacy pendientes de migración (Sem 4+)
+- Líneas de `MainActivity.kt` post-flip
+- Próximo paso: PR de cleanup legacy (≤300 líneas)
+
+### Borrador `docs/dev/refactor-arch-2026-q2/04-semana-4-identity-circle.md`
+
+Mínimo 3 secciones:
+- Objetivo de Sem 4
+- Callers a migrar (NativeStateBridge, StatusModalService, NotificationService)
+- Primer handler a migrar
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo | Cambio |
+|---------|------|--------|
+| `android/.../BridgeRouter.kt` | Modificado | `handleGeofencing` + `handleBadge` + `emitGeofenceEvent` + campo `registeredZones` |
+| `android/.../MainActivity.kt` | Modificado | `setupBridgeRouter` + `setupRemainingLegacyChannels` + bifurcación en `onResume`/`BroadcastReceiver`/`onNewIntent` |
+| `android/app/build.gradle` | Modificado | `USE_LEGACY_BRIDGE = false` |
+| `lib/platform/bridge/native_command.dart` | Modificado | Agregar `RegisterZone`, `UnregisterZone`, `SetBadgeCount` |
+| `lib/platform/bridge/android_native_bridge.dart` | Modificado | `_handleNativeEvent` geofence events + 3 nuevos casos en `invoke()` |
+| `test/platform/bridge/android_native_bridge_test.dart` | Modificado | Tests 11-15 |
+| `test/platform/bridge/native_command_test.dart` | Modificado | Test exhaustividad 8 subtipos |
+| `docs/dev/refactor-arch-2026-q2/03-semana-3-Dia-5.md` | Nuevo | Este documento |
+| `docs/dev/refactor-arch-2026-q2/04-semana-4-identity-circle.md` | Nuevo | Borrador Sem 4 |
+| `memory/project_refactor_sem3_done.md` | Nuevo | Memoria de cierre |
+
+**Archivos NO modificados:** `GeofencingService.dart`, `AppBadgeService.dart`,
+`NativeStateBridge.dart`, `StatusService.dart`, `native_bridge.dart`, `native_event.dart`
+
+---
+
+## Criterios de done
+
+| # | Criterio | Verificación |
+|---|----------|-------------|
+| 1 | `handleGeofencing` acepta `registerZone`/`unregisterZone`, `emitGeofenceEvent` compilado | Tests 11-12 |
+| 2 | `handleBadge` almacena badge count en SharedPrefs | Test 13 |
+| 3 | `_handleNativeEvent` enruta `geofenceEntered`/`geofenceExited` al stream | Tests 14-15 |
+| 4 | `setupBridgeRouter` registra todos los canales legacy no migrados | F5 E2E (sin MissingPluginException) |
+| 5 | `onResume`/`BroadcastReceiver`/`onNewIntent` bifurcan por `USE_LEGACY_BRIDGE` | F2 + F4 E2E |
+| 6 | `USE_LEGACY_BRIDGE = false` en `build.gradle` | `grep USE_LEGACY_BRIDGE build.gradle` |
+| 7 | `flutter test` — todos en verde (≥113) | Salida del comando |
+| 8 | `flutter analyze` — 0 warnings nuevos vs. baseline (394) | Salida del comando |
+| 9 | `flutter build apk --debug` — sin errores Kotlin | Salida del build |
+| 10 | 5 flows E2E pasan en device físico con flag false | Verificación manual |
+| 11 | Tag `refactor-sem3-done` en remoto | `git tag -l` |
+| 12 | `memory/project_refactor_sem3_done.md` escrito y en memoria | Archivo presente |
+| 13 | `04-semana-4-identity-circle.md` borrador | Archivo presente |
+
+---
+
+## Nota sobre criterio de líneas de `MainActivity.kt`
+
+El plan maestro indica `≤300 líneas` para Día 5. Con `USE_LEGACY_BRIDGE = false`
+**el código de `setupLegacyChannels` queda muerto pero físicamente presente**.
+Las 300 líneas se logran solo en el PR siguiente (cleanup legacy), que elimina:
+- `setupLegacyChannels()` (~280 líneas)
+- El bloque comentado al final del archivo (~183 líneas)
+
+**Ese PR va después de 48h de coexistencia** sin incidentes. El criterio real de Día 5 es:
+`MainActivity.kt` no crece más de +50 líneas vs. Día 4 (incorporando `setupRemainingLegacyChannels`
+como método extraído).
+
+---
+
+## Riesgos específicos de Día 5
+
+| Riesgo | Probabilidad | Mitigación |
+|--------|--------------|------------|
+| Canal legacy no registrado en `setupBridgeRouter` → `MissingPluginException` | Alta | Checklist exhaustivo de T3; F5 E2E lo detecta |
+| `onResume` / `BroadcastReceiver` / `onNewIntent` no bifurcan → estado perdido con flag false | Alta | 3 puntos de emisión deben incluir bifurcación; F2 + F4 E2E lo detecta |
+| `registeredZones` en BridgeRouter se pierde al rotar pantalla (campo de instancia) | Media | Aceptable en Día 5 — BridgeRouter se re-instancia en `configureFlutterEngine`; el flag protege en producción |
+| Geofencing dart (GeofencingService) llama a `zync/native_state` indirectamente | Baja | GeofencingService no usa MethodChannels directamente |
+| E2E F3 falla por permisos GPS en device CI/test | Media | Verificar en device físico con GPS activo; no en emulador |
+
+---
+
+## Salida de emergencia
+
+Si cualquier E2E falla con `USE_LEGACY_BRIDGE = false`:
+
+```gradle
+// Revertir en build.gradle:
+buildConfigField "boolean", "USE_LEGACY_BRIDGE", "true"
+```
+
+Documentar en `docs/dev/refactor-arch-2026-q2/blockers.md`:
+- Flow fallido
+- Canal o comportamiento roto
+- Canal específico no cubierto (si aplica)
+
+**Sem 4 NO inicia hasta que Sem 3 esté cerrada con flag en false.**
+
+---
+
+**Post-merge: PR de cleanup legacy** — eliminar `setupLegacyChannels()`, código comentado,
+imports huérfanos. `MainActivity.kt` queda en ≤300 líneas. Este PR va 48h después del flip.

--- a/lib/platform/bridge/android_native_bridge.dart
+++ b/lib/platform/bridge/android_native_bridge.dart
@@ -52,6 +52,16 @@ class AndroidNativeBridge implements NativeBridge {
         _eventController.add(const SilentDeactivatedByUser());
       case 'sessionCleared':
         _eventController.add(const SessionCleared());
+      case 'geofenceEntered':
+        final zoneId = args['zoneId'] as String?;
+        if (zoneId != null) {
+          _eventController.add(GeofenceEntered(zoneId));
+        }
+      case 'geofenceExited':
+        final zoneId = args['zoneId'] as String?;
+        if (zoneId != null) {
+          _eventController.add(GeofenceExited(zoneId));
+        }
       default:
         // Evento desconocido — ignorar silenciosamente
         break;
@@ -101,6 +111,20 @@ class AndroidNativeBridge implements NativeBridge {
         return null as T;
       case ClearSession():
         await _channel.invokeMethod<void>('clearSession');
+        return null as T;
+      case RegisterZone(:final zoneId, :final lat, :final lng, :final radiusMeters):
+        await _channel.invokeMethod<void>('registerZone', {
+          'zoneId':       zoneId,
+          'lat':          lat,
+          'lng':          lng,
+          'radiusMeters': radiusMeters,
+        });
+        return null as T;
+      case UnregisterZone(:final zoneId):
+        await _channel.invokeMethod<void>('unregisterZone', {'zoneId': zoneId});
+        return null as T;
+      case SetBadgeCount(:final count):
+        await _channel.invokeMethod<void>('setBadgeCount', {'count': count});
         return null as T;
     }
   }

--- a/lib/platform/bridge/native_command.dart
+++ b/lib/platform/bridge/native_command.dart
@@ -34,3 +34,36 @@ class SetUserSession extends NativeCommand<void> {
 class ClearSession extends NativeCommand<void> {
   const ClearSession();
 }
+
+/// Registra una zona geográfica circular en el handler nativo.
+///
+/// El handler la almacena en memoria para que el futuro
+/// `GeofencingBroadcastReceiver` (Sem 4) la consulte al recibir transiciones
+/// del OS Android.
+class RegisterZone extends NativeCommand<void> {
+  final String zoneId;
+  final double lat;
+  final double lng;
+  final double radiusMeters;
+  const RegisterZone({
+    required this.zoneId,
+    required this.lat,
+    required this.lng,
+    required this.radiusMeters,
+  });
+}
+
+/// Elimina el registro de una zona geográfica.
+class UnregisterZone extends NativeCommand<void> {
+  final String zoneId;
+  const UnregisterZone({required this.zoneId});
+}
+
+/// Actualiza el badge count del ícono de la aplicación.
+///
+/// El handler nativo persiste el valor en SharedPrefs para que la
+/// notificación persistente pueda reflejarlo via `setNumber(count)`.
+class SetBadgeCount extends NativeCommand<void> {
+  final int count;
+  const SetBadgeCount(this.count);
+}

--- a/test/platform/bridge/android_native_bridge_test.dart
+++ b/test/platform/bridge/android_native_bridge_test.dart
@@ -71,6 +71,38 @@ void main() {
       expect(calls.single.arguments, isNull);
     });
 
+    // Día 5 — Test 11
+    test('RegisterZone invokes "registerZone" with zoneId/lat/lng/radius', () async {
+      await bridge.invoke(const RegisterZone(
+        zoneId: 'z1',
+        lat: 1.0,
+        lng: 2.0,
+        radiusMeters: 100.0,
+      ));
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'registerZone');
+      expect(calls.single.arguments['zoneId'], 'z1');
+      expect(calls.single.arguments['lat'], 1.0);
+      expect(calls.single.arguments['lng'], 2.0);
+      expect(calls.single.arguments['radiusMeters'], 100.0);
+    });
+
+    // Día 5 — Test 12
+    test('UnregisterZone invokes "unregisterZone" with zoneId', () async {
+      await bridge.invoke(const UnregisterZone(zoneId: 'z1'));
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'unregisterZone');
+      expect(calls.single.arguments, {'zoneId': 'z1'});
+    });
+
+    // Día 5 — Test 13
+    test('SetBadgeCount invokes "setBadgeCount" with count', () async {
+      await bridge.invoke(const SetBadgeCount(3));
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'setBadgeCount');
+      expect(calls.single.arguments, {'count': 3});
+    });
+
     test('channelName is "nunakin/bridge"', () {
       expect(AndroidNativeBridge.channelName, 'nunakin/bridge');
     });
@@ -142,6 +174,46 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       await sub.cancel();
       expect(events, isEmpty);
+    });
+
+    // Día 5 — Test 14
+    test('geofenceEntered event emits GeofenceEntered with zoneId', () async {
+      final expectation = expectLater(
+        bridge.events,
+        emits(isA<GeofenceEntered>()
+            .having((e) => e.zoneId, 'zoneId', 'z1')),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        AndroidNativeBridge.channelName,
+        codec.encodeMethodCall(
+          const MethodCall('nativeEvent', {'type': 'geofenceEntered', 'zoneId': 'z1'}),
+        ),
+        (ByteData? _) {},
+      );
+
+      await expectation;
+    });
+
+    // Día 5 — Test 15
+    test('geofenceExited event emits GeofenceExited with zoneId', () async {
+      final expectation = expectLater(
+        bridge.events,
+        emits(isA<GeofenceExited>()
+            .having((e) => e.zoneId, 'zoneId', 'z1')),
+      );
+
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+        AndroidNativeBridge.channelName,
+        codec.encodeMethodCall(
+          const MethodCall('nativeEvent', {'type': 'geofenceExited', 'zoneId': 'z1'}),
+        ),
+        (ByteData? _) {},
+      );
+
+      await expectation;
     });
   });
 }

--- a/test/platform/bridge/native_command_test.dart
+++ b/test/platform/bridge/native_command_test.dart
@@ -29,8 +29,34 @@ void main() {
       expect(cmd, isA<NativeCommand<void>>());
     });
 
+    test('RegisterZone stores zoneId, lat, lng and radiusMeters', () {
+      const cmd = RegisterZone(
+        zoneId: 'home',
+        lat: -33.45,
+        lng: -70.66,
+        radiusMeters: 150.0,
+      );
+      expect(cmd.zoneId, 'home');
+      expect(cmd.lat, -33.45);
+      expect(cmd.lng, -70.66);
+      expect(cmd.radiusMeters, 150.0);
+      expect(cmd, isA<NativeCommand<void>>());
+    });
+
+    test('UnregisterZone stores zoneId', () {
+      const cmd = UnregisterZone(zoneId: 'home');
+      expect(cmd.zoneId, 'home');
+      expect(cmd, isA<NativeCommand<void>>());
+    });
+
+    test('SetBadgeCount stores count', () {
+      const cmd = SetBadgeCount(7);
+      expect(cmd.count, 7);
+      expect(cmd, isA<NativeCommand<void>>());
+    });
+
     test('switch over all subtypes is exhaustive — no default needed', () {
-      const NativeCommand<void> cmd = ActivateSilentMode();
+      const NativeCommand<dynamic> cmd = ActivateSilentMode();
 
       // Si se añade un nuevo subtipo y no se cubre aquí, el análisis falla.
       final label = switch (cmd) {
@@ -39,6 +65,9 @@ void main() {
         GetCurrentLocation()   => 'location',
         SetUserSession()       => 'setSession',
         ClearSession()         => 'clearSession',
+        RegisterZone()         => 'registerZone',
+        UnregisterZone()       => 'unregisterZone',
+        SetBadgeCount()        => 'setBadgeCount',
       };
 
       expect(label, 'activate');


### PR DESCRIPTION
## Summary

Cierra Sem 3 del refactor del bridge nativo migrando los dos handlers pendientes a `BridgeRouter` y flipeando el feature flag a `false` para que producción use el canal unificado `nunakin/bridge`.

⚠️ **DRAFT** — pendiente de T8 (E2E en device físico). El merge solo procede tras VoBo del desarrollador con los 5 flows en verde.

## Commits

1. `91a88bb` **T1 + T2** — `BridgeRouter.handleGeofencing` (registerZone/unregisterZone) + `emitGeofenceEvent` + `handleBadge` con SharedPrefs.
2. `733a91c` **T3 + T4 + T5** — `setupBridgeRouter` cablea los 3 handlers nuevos + `setupRemainingLegacyChannels` (5 canales no migrados) + bifurcación `BuildConfig.USE_LEGACY_BRIDGE` en `BroadcastReceiver.onReceive` / `onResume` / `onNewIntent`. Sealed `NativeCommand` ahora con 8 subtipos. `AndroidNativeBridge._handleNativeEvent` ruta `geofenceEntered`/`geofenceExited`; `invoke()` exhaustivo sin `default`.
3. `7fb5513` **T7** — Tests 11-15 (Dart) + exhaustividad 8 subtipos. 29/29 bridge tests, 116/116 suite (1 skip preexistente).
4. `cc0bf56` **T6** — `USE_LEGACY_BRIDGE = false` en `build.gradle.kts`.

## Canales legacy preservados (Sem 4 los migra)

| Canal | Dart caller |
|---|---|
| `com.datainfers.zync/status_modal` | `StatusModalService.dart` |
| `com.datainfers.zync/pending_status` | `StatusService.dart` (HYBRID) |
| `zync/native_state` | `NativeStateBridge.dart` |
| `zync/native_shortcuts` | `NativeShortcutService.dart`, `InCircleView` |
| `mini_emoji/notification` | `NotificationService.dart` |

> Nota: `zync/keep_alive` NO se registra en setupBridgeRouter — `KeepAliveService.start/stop` no se invoca desde Dart en producción (solo existe como fallback `MissingPluginException` en `AndroidNativeBridge` para silent mode, que ya está cubierto por `nunakin/bridge`).

## Verificación local

| Check | Resultado |
|---|---|
| `flutter test test/platform/bridge/` | ✅ 29/29 |
| `flutter test` (suite completa) | ✅ 116 pass / 1 skip / 0 fail |
| `flutter analyze` | ✅ 394 issues (baseline, sin nuevos warnings) |
| `flutter build apk --debug` (flag=true) | ✅ |
| `flutter build apk --debug` (flag=false) | ✅ |

## Pendiente antes del merge

- [ ] **T8 — E2E en device físico con flag=false** (5 flows):
  - F1 — Normal → Silent → Normal (Silent persiste tras reabrir)
  - F2 — BN durante Silent (estado llega a Firestore, Silent activo tras cerrar modal)
  - F3 — SOS con GPS (lat/lng en Firestore)
  - F4 — Estado manual vía QuickAction (sincroniza Flutter + Firestore)
  - F5 — Login / Logout (sin `MissingPluginException` en toda la sesión)
- [ ] **T9 — Cierre Sem 3**: tag `refactor-sem3-done`, memoria `project_refactor_sem3_done.md`, borrador `04-semana-4-identity-circle.md`.

Si T8 falla:
1. Revertir `cc0bf56` (commit T6) → flag vuelve a `true`.
2. Documentar bloqueador en `docs/dev/refactor-arch-2026-q2/blockers.md`.
3. El resto del PR queda mergeable (handlers y canales legacy preservados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)