### PR TITLE
feat(geofencing): ApplyGeofenceStatus + DomainEventBus wiring (Sem 4 Día 4)

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/04-semana-4-Dia-4.md
+++ b/docs/dev/refactor-arch-2026-q2/04-semana-4-Dia-4.md
@@ -1,0 +1,68 @@
+# Semana 4, Día 4 — `ApplyGeofenceStatus` + DomainEventBus wiring
+
+**Fecha:** 2026-05-17
+**Rama:** `refactor/sem4-geofence-eventbus`
+**Modelo:** Sonnet 4.6
+
+---
+
+## Objetivo
+
+Desacoplar `GeofencingService` de Firestore en el punto de transición de zonas.
+Reemplazar las llamadas directas a `_updateUserStatusByZoneEvent()` por publicaciones
+al `DomainEventBus`. El nuevo use case `ApplyGeofenceStatus` en `contexts/geofencing/`
+recibe los eventos y ejecuta la escritura vía `GeofenceStatusWriter`.
+
+---
+
+## Gaps identificados vs. PA doc original
+
+| Gap | Causa | Solución aplicada |
+|-----|-------|------------------|
+| `SetAutomaticStatus` no existía | No creado en Sem 2/3 | `GeofenceStatusWriter` (port) + `FirestoreGeofenceStatusWriter` (impl) |
+| `ZoneEntered`/`ZoneExited` sin zona metadata | Diseño original mínimo | Nuevos campos opcionales: `circleId`, `zoneTypeValue`, `zoneName`, `isPredefined` |
+| `GeofencingService` sin DI | Instanciado en `InCircleView` | Constructor acepta `DomainEventBus?`; `InCircleView` pasa `sl<DomainEventBus>()` |
+| `bus.events.whereType<T>()` en PA doc | API incorrecto | Corregido a `_bus.on<T>()` |
+| Test `domain_event_bus_test.dart` usaba constructores sin nuevos campos | Nuevos campos son `required` | Todos los nuevos campos son opcionales con defaults; test compila sin cambios |
+
+---
+
+## Archivos creados (4)
+
+| Archivo | Descripción |
+|---------|-------------|
+| `lib/contexts/geofencing/application/ports/geofence_status_writer.dart` | Port: `onZoneEntered` + `onZoneExited` |
+| `lib/contexts/geofencing/application/use_cases/apply_geofence_status.dart` | Use case: suscribe al bus, delega al writer |
+| `lib/contexts/geofencing/infrastructure/firestore_geofence_status_writer.dart` | Impl: extrae lógica de `_updateUserStatusByZoneEvent`. Preserva check `manualOverride`. |
+| `test/contexts/geofencing/application/apply_geofence_status_test.dart` | 3 tests: entered, exited, dispose |
+
+---
+
+## Archivos modificados (4)
+
+| Archivo | Cambio |
+|---------|--------|
+| `lib/shared/events/domain_event.dart` | `ZoneEntered` +4 campos opcionales; `ZoneExited` +`circleId` opcional |
+| `lib/features/geofencing/services/geofencing_service.dart` | Constructor acepta `DomainEventBus?`; 2 llamadas a `_updateUserStatusByZoneEvent` → `_bus?.publish(...)`. Método marcado `@Deprecated`. |
+| `lib/features/circle/presentation/widgets/in_circle_view.dart` | `GeofencingService()` → `GeofencingService(bus: sl<DomainEventBus>())` |
+| `lib/app/di/modules/geofencing_module.dart` | Registra `GeofenceStatusWriter` + `ApplyGeofenceStatus` |
+
+---
+
+## Criterio de done ✅
+
+- [x] `flutter test test/contexts/geofencing/` → 3/3 verde
+- [x] `flutter test test/shared/events/domain_event_bus_test.dart` → 4/4 verde
+- [x] `flutter analyze --no-fatal-infos` → 0 errores nuevos, 0 warnings nuevos
+- [x] `GeofencingService._detectZoneTransition` no llama `_updateUserStatusByZoneEvent`
+- [x] `_updateUserStatusByZoneEvent` marcado `@Deprecated` + `// ignore: unused_element`
+
+---
+
+## Invariante preservado
+
+- Check `manualOverride` en `FirestoreGeofenceStatusWriter.onZoneEntered` es idéntico al que
+  tenía `_updateUserStatusByZoneEvent` — lee Firestore antes de escribir.
+- `GeofencingService.suppressNextCheckOnReopen()` es método static, no afectado por el
+  nuevo constructor.
+- `domain_event_bus_test.dart` sigue verde sin modificar: los nuevos campos son opcionales.

