### PR TITLE
fix(auth): remove session-expired snackbar, redirect to login silently

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -11,8 +11,6 @@ import 'package:nunakin_app/platform/persistence/native_keys.dart';
 import 'app_badge_service.dart';
 import 'gps_service.dart';
 import 'session_cache_service.dart';
-import 'package:flutter/material.dart';
-import 'package:nunakin_app/core/global_keys.dart';
 import 'package:nunakin_app/core/services/secure_credential_service.dart';
 import 'dart:async';
 import 'dart:developer';
@@ -447,13 +445,6 @@ class StatusService {
   }
 
   static void _handleSessionExpired() {
-    rootScaffoldMessengerKey.currentState?.showSnackBar(
-      SnackBar(
-        content: const Text('Sesión expirada por inactividad. Vuelve a iniciar sesión.'),
-        duration: const Duration(seconds: 3),
-        backgroundColor: Colors.red.shade700,
-      ),
-    );
     Future.delayed(const Duration(seconds: 1), () async {
       await FirebaseAuth.instance.signOut();
     });


### PR DESCRIPTION
## Summary
- Eliminado el SnackBar rojo "Sesión expirada por inactividad" de `_handleSessionExpired()`
- La app redirige silenciosamente al login en 1 segundo sin ningún mensaje previo
- Removidos imports huérfanos: `flutter/material.dart` y `global_keys.dart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)