### PR TITLE
refactor(identity): SessionState sealed + IdentityRepository + IdentityViewModel [Sem 4 Día 1]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,7 @@ Decisiones EXCLUSIVAS del desarrollador:
 - Al recibir resumen comprimido por el sistema: guardar estado en `memory/` antes de continuar.
 - Antes de cambiar a feature no relacionado: guardar memoria y sugerir `/clear`.
 - Si el desarrollador dice "nueva tarea": guardar memoria → sugerir `/clear`.
+- **Antes de `/clear`:** guardar memoria primero y confirmar al desarrollador antes de proceder.
 
 ---
 

--- a/docs/dev/refactor-arch-2026-q2/04-semana-4-Dia-1.md
+++ b/docs/dev/refactor-arch-2026-q2/04-semana-4-Dia-1.md
@@ -1,0 +1,240 @@
+# Sem 4 - Día 1 — `SessionState` sealed + `IdentityRepository` + `IdentityViewModel`
+
+**Rama:** `refactor/sem4-identity-session`
+
+**PR:** `refactor(identity): SessionState sealed + IdentityRepository + FirebaseIdentityRepository`
+
+**Fecha planificada:** 2026-05-16
+
+**Base:** tag `refactor-sem3-done` → commit `373b450`
+
+**Modelo recomendado:** Sonnet — riesgo bajo. Código 100% Dart nuevo, sin interdependencias nativas, patrón idéntico a Sem 2 Día 1 (`PresenceState` + `SharedPrefsPresenceRepository` + `PresenceViewModel`). Sin migración de callers existentes.
+
+---
+
+## Contexto
+
+Primer día de Sem 4 (Identity + Circle). Hoy `FirebaseAuth.instance` se llama directamente desde servicios, widgets y workers sin una fuente de verdad tipada para la sesión. El objetivo es crear el puerto `IdentityRepository` con su implementación Firebase y exponerla vía `IdentityViewModel`.
+
+**Regla de oro:** ningún caller existente se migra hoy. `auth_final_page.dart`, `circle_provider.dart`, `AuthRemoteDataSourceImpl` y los use cases legacy de auth continúan intocados. `identity_module.dart` acumula los registros nuevos sin eliminar los legacy.
+
+---
+
+## Tarea 1 — `lib/contexts/identity/domain/session_state.dart`
+
+Modelo sealed puro. Sin dependencias externas ni de Firebase. Equivalente a `presence_state.dart`.
+
+```dart
+sealed class SessionState {
+  const SessionState();
+  bool get isAuthenticated => this is Authenticated;
+}
+
+final class Anonymous extends SessionState {
+  const Anonymous();
+}
+
+final class Authenticated extends SessionState {
+  final String uid;
+  final String email;
+  const Authenticated({required this.uid, required this.email});
+}
+```
+
+**Por qué `String email` y no el objeto `User` de Firebase:** el dominio solo necesita los datos mínimos de identidad. Importar `firebase_auth` en el dominio acoplaría la capa de negocio a un SDK externo — exactamente lo que se quiere eliminar.
+
+---
+
+## Tarea 2 — `lib/contexts/identity/application/ports/identity_repository.dart`
+
+Puerto abstracto. 3 miembros. Ninguna dependencia de Firebase.
+
+```dart
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+abstract class IdentityRepository {
+  /// Stream continuo de cambios de sesión. Emite en cada login/logout.
+  Stream<SessionState> get session;
+
+  /// Última snapshot en memoria. `Anonymous` si nunca hubo login.
+  SessionState get current;
+
+  /// Cierra la sesión del usuario autenticado.
+  Future<void> signOut();
+}
+```
+
+---
+
+## Tarea 3 — `lib/contexts/identity/infrastructure/firebase_identity_repository.dart`
+
+Implementación concreta. Recibe `FirebaseAuth` en constructor (DI-friendly, testeable sin Firebase). Mapea `authStateChanges()` → `SessionState` vía `StreamController.broadcast()`.
+
+```dart
+import 'dart:async';
+import 'dart:developer';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+class FirebaseIdentityRepository implements IdentityRepository {
+  final FirebaseAuth _auth;
+  final _controller = StreamController<SessionState>.broadcast();
+  StreamSubscription<User?>? _sub;
+  SessionState _current = const Anonymous();
+
+  FirebaseIdentityRepository(this._auth) {
+    _sub = _auth.authStateChanges().listen(_onAuthChanged);
+  }
+
+  void _onAuthChanged(User? user) {
+    _current = _mapUser(user);
+    _controller.add(_current);
+    log('[IdentityRepository] session → ${_current.runtimeType}');
+  }
+
+  SessionState _mapUser(User? user) => user != null
+      ? Authenticated(uid: user.uid, email: user.email ?? '')
+      : const Anonymous();
+
+  @override
+  Stream<SessionState> get session => _controller.stream;
+
+  @override
+  SessionState get current => _current;
+
+  @override
+  Future<void> signOut() => _auth.signOut();
+
+  void dispose() {
+    _sub?.cancel();
+    _controller.close();
+  }
+}
+```
+
+---
+
+## Tarea 4 — `lib/contexts/identity/presentation/view_models/identity_view_model.dart`
+
+Patrón idéntico a `PresenceViewModel`: expone stream + snapshot en memoria. No conecta a UI hoy — la conexión ocurre en Sem 5.
+
+```dart
+import 'dart:async';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+class IdentityViewModel {
+  final IdentityRepository _repository;
+  StreamSubscription<SessionState>? _sub;
+  SessionState? _current;
+
+  IdentityViewModel({required IdentityRepository repository})
+      : _repository = repository;
+
+  /// Carga el estado actual y suscribe al stream. Llamar post-login (Sem 5).
+  Future<void> init() async {
+    _current = _repository.current;
+    _sub = _repository.session.listen((state) {
+      _current = state;
+    });
+  }
+
+  /// Stream de cambios: emite cada vez que la sesión cambia.
+  Stream<SessionState> get sessionStream => _repository.session;
+
+  /// Última snapshot en memoria. Null antes de llamar a [init].
+  SessionState? get currentSnapshot => _current;
+
+  void dispose() => _sub?.cancel();
+}
+```
+
+---
+
+## Tarea 5 — Modificar `lib/app/di/modules/identity_module.dart`
+
+**Agregar al final del archivo.** No eliminar ni tocar los registros legacy de `features/auth/` — se necesitan hasta Día 5.
+
+```dart
+// ── NUEVO — Sem 4 Día 1 ───────────────────────────────────────────────────
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/infrastructure/firebase_identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/presentation/view_models/identity_view_model.dart';
+```
+
+Y en el cuerpo de `registerIdentityModule`:
+
+```dart
+  // Infrastructure
+  sl.registerLazySingleton<IdentityRepository>(
+    () => FirebaseIdentityRepository(sl<FirebaseAuth>()),
+  );
+
+  // Presentation
+  sl.registerLazySingleton(
+    () => IdentityViewModel(repository: sl<IdentityRepository>()),
+  );
+```
+
+`sl<FirebaseAuth>()` resuelve correctamente porque `FirebaseAuth.instance` ya está registrado en `external_module.dart`.
+
+---
+
+## Tarea 6 — Tests
+
+### `test/contexts/identity/domain/session_state_test.dart` (4 tests — pure Dart)
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 1 | `Anonymous()` | `isAuthenticated == false`, pattern match sin `default` |
+| 2 | `Authenticated(uid, email)` | `isAuthenticated == true`, campos accesibles |
+| 3 | Constructores `const` | ambas subclases son `const` |
+| 4 | Switch exhaustivo | el compilador no exige `default` al cubrir `Anonymous` y `Authenticated` |
+
+### `test/contexts/identity/application/identity_view_model_test.dart` (5 tests — fake repo)
+
+Usa `_FakeIdentityRepository` handwritten con `StreamController<SessionState>`. Sin Firebase ni paquetes externos.
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 1 | `currentSnapshot` antes de `init()` | es `null` |
+| 2 | `init()` carga `current` del repositorio | `currentSnapshot` es `Anonymous` |
+| 3 | `sessionStream` re-emite eventos del repo | listener recibe `Authenticated` tras emit del fake |
+| 4 | `currentSnapshot` se actualiza tras cada evento | snapshot refleja último estado emitido |
+| 5 | `dispose()` cancela suscripción sin excepción | no lanza tras cierre del stream |
+
+> **Nota:** `firebase_identity_repository_test.dart` no se incluye en este día — `firebase_auth_mocks` no está en pubspec y `User` es abstracto. La impl Firebase se valida vía smoke test en Día 5.
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo | Cambio |
+|---------|------|--------|
+| `lib/contexts/identity/domain/session_state.dart` | Nuevo | Sealed class `SessionState` |
+| `lib/contexts/identity/application/ports/identity_repository.dart` | Nuevo | Puerto abstracto |
+| `lib/contexts/identity/infrastructure/firebase_identity_repository.dart` | Nuevo | Impl Firebase |
+| `lib/contexts/identity/presentation/view_models/identity_view_model.dart` | Nuevo | ViewModel |
+| `lib/app/di/modules/identity_module.dart` | Modificado | +2 registros al final (legacy intocado) |
+| `test/contexts/identity/domain/session_state_test.dart` | Nuevo | 4 tests |
+| `test/contexts/identity/application/identity_view_model_test.dart` | Nuevo | 5 tests |
+
+**Archivos de producción activa no modificados:** `auth_final_page.dart`, `circle_provider.dart`, `AuthRemoteDataSourceImpl`, use cases legacy de auth, `FirebaseAuth.instance` callers existentes.
+
+---
+
+## Criterios de done
+
+| Criterio | Verificación |
+|----------|-------------|
+| `flutter test test/contexts/identity/` — 9/9 verde | `flutter test test/contexts/identity/` |
+| `flutter analyze` — 0 errores nuevos vs baseline | `flutter analyze` |
+| Los use cases legacy de auth siguen resolviendo en DI | Arrancar app — login funciona |
+| `IdentityRepository` accesible vía `GetIt.instance<IdentityRepository>()` | Verificar en test o en app |
+| `SessionState` no importa nada fuera de `domain/` | Revisar imports |
+
+---
+
+**Siguiente: Día 2 — `MembershipState` sealed + `CircleRepository` port + `firestore_circle_repository.dart`**