--- a/lib/app/di/modules/geofencing_module.dart
+++ b/lib/app/di/modules/geofencing_module.dart
@@ -1,6 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
+import 'package:nunakin_app/contexts/geofencing/application/ports/geofence_status_writer.dart';
+import 'package:nunakin_app/contexts/geofencing/application/use_cases/apply_geofence_status.dart';
+import 'package:nunakin_app/contexts/geofencing/infrastructure/firestore_geofence_status_writer.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
 
-/// Placeholder — se puebla en Sem 4.
 Future<void> registerGeofencingModule(GetIt sl) async {
-  // TODO Sem 4: ZoneRepository, ZoneEventService, GeofencingService
+  sl.registerLazySingleton<GeofenceStatusWriter>(
+    () => FirestoreGeofenceStatusWriter(
+      sl<FirebaseFirestore>(),
+      sl<FirebaseAuth>(),
+    ),
+  );
+
+  sl.registerSingleton<ApplyGeofenceStatus>(
+    ApplyGeofenceStatus(
+      bus:    sl<DomainEventBus>(),
+      writer: sl<GeofenceStatusWriter>(),
+    )..initialize(),
+  );
 }

--- a/lib/contexts/geofencing/application/ports/geofence_status_writer.dart
+++ b/lib/contexts/geofencing/application/ports/geofence_status_writer.dart
@@ -1,0 +1,8 @@
+import 'package:nunakin_app/shared/events/domain_event.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+abstract class GeofenceStatusWriter {
+  Future<Result<Unit>> onZoneEntered(ZoneEntered event);
+  Future<Result<Unit>> onZoneExited(ZoneExited event);
+}

--- a/lib/contexts/geofencing/application/use_cases/apply_geofence_status.dart
+++ b/lib/contexts/geofencing/application/use_cases/apply_geofence_status.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:nunakin_app/contexts/geofencing/application/ports/geofence_status_writer.dart';
+import 'package:nunakin_app/shared/events/domain_event.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
+
+class ApplyGeofenceStatus {
+  final DomainEventBus _bus;
+  final GeofenceStatusWriter _writer;
+  StreamSubscription<ZoneEntered>? _enteredSub;
+  StreamSubscription<ZoneExited>? _exitedSub;
+
+  ApplyGeofenceStatus({
+    required DomainEventBus bus,
+    required GeofenceStatusWriter writer,
+  })  : _bus    = bus,
+        _writer = writer;
+
+  void initialize() {
+    _enteredSub = _bus.on<ZoneEntered>().listen((e) async => _writer.onZoneEntered(e));
+    _exitedSub  = _bus.on<ZoneExited>().listen((e) async => _writer.onZoneExited(e));
+  }
+
+  void dispose() {
+    _enteredSub?.cancel();
+    _exitedSub?.cancel();
+  }
+}

