### PR TITLE
perf: pre-warm Firestore WebSocket and make emoji modal instant

### DIFF
--- a/lib/core/services/emoji_service.dart
+++ b/lib/core/services/emoji_service.dart
@@ -19,6 +19,8 @@ class EmojiService {
   static List<StatusType>? _cachedPredefined;
   static final Map<String, List<StatusType>> _cachedCustomByCircle = {};
 
+  static List<StatusType>? get cachedPredefined => _cachedPredefined;
+
   /// Obtiene todos los emojis predefinidos desde Firebase
   ///
   /// Carga desde /predefinedEmojis ordenados por 'order'

--- a/lib/core/widgets/emoji_modal.dart
+++ b/lib/core/widgets/emoji_modal.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
+import 'package:nunakin_app/core/services/session_cache_service.dart';
 import 'package:nunakin_app/core/services/status_service.dart';
 import 'package:nunakin_app/core/services/emoji_service.dart';
 import 'package:nunakin_app/core/widgets/status_widget.dart';
@@ -29,6 +30,10 @@ class _EmojiStatusBottomSheetState extends ConsumerState<EmojiStatusBottomSheet>
   @override
   void initState() {
     super.initState();
+    // Show immediately with cached/fallback so modal never blocks on Firestore.
+    _availableStatuses = EmojiService.cachedPredefined ?? StatusType.fallbackPredefined;
+    _isLoading = false;
+    // Refresh in background with real data (adds custom emojis when ready).
     _loadAvailableStatuses();
   }
 
@@ -38,30 +43,43 @@ class _EmojiStatusBottomSheetState extends ConsumerState<EmojiStatusBottomSheet>
     super.dispose();
   }
 
-  /// Carga los emojis predefinidos + personalizados desde Firebase
+  /// Carga los emojis predefinidos + personalizados desde Firebase.
+  /// No bloquea — initState ya mostró fallback/cache. Actualiza en background.
   Future<void> _loadAvailableStatuses() async {
     try {
-      // Obtener circleId del usuario actual
       final user = FirebaseAuth.instance.currentUser;
-      if (user == null) throw Exception('Usuario no autenticado');
+      if (user == null) return;
 
-      final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+      // Prefer in-memory SessionCache (0ms) to avoid a Firestore get() on every open.
+      final cachedCircleId = SessionCacheService.restoreSessionSync()?['circleId'];
+      String? circleId = (cachedCircleId?.isNotEmpty == true) ? cachedCircleId : null;
 
-      final circleId = userDoc.data()?['circleId'] as String?;
-      if (circleId == null) throw Exception('Usuario sin círculo');
+      if (circleId == null) {
+        try {
+          final userDoc = await FirebaseFirestore.instance
+              .collection('users')
+              .doc(user.uid)
+              .get(const GetOptions(source: Source.cache))
+              .timeout(const Duration(seconds: 2));
+          circleId = userDoc.data()?['circleId'] as String?;
+        } on FirebaseException {
+          final userDoc = await FirebaseFirestore.instance
+              .collection('users')
+              .doc(user.uid)
+              .get()
+              .timeout(const Duration(seconds: 3));
+          circleId = userDoc.data()?['circleId'] as String?;
+        }
+      }
 
-      // Cargar predefinidos + personalizados
+      if (circleId == null || circleId.isEmpty) return;
+
       final statuses = await EmojiService.getAllEmojisForCircle(circleId);
-      setState(() {
-        _availableStatuses = statuses;
-        _isLoading = false;
-      });
-    } catch (e) {
-      // Usar fallback si Firebase falla
-      setState(() {
-        _availableStatuses = StatusType.fallbackPredefined;
-        _isLoading = false;
-      });
+      if (mounted) {
+        setState(() => _availableStatuses = statuses);
+      }
+    } catch (_) {
+      // initState already set fallback — nothing to do.
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,6 +40,11 @@ void main() async {
     );
   }
 
+  // Pre-warm Firestore gRPC WebSocket before any user interaction.
+  // Ensures enableNetwork() in StatusService returns instantly on first status update.
+  // ignore: unawaited_futures
+  FirebaseFirestore.instance.enableNetwork();
+
   await di.initDependencies();
 
   // SessionCache debe estar listo antes de que AuthWrapper renderice


### PR DESCRIPTION
## Summary
- **main.dart**: \`enableNetwork()\` al arrancar (unawaited) — WebSocket gRPC listo antes de la primera interacción. Elimina el stall de 0-3s en StatusService en el primer update de estado.
- **emoji_service.dart**: getter \`cachedPredefined\` público para que el modal acceda al caché en memoria sin Firestore.
- **emoji_modal.dart**: modal abre instantáneo (emojis fallback/caché desde \`initState\`); carga predefinidos + custom en background y actualiza el grid. \`circleId\` resuelto con SessionCache → Source.cache → servidor, sin \`get()\` al servidor en el happy path.

## Test plan
- [ ] Abrir modal de selección de emoji — debe aparecer instantáneamente (sin spinner)
- [ ] Seleccionar emoji — la pantalla de Círculo debe actualizarse en <3s
- [ ] Verificar que emojis personalizados aparecen en el grid (pueden tardar 1-2s extra en cargar)
- [ ] Verificar flujo completo en \`flutter run --profile\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)