--- a/docs/dev/refactor-arch-2026-q2/04-semana-4-identity-circle.md
+++ b/docs/dev/refactor-arch-2026-q2/04-semana-4-identity-circle.md
@@ -1,0 +1,323 @@
+# Semana 4 — Identity + Circle
+
+> **Objetivo:** aislar membresía y sesión. Eliminar `CircleService._refreshController` global.  
+> **Riesgo:** Medio  
+> **Prerrequisito:** Smoke test 6 pasos en device físico PASS + tag `refactor-sem3-done` creado.  
+> **Modelo recomendado:** Sonnet (riesgo medio, sin interdependencias nativas)
+
+---
+
+## Entregables de la semana
+
+1. `IdentitySession` con `Stream<SessionState>` — reemplaza usos directos de `FirebaseAuth.instance` en código de negocio.
+2. `circle/` context: `CircleRepository` (port) + impl Firestore.
+3. `MembershipState` sealed (`UserNoCircle | UserPendingRequest | UserInCircle`) movido a `circle/domain/`.
+4. Use cases: `JoinCircle`, `ApproveJoinRequest`, `DeleteAccount`.
+5. Use case `ApplyGeofenceStatus` en `geofencing/` — conecta eventos del bridge con `SetAutomaticStatus` en presence.
+6. Migración auth: `lib/features/auth/` → `lib/contexts/identity/` (renombrar imports).
+
+---
+
+## Día 1 — `identity/` context + `IdentitySession`
+
+### Objetivo
+Crear la fuente única de verdad para la sesión del usuario. Hoy `FirebaseAuth.instance` se llama directamente desde servicios, widgets y workers — esto se extrae a un puerto tipado.
+
+### Archivos a crear
+
+```
+lib/contexts/identity/
+├── domain/
+│   └── session_state.dart         ← sealed: Anonymous | Authenticated
+├── application/
+│   └── ports/
+│       └── identity_repository.dart
+├── infrastructure/
+│   └── firebase_identity_repository.dart
+└── presentation/
+    └── view_models/
+        └── identity_view_model.dart
+lib/app/di/modules/identity_module.dart
+```
+
+### `session_state.dart`
+```dart
+sealed class SessionState {
+  const SessionState();
+}
+
+class Anonymous extends SessionState {
+  const Anonymous();
+}
+
+class Authenticated extends SessionState {
+  final String uid;
+  final String email;
+  const Authenticated({required this.uid, required this.email});
+}
+```
+
+### `identity_repository.dart` (port)
+```dart
+abstract class IdentityRepository {
+  Stream<SessionState> get session;
+  SessionState get current;
+  Future<void> signOut();
+}
+```
+
+### `firebase_identity_repository.dart` (impl)
+Wrappea `FirebaseAuth.authStateChanges()` y mapea `User?` a `SessionState`.  
+Implementa el stream como `BehaviorSubject`-style usando `StreamController.broadcast()`.
+
+### `identity_module.dart`
+```dart
+void registerIdentityModule(GetIt sl) {
+  sl.registerSingleton<IdentityRepository>(FirebaseIdentityRepository());
+  sl.registerSingleton<IdentityViewModel>(
+    IdentityViewModel(sl<IdentityRepository>()),
+  );
+}
+```
+
+### Tests — `test/contexts/identity/`
+- `session_state_test.dart` — constructores, equality, pattern matching exhaustivo
+- `firebase_identity_repository_test.dart` — stream emite `Authenticated` y `Anonymous` correctamente
+
+**Criterio de done:** `flutter test test/contexts/identity/` verde, 0 errores en analyze.
+
+---
+
+## Día 2 — `circle/` context skeleton + `MembershipState`
+
+### Objetivo
+Extraer el concepto de membresía al círculo a un bounded context propio.  
+`UserCircleState` ya existe en `lib/providers/circle_provider.dart` — se mueve a `circle/domain/`.
+
+### Archivos a crear
+
+```
+lib/contexts/circle/
+├── domain/
+│   ├── membership_state.dart      ← sealed (renombrado de UserCircleState)
+│   └── circle_entity.dart         ← entidad Circle (extraída de circle_service.dart)
+├── application/
+│   └── ports/
+│       └── circle_repository.dart
+├── infrastructure/
+│   └── firestore_circle_repository.dart
+└── presentation/
+    └── view_models/
+        └── circle_view_model.dart
+lib/app/di/modules/circle_module.dart
+```
+
+### `membership_state.dart`
+```dart
+sealed class MembershipState {
+  const MembershipState();
+}
+
+class UserNoCircle extends MembershipState {
+  const UserNoCircle();
+}
+
+class UserPendingRequest extends MembershipState {
+  final String circleId;
+  const UserPendingRequest({required this.circleId});
+}
+
+class UserInCircle extends MembershipState {
+  final String circleId;
+  final bool isCreator;
+  const UserInCircle({required this.circleId, required this.isCreator});
+}
+```
+
+### `circle_repository.dart` (port)
+```dart
+abstract class CircleRepository {
+  Stream<MembershipState> get membership;
+  Future<Circle> getCircle(String circleId);
+  Future<Circle> createCircle(String name);
+}
+```
+
+### Migración `circle_provider.dart`
+- `UserCircleState` sealed → alias o eliminación progresiva, callers migrados a `MembershipState`
+- `CircleProvider` pasa a consumir `CircleRepository` en lugar de `CircleService` directamente
+
+### Tests — `test/contexts/circle/`
+- `membership_state_test.dart` — pattern matching, properties
+
+**Criterio de done:** `flutter test test/contexts/circle/` verde.
+
+---
+
+## Día 3 — Circle use cases
+
+### Objetivo
+Extraer la lógica de negocio del círculo de `CircleService` a use cases con DbC.
+
+### Use cases a crear
+
+```
+lib/contexts/circle/application/use_cases/
+├── join_circle.dart
+├── approve_join_request.dart
+└── delete_account.dart
+```
+
+#### `join_circle.dart`
+```dart
+class JoinCircle {
+  final CircleRepository _repo;
+
+  Future<Result<Unit>> call(String circleId) async {
+    Contract.requires(circleId.isNotEmpty, 'circleId must not be empty');
+    // lógica extraída de CircleService.joinCircle()
+    return _repo.join(circleId);
+  }
+}
+```
+
+#### `approve_join_request.dart`
+Extrae lógica de `CircleService.approveJoinRequest()`.  
+DbC: solo el creador puede aprobar.
+
+#### `delete_account.dart`
+Extrae lógica de `settings_page.dart` — actualmente mezclada con UI.  
+Orquesta: sign out → borrar datos Firestore → Firebase Auth delete.  
+DbC: requiere re-autenticación previa (ya implementada en UI).
+
+### Tests
+- `join_circle_test.dart` — éxito, circleId vacío, ya miembro
+- `approve_join_request_test.dart` — éxito, no es creador (debe fallar)
+- `delete_account_test.dart` — orquestación correcta
+
+**Criterio de done:** tests verdes, `settings_page.dart` aún no migrado (se hace en Sem 5).
+
+---
+
+## Día 4 — `ApplyGeofenceStatus` use case
+
+### Objetivo
+Crear el puente entre `GeofenceEntered`/`GeofenceExited` del `DomainEventBus` y `SetAutomaticStatus` en el contexto `presence`. Cierra definitivamente el coupling entre `GeofencingService` y `StatusService`.
+
+### Archivos a crear
+
+```
+lib/contexts/geofencing/application/use_cases/apply_geofence_status.dart
+lib/app/di/modules/geofencing_module.dart        ← actualizar
+```
+
+### `apply_geofence_status.dart`
+```dart
+class ApplyGeofenceStatus {
+  final DomainEventBus _bus;
+  final SetAutomaticStatus _setStatus;
+  StreamSubscription? _sub;
+
+  void initialize() {
+    _sub = _bus.events.whereType<ZoneEntered>().listen((e) async {
+      await _setStatus.call(zoneId: e.zoneId, userId: e.userId);
+    });
+    _bus.events.whereType<ZoneExited>().listen((e) async {
+      await _setStatus.callExit(userId: e.userId);
+    });
+  }
+
+  void dispose() => _sub?.cancel();
+}
+```
+
+### Wiring en DI
+`geofencing_module.dart`:
+```dart
+sl.registerSingleton<ApplyGeofenceStatus>(
+  ApplyGeofenceStatus(sl<DomainEventBus>(), sl<SetAutomaticStatus>()),
+)..initialize();
+```
+
+### Relación con `GeofencingService` actual
+`GeofencingService` sigue existiendo pero deja de llamar a `_updateUserStatusByZoneEvent()`.  
+En cambio, publica al `DomainEventBus`:
+```dart
+// ANTES (en _detectZoneTransition):
+await _updateUserStatusByZoneEvent(isEntry: true, zone: newZone);
+
+// DESPUÉS:
+_bus.publish(ZoneEntered(zoneId: newZone.id, userId: user.uid));
+```
+El método `_updateUserStatusByZoneEvent` queda deprecated (no se borra hasta Sem 8).
+
+### Tests
+- `apply_geofence_status_test.dart` — `ZoneEntered` dispara `SetAutomaticStatus`, `ZoneExited` restaura
+
+**Criterio de done:** tests verdes. `GeofencingService` ya no escribe directo a Firestore en entrada/salida.
+
+---
+
+## Día 5 — Migración auth + smoke test + tag
+
+### Objetivo
+Mover `lib/features/auth/` → `lib/contexts/identity/` y cerrar la semana con device validation.
+
+### Migración de archivos
+
+| Origen | Destino |
+|--------|---------|
+| `lib/features/auth/data/` | `lib/contexts/identity/infrastructure/` |
+| `lib/features/auth/domain/` | `lib/contexts/identity/domain/` (merge con lo de Día 1) |
+| `lib/features/auth/presentation/pages/auth_final_page.dart` | `lib/contexts/identity/presentation/pages/auth_final_page.dart` |
+| `lib/features/auth/presentation/provider/auth_state.dart` | Migrar a `IdentityViewModel` de Día 1 |
+
+**Regla:** `auth_final_page.dart` es el ÚNICO archivo activo de auth (CLAUDE.md §12). El resto es legacy — borrar.
+
+**Archivos legacy a borrar:**
+- `lib/features/auth/presentation/widgets/` (legacy confirmado en §12)
+- `lib/features/auth/data/datasources/auth_local_data_source.dart` y `_impl.dart` si están sin callers activos
+
+### Smoke test pre-tag (6 pasos estándar)
+1. Login con cuenta existente → llega a home
+2. Estado del usuario carga correctamente en Círculo
+3. Cambio de estado manual → refleja en Círculo
+4. Silent Mode ON → estado cambia; OFF → emoji previo restaurado
+5. Minimizar → maximizar → estado no se resetea
+6. Logout → re-login → estado persiste
+
+**Si todos pasan:**
+```bash
+git tag refactor-sem4-done
+git push origin refactor-sem4-done
+```
+
+### Criterio de done de Semana 4
+- [ ] `flutter analyze` — 0 errores nuevos vs baseline Sem 3
+- [ ] `flutter test` — todos los tests verdes
+- [ ] Smoke test 6 pasos PASS en device físico
+- [ ] Tag `refactor-sem4-done` pusheado
+- [ ] Memoria `project_refactor_sem4_done.md` guardada
+
+---
+
+## Métricas objetivo
+
+| Métrica | Baseline (fin Sem 3) | Objetivo Sem 4 |
+|---------|---------------------|----------------|
+| Tests totales | ~116 ✅ | +30 mínimo |
+| `flutter analyze` warnings | 394 | ≤ 394 (0 nuevos) |
+| Callers directos de `FirebaseAuth.instance` en negocio | N | 0 fuera de `FirebaseIdentityRepository` |
+| Callers directos de `CircleService` en UI | N | reducidos (migración Sem 5 completa) |
+| `GeofencingService` escribe directo a Firestore | Sí | No (vía DomainEventBus) |
+
+---
+
+## Riesgos y mitigaciones
+
+| Riesgo | Probabilidad | Mitigación |
+|--------|-------------|------------|
+| Migración auth rompe flujo de login | Media | `auth_final_page.dart` no cambia su lógica, solo su ubicación y imports |
+| `MembershipState` rename rompe callers | Media | Grep todos los callers de `UserCircleState` antes del rename |
+| `ApplyGeofenceStatus` + `GeofencingService` duplican escrituras | Media | Eliminar `_updateUserStatusByZoneEvent` inmediatamente tras cablear el bus |
+| Smoke test falla por import roto post-migración | Baja | `flutter analyze` cero errores antes de correr smoke test |

