### PR TITLE
perf: circle members appear instantly after Silent Mode resume

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -109,7 +109,15 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
   final Map<String, Map<String, dynamic>> _memberDataCache = {};
   bool _isUpdatingStatus = false;
   final Map<String, String> _memberNicknamesCache = {};
-  bool _isLoadingNicknames = true;
+  // ════════════════════════════════════════════════════════════
+  // [FIX] Mostrar miembros inmediatamente con placeholder '...'
+  // Fecha: 2026-05-14
+  // PROBLEMA: true bloqueaba la lista completa con un spinner hasta que
+  //   _refreshDataInBackground() completaba los getUserDoc() de red (~6s).
+  // SOLUCIÓN: false desde el inicio. La lista renderiza con '...' y se
+  //   actualiza cuando llegan los nicknames reales (setState en background).
+  // ════════════════════════════════════════════════════════════
+  bool _isLoadingNicknames = false;
   List<StatusType>? _predefinedEmojis;
 
   // ════════════════════════════════════════════════════════════

--- a/lib/services/circle_service.dart
+++ b/lib/services/circle_service.dart
@@ -530,8 +530,25 @@ class CircleService {
     return controller.stream;
   }
 
+  // ════════════════════════════════════════════════════════════
+  // [FIX] Source.cache primero para getUserDoc
+  // Fecha: 2026-05-14
+  // PROBLEMA: .get() sin Source.cache siempre iba a servidor (~6s en red fría),
+  //   bloqueando _getAllMemberNicknames() en InCircleView.
+  // SOLUCIÓN: intentar cache local primero (0ms si existe); si no, servidor.
+  // ════════════════════════════════════════════════════════════
   Future<DocumentSnapshot<Map<String, dynamic>>> getUserDoc(String uid) async {
-    return await FirebaseFirestore.instance.collection('users').doc(uid).get();
+    try {
+      return await FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .get(const GetOptions(source: Source.cache));
+    } on FirebaseException {
+      return await FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .get();
+    }
   }
 
   /// Permite al usuario actual salir del círculo


### PR DESCRIPTION
## Causa raíz
`_isLoadingNicknames = true` bloqueaba la lista completa de miembros con un spinner hasta que `_refreshDataInBackground()` completaba un `getUserDoc()` por miembro — sin `Source.cache`, sin timeout, en red fría post-Silent Mode (~6s).

## Fix
- `in_circle_view.dart`: `_isLoadingNicknames = false` desde el inicio. La lista renderiza inmediatamente con `'...'` para nombres desconocidos (fallback ya existente en línea 760). Los nicknames reales actualizan vía `setState` en background.
- `circle_service.dart` → `getUserDoc()`: intenta `Source.cache` primero (0ms si el doc está en cache local de Firestore); cae a servidor solo si no hay cache.

## Test plan
- [ ] Salir de Modo Silencio → abrir app → miembros visibles en <500ms (antes ~6s)
- [ ] Nicknames reales reemplazan `...` en <1s en sesión con cache caliente
- [ ] Primera sesión (cache vacío): miembros visibles inmediatamente con `...`, nombres cargan en background
- [ ] Sin regresiones en estados de miembros ni en el listener de Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)