--- a/lib/contexts/geofencing/infrastructure/firestore_geofence_status_writer.dart
+++ b/lib/contexts/geofencing/infrastructure/firestore_geofence_status_writer.dart
@@ -1,0 +1,109 @@
+import 'dart:developer';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:nunakin_app/contexts/geofencing/application/ports/geofence_status_writer.dart';
+import 'package:nunakin_app/shared/events/domain_event.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class FirestoreGeofenceStatusWriter implements GeofenceStatusWriter {
+  final FirebaseFirestore _firestore;
+  final FirebaseAuth _auth;
+
+  FirestoreGeofenceStatusWriter(this._firestore, this._auth);
+
+  @override
+  Future<Result<Unit>> onZoneEntered(ZoneEntered event) async {
+    if (event.circleId.isEmpty) return Success(Unit.instance);
+
+    final user = _auth.currentUser;
+    if (user == null) return Success(Unit.instance);
+
+    try {
+      if (await _hasManualOverride(event.circleId, user.uid)) {
+        log('[GeofenceStatusWriter] ⏸️ Omitido — manualOverride activo (zona: ${event.zoneName})');
+        return Success(Unit.instance);
+      }
+
+      final String statusType = _statusFromZoneType(event.zoneTypeValue);
+      final String customEmoji = event.isPredefined ? _emojiFromZoneType(event.zoneTypeValue) : '📍';
+
+      await _firestore.collection('circles').doc(event.circleId).update({
+        'memberStatus.${user.uid}': {
+          'statusType':  statusType,
+          'customEmoji': customEmoji,
+          'zoneName':    event.zoneName,
+          'zoneId':      event.zoneId,
+          'autoUpdated': true,
+          'timestamp':   FieldValue.serverTimestamp(),
+        },
+      });
+
+      log('[GeofenceStatusWriter] ✅ Entrada zona: $statusType (${event.zoneName})');
+      return Success(Unit.instance);
+    } catch (e, st) {
+      log('[GeofenceStatusWriter] ❌ Error en entrada: $e');
+      return FailureResult(UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+
+  @override
+  Future<Result<Unit>> onZoneExited(ZoneExited event) async {
+    if (event.circleId.isEmpty) return Success(Unit.instance);
+
+    final user = _auth.currentUser;
+    if (user == null) return Success(Unit.instance);
+
+    try {
+      await _firestore.collection('circles').doc(event.circleId).update({
+        'memberStatus.${user.uid}': {
+          'statusType':       'fine',
+          'customEmoji':      null,
+          'zoneName':         null,
+          'zoneId':           null,
+          'autoUpdated':      true,
+          'lastKnownZone':    event.zoneId,
+          'lastKnownZoneTime': FieldValue.serverTimestamp(),
+          'timestamp':        FieldValue.serverTimestamp(),
+        },
+      });
+
+      log('[GeofenceStatusWriter] ✅ Salida de zona — estado: fine');
+      return Success(Unit.instance);
+    } catch (e, st) {
+      log('[GeofenceStatusWriter] ❌ Error en salida: $e');
+      return FailureResult(UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+
+  Future<bool> _hasManualOverride(String circleId, String userId) async {
+    final doc = await _firestore.collection('circles').doc(circleId).get();
+    final memberStatus = doc.data()?['memberStatus'] as Map<String, dynamic>?;
+    final userStatus   = memberStatus?[userId] as Map<String, dynamic>?;
+    return userStatus?['manualOverride'] as bool? ?? false;
+  }
+
+  String _statusFromZoneType(String zoneTypeValue) {
+    switch (zoneTypeValue) {
+      case 'school':
+      case 'university':
+        return 'studying';
+      case 'work':
+        return 'busy';
+      default:
+        return 'fine';
+    }
+  }
+
+  String _emojiFromZoneType(String zoneTypeValue) {
+    switch (zoneTypeValue) {
+      case 'home':       return '🏠';
+      case 'school':     return '🏫';
+      case 'university': return '🎓';
+      case 'work':       return '💼';
+      default:           return '📍';
+    }
+  }
+}

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -21,6 +21,8 @@ import '../../../../core/services/silent_functionality_coordinator.dart';
 import '../../../settings/presentation/pages/settings_page.dart';
 import '../../../../core/models/user_status.dart';
 import '../../../geofencing/services/geofencing_service.dart'; // Servicio de geofencing
+import 'package:nunakin_app/app/di/injection_container.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
 // CACHE-FIRST: Importar caches
 import '../../../../core/cache/in_memory_cache.dart';
 import '../../../../core/cache/persistent_cache.dart';
@@ -138,7 +140,7 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
   StreamSubscription<QuerySnapshot>? _customEmojisListener;
 
   // Servicio de geofencing
-  final GeofencingService _geofencingService = GeofencingService();
+  final GeofencingService _geofencingService = GeofencingService(bus: sl<DomainEventBus>());
   // --- FIN DE LA MODIFICACIÓN ---
 
   // Aprobación de ingreso

--- a/lib/features/geofencing/services/geofencing_service.dart
+++ b/lib/features/geofencing/services/geofencing_service.dart
@@ -5,6 +5,8 @@ import 'dart:developer';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:nunakin_app/shared/events/domain_event.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
 import '../domain/entities/zone.dart';
 import '../domain/entities/zone_event.dart';
 import 'zone_service.dart';
@@ -14,6 +16,9 @@ import 'zone_event_service.dart';
 class GeofencingService {
   final ZoneService _zoneService = ZoneService();
   final ZoneEventService _eventService = ZoneEventService();
+  final DomainEventBus? _bus;
+
+  GeofencingService({DomainEventBus? bus}) : _bus = bus;
 
   // Cuando el usuario elige un emoji desde la BN con el proceso muerto, al reabrir
   // startMonitoring() dispararía checkCurrentLocation() y sobreescribiría ese emoji
@@ -195,13 +200,12 @@ class GeofencingService {
       );
       _lastEventTime = DateTime.now();
 
-      // US-GEO-004: Actualizar estado a "Viajando" al salir de cualquier zona
-      try {
-        await _updateUserStatusByZoneEvent(isEntry: false, zone: null);
-        log('[Geofencing] ✅ Estado actualizado a: Viajando (salida de ${exitedZone.name})');
-      } catch (e) {
-        log('[Geofencing] ❌ Error al actualizar estado en salida: $e');
-      }
+      // US-GEO-004: Publicar evento de salida → ApplyGeofenceStatus actualiza el estado
+      _bus?.publish(ZoneExited(
+        zoneId:   _currentZoneId!,
+        userId:   user.uid,
+        circleId: _currentCircleId!,
+      ));
     }
 
     // ════════════════════════════════════════════════════════════
@@ -234,13 +238,15 @@ class GeofencingService {
       );
       _lastEventTime = DateTime.now();
 
-      // US-GEO-004: Actualizar estado según tipo de zona
-      try {
-        await _updateUserStatusByZoneEvent(isEntry: true, zone: newZone);
-        log('[Geofencing] ✅ Estado actualizado según zona (entrada a ${newZone.type.emoji}${newZone.name})');
-      } catch (e) {
-        log('[Geofencing] ❌ Error al actualizar estado en entrada: $e');
-      }
+      // US-GEO-004: Publicar evento de entrada → ApplyGeofenceStatus actualiza el estado
+      _bus?.publish(ZoneEntered(
+        zoneId:        newZoneId,
+        userId:        user.uid,
+        circleId:      _currentCircleId!,
+        zoneTypeValue: newZone.type.value,
+        zoneName:      newZone.name,
+        isPredefined:  newZone.isPredefined,
+      ));
     } // Actualizar estado actual
     _currentZoneId = newZoneId;
   }
@@ -260,8 +266,9 @@ class GeofencingService {
   /// Obtener ID del círculo siendo monitoreado
   String? get monitoringCircleId => _currentCircleId;
 
-  /// Actualiza el estado del usuario en Firestore según el evento de zona
-  /// US-GEO-004: Actualización automática de estado basado en zona
+  /// Lógica migrada a [FirestoreGeofenceStatusWriter]. Se conserva hasta Sem 8.
+  @Deprecated('Usar GeofenceStatusWriter vía DomainEventBus. Eliminar en Sem 8.')
+  // ignore: unused_element
   Future<void> _updateUserStatusByZoneEvent({
     required bool isEntry,
     Zone? zone,

--- a/lib/shared/events/domain_event.dart
+++ b/lib/shared/events/domain_event.dart
@@ -9,13 +9,31 @@ sealed class DomainEvent {
 class ZoneEntered extends DomainEvent {
   final String zoneId;
   final String userId;
-  const ZoneEntered({required this.zoneId, required this.userId});
+  final String circleId;
+  final String zoneTypeValue;  // 'home'|'school'|'university'|'work'|'custom'
+  final String zoneName;
+  final bool   isPredefined;
+
+  const ZoneEntered({
+    required this.zoneId,
+    required this.userId,
+    this.circleId      = '',
+    this.zoneTypeValue = 'custom',
+    this.zoneName      = '',
+    this.isPredefined  = false,
+  });
 }
 
 class ZoneExited extends DomainEvent {
   final String zoneId;
   final String userId;
-  const ZoneExited({required this.zoneId, required this.userId});
+  final String circleId;
+
+  const ZoneExited({
+    required this.zoneId,
+    required this.userId,
+    this.circleId = '',
+  });
 }
 
 // ── Identity ─────────────────────────────────────────────────────────────────

--- a/test/contexts/geofencing/application/apply_geofence_status_test.dart
+++ b/test/contexts/geofencing/application/apply_geofence_status_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/geofencing/application/ports/geofence_status_writer.dart';
+import 'package:nunakin_app/contexts/geofencing/application/use_cases/apply_geofence_status.dart';
+import 'package:nunakin_app/shared/events/domain_event.dart';
+import 'package:nunakin_app/shared/events/domain_event_bus.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+class _FakeGeofenceStatusWriter implements GeofenceStatusWriter {
+  int enteredCalls = 0;
+  int exitedCalls  = 0;
+  ZoneEntered? lastEntered;
+  ZoneExited?  lastExited;
+
+  @override
+  Future<Result<Unit>> onZoneEntered(ZoneEntered event) async {
+    enteredCalls++;
+    lastEntered = event;
+    return Success(Unit.instance);
+  }
+
+  @override
+  Future<Result<Unit>> onZoneExited(ZoneExited event) async {
+    exitedCalls++;
+    lastExited = event;
+    return Success(Unit.instance);
+  }
+}
+
+void main() {
+  late DomainEventBus bus;
+  late _FakeGeofenceStatusWriter writer;
+  late ApplyGeofenceStatus useCase;
+
+  setUp(() {
+    bus     = DomainEventBus();
+    writer  = _FakeGeofenceStatusWriter();
+    useCase = ApplyGeofenceStatus(bus: bus, writer: writer)..initialize();
+  });
+
+  tearDown(() {
+    useCase.dispose();
+    bus.dispose();
+  });
+
+  test('ZoneEntered dispara onZoneEntered con los datos correctos', () async {
+    const event = ZoneEntered(
+      zoneId:        'z1',
+      userId:        'u1',
+      circleId:      'c1',
+      zoneTypeValue: 'home',
+      zoneName:      'Casa',
+      isPredefined:  true,
+    );
+
+    bus.publish(event);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(writer.enteredCalls, 1);
+    expect(writer.exitedCalls,  0);
+    expect(writer.lastEntered?.zoneId, 'z1');
+    expect(writer.lastEntered?.isPredefined, isTrue);
+  });
+
+  test('ZoneExited dispara onZoneExited con los datos correctos', () async {
+    const event = ZoneExited(zoneId: 'z1', userId: 'u1', circleId: 'c1');
+
+    bus.publish(event);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(writer.exitedCalls,  1);
+    expect(writer.enteredCalls, 0);
+    expect(writer.lastExited?.circleId, 'c1');
+  });
+
+  test('dispose — eventos posteriores no disparan el writer', () async {
+    useCase.dispose();
+
+    bus.publish(const ZoneEntered(zoneId: 'z2', userId: 'u2'));
+    bus.publish(const ZoneExited(zoneId: 'z2', userId: 'u2'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(writer.enteredCalls, 0);
+    expect(writer.exitedCalls,  0);
+  });
+}


### PR DESCRIPTION
## Summary

- `ZoneEntered`/`ZoneExited` enriquecidos con metadata de zona (campos opcionales — tests existentes sin cambios)
- `GeofenceStatusWriter` port + `FirestoreGeofenceStatusWriter` impl: extrae la lógica de `_updateUserStatusByZoneEvent`, preservando el check `manualOverride`
- `ApplyGeofenceStatus` use case: suscribe al `DomainEventBus` y delega al writer
- `GeofencingService` acepta `DomainEventBus?`; publica eventos en lugar de escribir Firestore directamente. `_updateUserStatusByZoneEvent` marcado `@Deprecated`
- `InCircleView` pasa `sl<DomainEventBus>()` al constructor de `GeofencingService`
- `geofencing_module.dart` registra `GeofenceStatusWriter` + `ApplyGeofenceStatus`

## Test plan

- [ ] `flutter test test/contexts/geofencing/` → 3/3 verde ✅
- [ ] `flutter test test/shared/events/domain_event_bus_test.dart` → 4/4 verde ✅
- [ ] `flutter analyze --no-fatal-infos` → 0 errores/warnings nuevos ✅
- [ ] Smoke test en dispositivo: entrar/salir zona → estado actualiza correctamente
- [ ] Verificar que `manualOverride` sigue bloqueando actualizaciones automáticas

⚠️ Riesgo activo: `GeofencingService._updateUserStatusByZoneEvent` ya no se llama — la escritura de estado de zona va 100% por `ApplyGeofenceStatus` vía bus. Verificar en dispositivo físico antes del próximo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)