--- a/lib/app/di/modules/identity_module.dart
+++ b/lib/app/di/modules/identity_module.dart
@@ -1,4 +1,8 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/infrastructure/firebase_identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/presentation/view_models/identity_view_model.dart';
 import 'package:nunakin_app/features/auth/data/datasources/auth_local_data_source.dart';
 import 'package:nunakin_app/features/auth/data/datasources/auth_local_data_source_impl.dart';
 import 'package:nunakin_app/features/auth/data/datasources/auth_remote_data_source.dart';
@@ -25,5 +29,13 @@ Future<void> registerIdentityModule(GetIt sl) async {
   );
   sl.registerLazySingleton<AuthLocalDataSource>(
     () => AuthLocalDataSourceImpl(sharedPreferences: sl()),
+  );
+
+  // ── NUEVO — Sem 4 Día 1 ───────────────────────────────────────────────────
+  sl.registerLazySingleton<IdentityRepository>(
+    () => FirebaseIdentityRepository(sl<FirebaseAuth>()),
+  );
+  sl.registerLazySingleton(
+    () => IdentityViewModel(repository: sl<IdentityRepository>()),
   );
 }

--- a/lib/contexts/identity/application/ports/identity_repository.dart
+++ b/lib/contexts/identity/application/ports/identity_repository.dart
@@ -1,0 +1,12 @@
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+abstract class IdentityRepository {
+  /// Stream continuo de cambios de sesión. Emite en cada login/logout.
+  Stream<SessionState> get session;
+
+  /// Última snapshot en memoria. `Anonymous` si nunca hubo login.
+  SessionState get current;
+
+  /// Cierra la sesión del usuario autenticado.
+  Future<void> signOut();
+}

