### PR TITLE
fix(silent-mode): eliminate ~10s freeze when activating Silent Mode

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -195,6 +195,11 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
       });
     }
 
+    // InCircleView solo renderiza cuando el usuario tiene círculo — siempre correcto.
+    // Evita la race condition donde _userHasCircle queda false en cold start y
+    // activateSilentMode dispara un getUserCircle() frío (~5-8s) al primer tap.
+    SilentFunctionalityCoordinator.syncCircleState(hasCircle: true);
+
     // PASO 5: Escuchar solicitudes de ingreso (solo si el usuario actual es el creador)
     final currentUid = FirebaseAuth.instance.currentUser?.uid;
     if (currentUid != null && currentUid == widget.circle.creatorId) {
@@ -995,7 +1000,9 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
     );
 
     if (confirmed == true && context.mounted) {
-      SilentFunctionalityCoordinator.activateSilentMode(context);
+      setState(() => _isUpdatingStatus = true);
+      await SilentFunctionalityCoordinator.activateSilentMode(context);
+      if (mounted) setState(() => _isUpdatingStatus = false);
     }
   }
 


### PR DESCRIPTION
## Root cause
_userHasCircle=false race condition on cold start. activateAfterLogin() returns early when _isInitialized=false. No retry — _userHasCircle stays false permanently.

First tap on Silent Mode triggers cold Firestore getUserCircle() (~5-8s), no visual feedback — looks frozen (~10s).

## Fixes

Fix 1 — InCircleView.initState(): syncCircleState(hasCircle:true) on mount. InCircleView only renders with widget.circle present — always correct. Eliminates cold Firestore fallback before any user interaction.

Fix 2 — _confirmAndActivateSilentMode(): await + _isUpdatingStatus=true disables button instantly on tap. Resets if activation fails. App closes via finishAndRemoveTask() on success path.

## No regressions
- isLoadingNicknames=false fix (#178): unaffected
- Status overlay instant (#177): unaffected
- Status modal fire-and-forget (#176): unaffected
- WebSocket pre-warm (#175): unaffected

## Test plan
- [ ] Cold start: tap Modo Silencio → button disables <200ms, app closes <2s
- [ ] Warm resume: same behavior
- [ ] Double-tap: ignored (button disabled)
- [ ] Deactivate Silent Mode: no regression

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>