### PR TITLE
refactor(circle): JoinCircle + ApproveJoinRequest + DeleteAccount use cases [Sem 4 Día 3]

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/04-semana-4-Dia-3.md
+++ b/docs/dev/refactor-arch-2026-q2/04-semana-4-Dia-3.md
@@ -1,0 +1,312 @@
+# Sem 4 — Día 3: Circle use cases — `JoinCircle`, `ApproveJoinRequest`, `DeleteAccount`
+
+**Rama:** `refactor/sem4-circle-usecases`  
+**PR:** `refactor(circle): JoinCircle + ApproveJoinRequest + DeleteAccount use cases`  
+**Fecha planificada:** 2026-05-17  
+**Base:** `59afb73` (main post-PR #186)  
+**Modelo:** Sonnet — riesgo bajo. Lógica extraída de `CircleService`, patrón idéntico a Sem 2 use cases.
+
+---
+
+## Contexto
+
+Hoy la lógica de negocio del círculo está mezclada en `CircleService` y llamada directamente desde widgets:
+
+| Operación | Caller actual | Método del servicio |
+|-----------|--------------|---------------------|
+| Unirse (enviar solicitud) | `JoinCircleView:53` vía `CircleService()` | `requestToJoinCircle(invitationCode)` |
+| Aprobar solicitud | `InCircleView:939` vía `_circleService` | `approveJoinRequest(circleId, userId)` |
+| Eliminar cuenta | `SettingsPage:461`, `NoCircleView:159,285` vía `CircleService()` | `deleteAccount()` |
+
+El objetivo es crear use cases que encapsulen estas operaciones detrás del port `CircleRepository`. Los widgets no se migran hoy — eso ocurre en Sem 5.
+
+**Nota sobre `rejectJoinRequest`:** existe en `CircleService` pero no tiene callers en UI (grep confirmado). No se crea use case — YAGNI.
+
+---
+
+## Análisis de dependencias
+
+### `shared/` existente — reusado sin cambios
+
+| Archivo | Uso |
+|---------|-----|
+| `lib/shared/contract.dart` | `Contract.requires()` — DbC en debug mode |
+| `lib/shared/result.dart` | `Result<T>`, `Success<T>`, `FailureResult<T>` |
+| `lib/shared/unit.dart` | `Unit.instance` — valor de retorno en success sin datos |
+| `lib/shared/failure.dart` | `DomainFailure`, `UnexpectedFailure` — tipado de errores |
+
+Patrón de las impls en `FirestoreCircleRepository`:
+```dart
+try {
+  await _service.theMethod(...);
+  return Success(Unit.instance);
+} on Exception catch (e) {
+  return FailureResult(DomainFailure(message: e.toString(), cause: e));
+}
+```
+
+---
+
+## Tarea 1 — Extender `lib/contexts/circle/application/ports/circle_repository.dart`
+
+Agregar 3 métodos al final. Los 3 existentes (`membership`, `getCircle`, `createCircle`) no se tocan.
+
+```dart
+/// Envía solicitud de ingreso al círculo con el código dado.
+/// El usuario queda en estado pendiente hasta que el creador apruebe.
+Future<Result<Unit>> requestToJoin(String invitationCode);
+
+/// Aprueba la solicitud de [requestingUserId] en [circleId].
+/// El servicio verifica que el caller sea el creador — lanza si no lo es.
+Future<Result<Unit>> approveJoin({
+  required String circleId,
+  required String requestingUserId,
+});
+
+/// Elimina la cuenta del usuario autenticado.
+/// Si es creador: borra el círculo. Si es miembro: sale del círculo.
+/// Orquesta: Firestore cleanup → Firebase Auth delete.
+Future<Result<Unit>> deleteAccount();
+```
+
+Imports a agregar en el encabezado:
+```dart
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+```
+
+---
+
+## Tarea 2 — Implementar en `lib/contexts/circle/infrastructure/firestore_circle_repository.dart`
+
+Agregar 3 implementaciones al final de la clase. El resto intocado.
+
+Imports a agregar:
+```dart
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+```
+
+```dart
+@override
+Future<Result<Unit>> requestToJoin(String invitationCode) async {
+  try {
+    await _service.requestToJoinCircle(invitationCode);
+    return Success(Unit.instance);
+  } on Exception catch (e) {
+    return FailureResult(DomainFailure(message: e.toString(), cause: e));
+  }
+}
+
+@override
+Future<Result<Unit>> approveJoin({
+  required String circleId,
+  required String requestingUserId,
+}) async {
+  try {
+    await _service.approveJoinRequest(circleId, requestingUserId);
+    return Success(Unit.instance);
+  } on Exception catch (e) {
+    return FailureResult(DomainFailure(message: e.toString(), cause: e));
+  }
+}
+
+@override
+Future<Result<Unit>> deleteAccount() async {
+  try {
+    await _service.deleteAccount();
+    return Success(Unit.instance);
+  } on Exception catch (e) {
+    return FailureResult(UnexpectedFailure(message: e.toString(), cause: e));
+  }
+}
+```
+
+**Por qué `DomainFailure` para approve y `UnexpectedFailure` para delete:**
+- `approveJoin` puede fallar por reglas de negocio esperadas ("no eres el creador", "ya es miembro") → `DomainFailure`.
+- `deleteAccount` puede fallar por razones más variadas (red, requires-recent-login, etc.) → `UnexpectedFailure` como fallback.
+
+---
+
+## Tarea 3 — `lib/contexts/circle/application/use_cases/join_circle.dart`
+
+```dart
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class JoinCircle {
+  final CircleRepository _repository;
+
+  JoinCircle({required CircleRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call(String invitationCode) async {
+    Contract.requires(
+      invitationCode.isNotEmpty,
+      'invitationCode must not be empty',
+    );
+    return _repository.requestToJoin(invitationCode);
+  }
+}
+```
+
+---
+
+## Tarea 4 — `lib/contexts/circle/application/use_cases/approve_join_request.dart`
+
+```dart
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class ApproveJoinRequest {
+  final CircleRepository _repository;
+
+  ApproveJoinRequest({required CircleRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call({
+    required String circleId,
+    required String requestingUserId,
+  }) async {
+    Contract.requires(circleId.isNotEmpty, 'circleId must not be empty');
+    Contract.requires(
+      requestingUserId.isNotEmpty,
+      'requestingUserId must not be empty',
+    );
+    return _repository.approveJoin(
+      circleId: circleId,
+      requestingUserId: requestingUserId,
+    );
+  }
+}
+```
+
+**Nota:** la verificación "solo el creador puede aprobar" la enforza `CircleService.approveJoinRequest()` (ya existe). El use case no duplica esa lógica — el `DomainFailure` propagado desde el repo es suficiente. El `Contract.requires` solo guarda los invariantes de datos (IDs no vacíos).
+
+---
+
+## Tarea 5 — `lib/contexts/circle/application/use_cases/delete_account.dart`
+
+```dart
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class DeleteAccount {
+  final CircleRepository _repository;
+
+  DeleteAccount({required CircleRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call() => _repository.deleteAccount();
+}
+```
+
+Sin `Contract.requires`: el servicio ya valida `_auth.currentUser != null` y lanza si no hay sesión. Esa validación ocurre en la capa de infraestructura, no en el dominio.
+
+---
+
+## Tarea 6 — Modificar `lib/app/di/modules/circle_module.dart`
+
+Agregar imports y 3 registros al final de `registerCircleModule`. El resto intocado.
+
+Imports a agregar:
+```dart
+import 'package:nunakin_app/contexts/circle/application/use_cases/approve_join_request.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/delete_account.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/join_circle.dart';
+```
+
+Registros a agregar al final de la función:
+```dart
+  // Use cases
+  sl.registerLazySingleton(
+    () => JoinCircle(repository: sl<CircleRepository>()),
+  );
+  sl.registerLazySingleton(
+    () => ApproveJoinRequest(repository: sl<CircleRepository>()),
+  );
+  sl.registerLazySingleton(
+    () => DeleteAccount(repository: sl<CircleRepository>()),
+  );
+```
+
+---
+
+## Tarea 7 — Tests
+
+### `test/contexts/circle/application/join_circle_test.dart` (3 tests)
+
+Usa `_FakeCircleRepository` extendido de Día 2 + nuevo campo `requestToJoinResult`.
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 1 | Éxito: repo devuelve `Success` | use case retorna `Success(Unit.instance)` |
+| 2 | `invitationCode` vacío | `ContractViolation` lanzado en debug mode |
+| 3 | Fallo: repo devuelve `FailureResult` | use case propaga el `FailureResult` |
+
+### `test/contexts/circle/application/approve_join_request_test.dart` (3 tests)
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 1 | Éxito | retorna `Success(Unit.instance)` |
+| 2 | `circleId` vacío | `ContractViolation` |
+| 3 | `requestingUserId` vacío | `ContractViolation` |
+
+### `test/contexts/circle/application/delete_account_test.dart` (2 tests)
+
+| # | Escenario | Qué verifica |
+|---|-----------|-------------|
+| 1 | Éxito | retorna `Success(Unit.instance)` |
+| 2 | Fallo: repo devuelve `FailureResult` | use case propaga el `FailureResult` |
+
+**Total nuevo: 8 tests**
+
+---
+
+## Archivos afectados
+
+| Archivo | Tipo | Cambio |
+|---------|------|--------|
+| `lib/contexts/circle/application/ports/circle_repository.dart` | Modificado | +3 métodos al final |
+| `lib/contexts/circle/infrastructure/firestore_circle_repository.dart` | Modificado | +3 implementaciones |
+| `lib/contexts/circle/application/use_cases/join_circle.dart` | Nuevo | Use case |
+| `lib/contexts/circle/application/use_cases/approve_join_request.dart` | Nuevo | Use case |
+| `lib/contexts/circle/application/use_cases/delete_account.dart` | Nuevo | Use case |
+| `lib/app/di/modules/circle_module.dart` | Modificado | +3 registros use cases |
+| `test/contexts/circle/application/join_circle_test.dart` | Nuevo | 3 tests |
+| `test/contexts/circle/application/approve_join_request_test.dart` | Nuevo | 3 tests |
+| `test/contexts/circle/application/delete_account_test.dart` | Nuevo | 2 tests |
+
+**No se toca:** `circle_service.dart`, `circle_provider.dart`, `join_circle_view.dart`, `in_circle_view.dart`, `settings_page.dart`, `no_circle_view.dart`.
+
+---
+
+## Criterios de done
+
+| Criterio | Verificación |
+|----------|-------------|
+| `flutter test test/contexts/circle/application/` — todos verdes | `flutter test test/contexts/circle/application/` |
+| `flutter analyze` — 0 errores nuevos vs baseline (375) | `flutter analyze` |
+| `JoinCircle`, `ApproveJoinRequest`, `DeleteAccount` accesibles en GetIt | `sl.isRegistered<JoinCircle>()` |
+| Widgets existentes siguen funcionando (no se tocaron) | `flutter analyze` sin errores nuevos |
+
+---
+
+## Riesgos y mitigaciones
+
+| Riesgo | Probabilidad | Mitigación |
+|--------|-------------|------------|
+| `Unit` no importado en port/infra | Baja | Verificar imports antes de compilar |
+| `ContractViolation` en tests de string vacío | Intencional | Los tests verifican exactamente eso |
+| `deleteAccount` en `UnexpectedFailure` vs `AuthFailure` | Baja | `UnexpectedFailure` es el fallback correcto; Firebase Auth puede lanzar `FirebaseAuthException` — la infra lo captura como `on Exception` |
+
+---
+
+**Siguiente: Día 4 — `ApplyGeofenceStatus` use case + `DomainEventBus` wiring**  
+**Modelo Día 4:** Sonnet

--- a/lib/app/di/modules/circle_module.dart
+++ b/lib/app/di/modules/circle_module.dart
@@ -2,6 +2,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
 import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/approve_join_request.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/delete_account.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/join_circle.dart';
 import 'package:nunakin_app/contexts/circle/infrastructure/firestore_circle_repository.dart';
 import 'package:nunakin_app/contexts/circle/presentation/view_models/circle_view_model.dart';
 import 'package:nunakin_app/services/circle_service.dart';
@@ -22,5 +25,16 @@ Future<void> registerCircleModule(GetIt sl) async {
   // Presentation
   sl.registerLazySingleton(
     () => CircleViewModel(repository: sl<CircleRepository>()),
+  );
+
+  // Use cases
+  sl.registerLazySingleton(
+    () => JoinCircle(repository: sl<CircleRepository>()),
+  );
+  sl.registerLazySingleton(
+    () => ApproveJoinRequest(repository: sl<CircleRepository>()),
+  );
+  sl.registerLazySingleton(
+    () => DeleteAccount(repository: sl<CircleRepository>()),
   );
 }

--- a/lib/contexts/circle/application/ports/circle_repository.dart
+++ b/lib/contexts/circle/application/ports/circle_repository.dart
@@ -1,5 +1,7 @@
 import 'package:nunakin_app/contexts/circle/domain/circle_entity.dart';
 import 'package:nunakin_app/contexts/circle/domain/membership_state.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
 
 abstract class CircleRepository {
   /// Stream tri-estado de membresía. Emite en cada cambio de Firestore.
@@ -10,4 +12,19 @@ abstract class CircleRepository {
 
   /// Crea un nuevo círculo y retorna su ID.
   Future<String> createCircle(String name);
+
+  /// Envía solicitud de ingreso al círculo con el código dado.
+  /// El usuario queda en estado pendiente hasta que el creador apruebe.
+  Future<Result<Unit>> requestToJoin(String invitationCode);
+
+  /// Aprueba la solicitud de [requestingUserId] en [circleId].
+  /// El servicio verifica que el caller sea el creador — lanza si no lo es.
+  Future<Result<Unit>> approveJoin({
+    required String circleId,
+    required String requestingUserId,
+  });
+
+  /// Elimina la cuenta del usuario autenticado.
+  /// Si es creador: borra el círculo. Si es miembro: sale del círculo.
+  Future<Result<Unit>> deleteAccount();
 }

--- a/lib/contexts/circle/application/use_cases/approve_join_request.dart
+++ b/lib/contexts/circle/application/use_cases/approve_join_request.dart
@@ -1,0 +1,26 @@
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class ApproveJoinRequest {
+  final CircleRepository _repository;
+
+  ApproveJoinRequest({required CircleRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call({
+    required String circleId,
+    required String requestingUserId,
+  }) async {
+    Contract.requires(circleId.isNotEmpty, 'circleId must not be empty');
+    Contract.requires(
+      requestingUserId.isNotEmpty,
+      'requestingUserId must not be empty',
+    );
+    return _repository.approveJoin(
+      circleId: circleId,
+      requestingUserId: requestingUserId,
+    );
+  }
+}

--- a/lib/contexts/circle/application/use_cases/delete_account.dart
+++ b/lib/contexts/circle/application/use_cases/delete_account.dart
@@ -1,0 +1,12 @@
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class DeleteAccount {
+  final CircleRepository _repository;
+
+  DeleteAccount({required CircleRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call() => _repository.deleteAccount();
+}

--- a/lib/contexts/circle/application/use_cases/join_circle.dart
+++ b/lib/contexts/circle/application/use_cases/join_circle.dart
@@ -1,0 +1,19 @@
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/shared/contract.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class JoinCircle {
+  final CircleRepository _repository;
+
+  JoinCircle({required CircleRepository repository})
+      : _repository = repository;
+
+  Future<Result<Unit>> call(String invitationCode) async {
+    Contract.requires(
+      invitationCode.isNotEmpty,
+      'invitationCode must not be empty',
+    );
+    return _repository.requestToJoin(invitationCode);
+  }
+}

--- a/lib/contexts/circle/infrastructure/firestore_circle_repository.dart
+++ b/lib/contexts/circle/infrastructure/firestore_circle_repository.dart
@@ -5,6 +5,9 @@ import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.
 import 'package:nunakin_app/contexts/circle/domain/circle_entity.dart';
 import 'package:nunakin_app/contexts/circle/domain/membership_state.dart';
 import 'package:nunakin_app/services/circle_service.dart' as legacy;
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
 
 class FirestoreCircleRepository implements CircleRepository {
   final legacy.CircleService _service;
@@ -54,5 +57,38 @@ class FirestoreCircleRepository implements CircleRepository {
   Future<String> createCircle(String name) {
     assert(name.isNotEmpty, 'circle name must not be empty');
     return _service.createCircle(name);
+  }
+
+  @override
+  Future<Result<Unit>> requestToJoin(String invitationCode) async {
+    try {
+      await _service.requestToJoinCircle(invitationCode);
+      return Success(Unit.instance);
+    } on Exception catch (e) {
+      return FailureResult(DomainFailure(message: e.toString(), cause: e));
+    }
+  }
+
+  @override
+  Future<Result<Unit>> approveJoin({
+    required String circleId,
+    required String requestingUserId,
+  }) async {
+    try {
+      await _service.approveJoinRequest(circleId, requestingUserId);
+      return Success(Unit.instance);
+    } on Exception catch (e) {
+      return FailureResult(DomainFailure(message: e.toString(), cause: e));
+    }
+  }
+
+  @override
+  Future<Result<Unit>> deleteAccount() async {
+    try {
+      await _service.deleteAccount();
+      return Success(Unit.instance);
+    } on Exception catch (e) {
+      return FailureResult(UnexpectedFailure(message: e.toString(), cause: e));
+    }
   }
 }

--- a/test/contexts/circle/application/approve_join_request_test.dart
+++ b/test/contexts/circle/application/approve_join_request_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/approve_join_request.dart';
+import 'package:nunakin_app/contexts/circle/domain/circle_entity.dart';
+import 'package:nunakin_app/contexts/circle/domain/membership_state.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class _FakeCircleRepository implements CircleRepository {
+  @override
+  Stream<MembershipState> get membership => const Stream.empty();
+
+  @override
+  Future<CircleEntity?> getCircle(String circleId) async => null;
+
+  @override
+  Future<String> createCircle(String name) async => 'fake-id';
+
+  @override
+  Future<Result<Unit>> requestToJoin(String invitationCode) async =>
+      Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> approveJoin({
+    required String circleId,
+    required String requestingUserId,
+  }) async => Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> deleteAccount() async => Success(Unit.instance);
+}
+
+void main() {
+  late ApproveJoinRequest useCase;
+
+  setUp(() {
+    useCase = ApproveJoinRequest(repository: _FakeCircleRepository());
+  });
+
+  test('éxito: retorna Success con IDs válidos', () async {
+    final result = await useCase.call(
+      circleId: 'circle-1',
+      requestingUserId: 'user-1',
+    );
+    expect(result.isSuccess, isTrue);
+  });
+
+  test('circleId vacío: lanza ContractViolation', () {
+    expect(
+      () => useCase.call(circleId: '', requestingUserId: 'user-1'),
+      throwsA(isA<Error>()),
+    );
+  });
+
+  test('requestingUserId vacío: lanza ContractViolation', () {
+    expect(
+      () => useCase.call(circleId: 'circle-1', requestingUserId: ''),
+      throwsA(isA<Error>()),
+    );
+  });
+}

--- a/test/contexts/circle/application/circle_view_model_test.dart
+++ b/test/contexts/circle/application/circle_view_model_test.dart
@@ -4,6 +4,8 @@ import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.
 import 'package:nunakin_app/contexts/circle/domain/circle_entity.dart';
 import 'package:nunakin_app/contexts/circle/domain/membership_state.dart';
 import 'package:nunakin_app/contexts/circle/presentation/view_models/circle_view_model.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
 
 class _FakeCircleRepository implements CircleRepository {
   final _controller = StreamController<MembershipState>.broadcast();
@@ -18,6 +20,19 @@ class _FakeCircleRepository implements CircleRepository {
 
   @override
   Future<String> createCircle(String name) async => 'fake-id';
+
+  @override
+  Future<Result<Unit>> requestToJoin(String invitationCode) async =>
+      Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> approveJoin({
+    required String circleId,
+    required String requestingUserId,
+  }) async => Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> deleteAccount() async => Success(Unit.instance);
 
   void close() => _controller.close();
 }

--- a/test/contexts/circle/application/delete_account_test.dart
+++ b/test/contexts/circle/application/delete_account_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/delete_account.dart';
+import 'package:nunakin_app/contexts/circle/domain/circle_entity.dart';
+import 'package:nunakin_app/contexts/circle/domain/membership_state.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class _FakeCircleRepository implements CircleRepository {
+  Result<Unit> deleteAccountResult = Success(Unit.instance);
+
+  @override
+  Stream<MembershipState> get membership => const Stream.empty();
+
+  @override
+  Future<CircleEntity?> getCircle(String circleId) async => null;
+
+  @override
+  Future<String> createCircle(String name) async => 'fake-id';
+
+  @override
+  Future<Result<Unit>> requestToJoin(String invitationCode) async =>
+      Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> approveJoin({
+    required String circleId,
+    required String requestingUserId,
+  }) async => Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> deleteAccount() async => deleteAccountResult;
+}
+
+void main() {
+  late _FakeCircleRepository repo;
+  late DeleteAccount useCase;
+
+  setUp(() {
+    repo = _FakeCircleRepository();
+    useCase = DeleteAccount(repository: repo);
+  });
+
+  test('éxito: retorna Success cuando el repo devuelve Success', () async {
+    final result = await useCase.call();
+    expect(result.isSuccess, isTrue);
+  });
+
+  test('fallo: propaga FailureResult del repo', () async {
+    repo.deleteAccountResult =
+        FailureResult(const UnexpectedFailure(message: 'error de red'));
+
+    final result = await useCase.call();
+    expect(result.isFailure, isTrue);
+    expect(result.failureOrNull, isA<UnexpectedFailure>());
+  });
+}

--- a/test/contexts/circle/application/join_circle_test.dart
+++ b/test/contexts/circle/application/join_circle_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/circle/application/ports/circle_repository.dart';
+import 'package:nunakin_app/contexts/circle/application/use_cases/join_circle.dart';
+import 'package:nunakin_app/contexts/circle/domain/circle_entity.dart';
+import 'package:nunakin_app/contexts/circle/domain/membership_state.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class _FakeCircleRepository implements CircleRepository {
+  Result<Unit> requestToJoinResult = Success(Unit.instance);
+
+  @override
+  Stream<MembershipState> get membership => const Stream.empty();
+
+  @override
+  Future<CircleEntity?> getCircle(String circleId) async => null;
+
+  @override
+  Future<String> createCircle(String name) async => 'fake-id';
+
+  @override
+  Future<Result<Unit>> requestToJoin(String invitationCode) async =>
+      requestToJoinResult;
+
+  @override
+  Future<Result<Unit>> approveJoin({
+    required String circleId,
+    required String requestingUserId,
+  }) async => Success(Unit.instance);
+
+  @override
+  Future<Result<Unit>> deleteAccount() async => Success(Unit.instance);
+}
+
+void main() {
+  late _FakeCircleRepository repo;
+  late JoinCircle useCase;
+
+  setUp(() {
+    repo = _FakeCircleRepository();
+    useCase = JoinCircle(repository: repo);
+  });
+
+  test('éxito: retorna Success cuando el repo devuelve Success', () async {
+    final result = await useCase.call('ABC123');
+    expect(result.isSuccess, isTrue);
+  });
+
+  test('invitationCode vacío: lanza ContractViolation', () {
+    expect(
+      () => useCase.call(''),
+      throwsA(isA<Error>()),
+    );
+  });
+
+  test('fallo: propaga FailureResult del repo', () async {
+    repo.requestToJoinResult =
+        FailureResult(const DomainFailure(message: 'código inválido'));
+
+    final result = await useCase.call('ZZZ999');
+    expect(result.isFailure, isTrue);
+    expect(result.failureOrNull, isA<DomainFailure>());
+  });
+}


### PR DESCRIPTION
## Summary

Extiende el port `CircleRepository` con 3 métodos de operación y crea los use cases correspondientes:

- **`CircleRepository` + `FirestoreCircleRepository`** — +3 métodos (`requestToJoin`, `approveJoin`, `deleteAccount`) que retornan `Result<Unit>` y delegan a `CircleService`
- **`JoinCircle`** — llama `requestToJoinCircle` (flujo approval, no `joinCircle` legacy). Confirmado por `JoinCircleView:53`
- **`ApproveJoinRequest`** — DbC guards en `circleId` + `requestingUserId`; verificación de creador delegada al servicio → `DomainFailure`
- **`DeleteAccount`** — sin precondiciones en el use case; el servicio maneja creador vs. miembro
- **`circle_module.dart`** — +3 lazy singletons
- **`circle_view_model_test.dart`** — actualizado para implementar los 3 nuevos métodos del port

## Tests

| Archivo | Tests |
|---------|-------|
| `join_circle_test.dart` | 3 (éxito, vacío, fallo propagado) |
| `approve_join_request_test.dart` | 3 (éxito, circleId vacío, requestingUserId vacío) |
| `delete_account_test.dart` | 2 (éxito, fallo propagado) |

**17/17 verde (circle context completo). `flutter analyze`: 375 (sin cambio).**

## No se toca

`circle_service.dart`, `circle_provider.dart`, `join_circle_view.dart`, `in_circle_view.dart`, `settings_page.dart`, `no_circle_view.dart`.

## Siguiente

Día 4 — `ApplyGeofenceStatus` use case + `DomainEventBus` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)