--- a/lib/contexts/identity/domain/session_state.dart
+++ b/lib/contexts/identity/domain/session_state.dart
@@ -1,0 +1,14 @@
+sealed class SessionState {
+  const SessionState();
+  bool get isAuthenticated => this is Authenticated;
+}
+
+final class Anonymous extends SessionState {
+  const Anonymous();
+}
+
+final class Authenticated extends SessionState {
+  final String uid;
+  final String email;
+  const Authenticated({required this.uid, required this.email});
+}

--- a/lib/contexts/identity/infrastructure/firebase_identity_repository.dart
+++ b/lib/contexts/identity/infrastructure/firebase_identity_repository.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+import 'dart:developer';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+class FirebaseIdentityRepository implements IdentityRepository {
+  final FirebaseAuth _auth;
+  final _controller = StreamController<SessionState>.broadcast();
+  StreamSubscription<User?>? _sub;
+  SessionState _current = const Anonymous();
+
+  FirebaseIdentityRepository(this._auth) {
+    _sub = _auth.authStateChanges().listen(_onAuthChanged);
+  }
+
+  void _onAuthChanged(User? user) {
+    _current = _mapUser(user);
+    _controller.add(_current);
+    log('[IdentityRepository] session → ${_current.runtimeType}');
+  }
+
+  SessionState _mapUser(User? user) => user != null
+      ? Authenticated(uid: user.uid, email: user.email ?? '')
+      : const Anonymous();
+
+  @override
+  Stream<SessionState> get session => _controller.stream;
+
+  @override
+  SessionState get current => _current;
+
+  @override
+  Future<void> signOut() => _auth.signOut();
+
+  void dispose() {
+    _sub?.cancel();
+    _controller.close();
+  }
+}

