### PR TITLE
fix(circle-provider): handle UserCircleState sealed subtypes in stream listener

### DIFF
--- a/lib/providers/circle_provider.dart
+++ b/lib/providers/circle_provider.dart
@@ -33,10 +33,21 @@ class CircleProvider extends ChangeNotifier {
     
     _circleSubscription?.cancel();
     _circleSubscription = _service.getUserCircleStream().listen(
-      (circle) {
-        log('[CircleProvider] Stream actualizado: ${circle.name ?? 'null'}');
-        _circle = circle;
-        _status = CircleStatus.loaded;
+      (state) {
+        switch (state) {
+          case UserInCircle(:final circle):
+            log('[CircleProvider] Stream actualizado: ${circle.name}');
+            _circle = circle;
+            _status = CircleStatus.loaded;
+          case UserPendingRequest():
+            log('[CircleProvider] Stream: solicitud pendiente');
+            _circle = null;
+            _status = CircleStatus.initial;
+          case UserNoCircle():
+            log('[CircleProvider] Stream: sin círculo');
+            _circle = null;
+            _status = CircleStatus.initial;
+        }
         _error = null;
         notifyListeners();
       },


### PR DESCRIPTION
## Summary
- `_initializeCircleStream()` trataba `Stream<UserCircleState>` como `Stream<Circle?>`, causando errores de tipo en runtime
- Reemplazado listener con `switch (state)` exhaustivo sobre `UserInCircle / UserPendingRequest / UserNoCircle`
- Bug pre-existente, no relacionado con el refactor Sem 3

## Test plan
- [ ] `dart analyze lib/providers/circle_provider.dart` — sin errores ✅
- [ ] Smoke: login → home muestra círculo sin crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)