### PR TITLE
docs: correct stale Silent Mode comments

### DIFF
--- a/docs/dev/REGLAS_NEGOCIO.md
+++ b/docs/dev/REGLAS_NEGOCIO.md
@@ -21,7 +21,7 @@ La fuente de la verdad es siempre el último estado registrado, ya sea:
 
 1. El usuario selecciona uno nuevo manualmente.
 2. El Geofencing detecta una entrada o salida de Zona.
-3. El usuario activa Modo Silencio (escribe `do_not_disturb` explícitamente).
+3. El usuario selecciona `do_not_disturb` (🔕 No molestar) manualmente en el selector.
 
 Cualquier comportamiento que resetee el estado a `fine` u otro valor por defecto es un **bug**, no una feature.
 

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -389,14 +389,14 @@ class StatusService {
   //
   // SOLUCIÓN IMPLEMENTADA:
   // - Eliminar el concepto "Desconectado" por completo.
-  // - Al activar Modo Silencio → se escribe 'do_not_disturb' en Firestore (ver
-  //   SilentFunctionalityCoordinator.activateSilentMode).
+  // - Al activar Modo Silencio → el estado/emoji se PRESERVA. Silent Mode no
+  //   escribe 'do_not_disturb' ni ningún otro estado (eliminado en PR #117).
   // - Al reabrir la app → el último estado persiste en Firestore sin reset a 'fine'.
   // - Estos métodos se conservan como no-ops para evitar errores de compilación
   //   durante la transición; eliminar en post-MVP.
   // ========================================================================
 
-  /// @deprecated — No-op. Reemplazado por escritura de 'do_not_disturb' en activateSilentMode.
+  /// @deprecated — No-op. El estado se preserva en Modo Silencio; no se escribe 'do_not_disturb'.
   static Future<void> setOfflineStatus() async {
     log('[StatusService] ⚠️ setOfflineStatus() llamado — no-op (deprecado)');
   }


### PR DESCRIPTION
## Summary
- `REGLAS_NEGOCIO.md §0.3`: eliminada mención errónea de que Modo Silencio escribe `do_not_disturb`; ahora describe correctamente que es una selección manual del usuario
- `status_service.dart:391-399`: comentario de 2026-04-14 actualizado para reflejar que Silent Mode preserva el estado (comportamiento vigente desde PR #117)

## Causa raíz
Ambas referencias describían el comportamiento **anterior** a PR #117 y no se actualizaron cuando se eliminó la escritura de `do_not_disturb` en Silent Mode activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)