--- a/lib/contexts/identity/presentation/view_models/identity_view_model.dart
+++ b/lib/contexts/identity/presentation/view_models/identity_view_model.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+class IdentityViewModel {
+  final IdentityRepository _repository;
+  StreamSubscription<SessionState>? _sub;
+  SessionState? _current;
+
+  IdentityViewModel({required IdentityRepository repository})
+      : _repository = repository;
+
+  /// Carga el estado actual y suscribe al stream. Llamar post-login (Sem 5).
+  Future<void> init() async {
+    _current = _repository.current;
+    _sub = _repository.session.listen((state) {
+      _current = state;
+    });
+  }
+
+  /// Stream de cambios: emite cada vez que la sesión cambia.
+  Stream<SessionState> get sessionStream => _repository.session;
+
+  /// Última snapshot en memoria. Null antes de llamar a [init].
+  SessionState? get currentSnapshot => _current;
+
+  void dispose() => _sub?.cancel();
+}

--- a/test/contexts/identity/application/identity_view_model_test.dart
+++ b/test/contexts/identity/application/identity_view_model_test.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/identity/application/ports/identity_repository.dart';
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+import 'package:nunakin_app/contexts/identity/presentation/view_models/identity_view_model.dart';
+
+class _FakeIdentityRepository implements IdentityRepository {
+  final _controller = StreamController<SessionState>.broadcast();
+  SessionState _current = const Anonymous();
+
+  void emit(SessionState state) {
+    _current = state;
+    _controller.add(state);
+  }
+
+  @override
+  Stream<SessionState> get session => _controller.stream;
+
+  @override
+  SessionState get current => _current;
+
+  @override
+  Future<void> signOut() async {}
+
+  void close() => _controller.close();
+}
+
+void main() {
+  late _FakeIdentityRepository repo;
+  late IdentityViewModel vm;
+
+  setUp(() {
+    repo = _FakeIdentityRepository();
+    vm = IdentityViewModel(repository: repo);
+  });
+
+  tearDown(() {
+    vm.dispose();
+    repo.close();
+  });
+
+  test('currentSnapshot es null antes de init()', () {
+    expect(vm.currentSnapshot, isNull);
+  });
+
+  test('init() carga current del repositorio', () async {
+    await vm.init();
+    expect(vm.currentSnapshot, isA<Anonymous>());
+  });
+
+  test('sessionStream re-emite eventos del repo', () async {
+    await vm.init();
+    const auth = Authenticated(uid: 'u1', email: 'a@b.com');
+
+    expectLater(vm.sessionStream, emits(auth));
+    repo.emit(auth);
+  });
+
+  test('currentSnapshot se actualiza tras cada evento', () async {
+    await vm.init();
+    const auth = Authenticated(uid: 'u2', email: 'x@y.com');
+
+    repo.emit(auth);
+    await Future.delayed(Duration.zero);
+
+    expect(vm.currentSnapshot, isA<Authenticated>());
+    expect((vm.currentSnapshot as Authenticated).uid, 'u2');
+  });
+
+  test('dispose() cancela suscripción sin excepción', () async {
+    await vm.init();
+    expect(() => vm.dispose(), returnsNormally);
+  });
+}

--- a/test/contexts/identity/domain/session_state_test.dart
+++ b/test/contexts/identity/domain/session_state_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/identity/domain/session_state.dart';
+
+void main() {
+  group('SessionState', () {
+    test('Anonymous — isAuthenticated es false y pattern match sin default', () {
+      const SessionState state = Anonymous();
+      expect(state.isAuthenticated, isFalse);
+
+      final label = switch (state) {
+        Anonymous() => 'anon',
+        Authenticated() => 'auth',
+      };
+      expect(label, 'anon');
+    });
+
+    test('Authenticated — isAuthenticated es true, campos accesibles', () {
+      const state = Authenticated(uid: 'uid-123', email: 'user@test.com');
+      expect(state.isAuthenticated, isTrue);
+      expect(state.uid, 'uid-123');
+      expect(state.email, 'user@test.com');
+    });
+
+    test('Constructores son const — misma instancia en igualdad referencial', () {
+      const a1 = Anonymous();
+      const a2 = Anonymous();
+      expect(identical(a1, a2), isTrue);
+
+      const auth1 = Authenticated(uid: 'u', email: 'e');
+      const auth2 = Authenticated(uid: 'u', email: 'e');
+      expect(identical(auth1, auth2), isTrue);
+    });
+
+    test('Switch exhaustivo — no requiere default al cubrir Anonymous y Authenticated', () {
+      SessionState state = const Authenticated(uid: 'u', email: 'e');
+      final result = switch (state) {
+        Anonymous() => 0,
+        Authenticated() => 1,
+      };
+      expect(result, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **`SessionState` sealed** (`Anonymous | Authenticated`) — domain puro, sin imports de Firebase
- **`IdentityRepository`** — puerto abstracto con `session` stream + `current` snapshot + `signOut()`
- **`FirebaseIdentityRepository`** — impl que wrappea `authStateChanges()`, DI-friendly (recibe `FirebaseAuth` en constructor)
- **`IdentityViewModel`** — patrón idéntico a `PresenceViewModel` (Sem 2); expone stream + snapshot, conexión a UI se hace en Sem 5
- **`identity_module.dart`** — +2 `registerLazySingleton` al final; legacy `features/auth/` intocado

## Tests

- `session_state_test.dart` — 4 tests: `isAuthenticated`, campos, constructores `const`, switch exhaustivo
- `identity_view_model_test.dart` — 5 tests con `_FakeIdentityRepository` handwritten, sin Firebase

**9/9 verde. `flutter analyze`: 375 issues (baseline Sem 3: 394 — 0 issues nuevos).**

## Archivos de producción activa no modificados

`auth_final_page.dart`, `circle_provider.dart`, `AuthRemoteDataSourceImpl`, use cases legacy de auth.

## Criterio de done

- [x] `flutter test test/contexts/identity/` — 9/9 verde
- [x] `flutter analyze` — 0 errores nuevos vs baseline Sem 3
- [x] Legacy DI intacto — login flow no se toca

## Siguiente

Día 2 — `MembershipState` sealed + `CircleRepository` port + `firestore_circle_repository.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)