### PR TITLE
fix(auth): proactive token refresh only after 50min background

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -300,19 +300,22 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       // SOLUCIÓN: _refreshTokenWithRetry v3 reintenta indefinidamente (cap 120s)
       //   y al éxito fuerza reconexión de Firestore.
       // ════════════════════════════════════════════════════════════
-      // Si el background fue >5min, el token cacheado puede ser inválido
-      // (circuit-breaker de securetoken.googleapis.com post-Doze/Silent Mode).
-      // Marcar flag para que el próximo write en StatusService use forceRefresh=true.
+      // Token Firebase TTL = 1h. Solo refrescar proactivamente si background > 50min.
+      // Resume corto (< 50min): token en caché del SDK — sin llamada de red.
       final bg = _backgroundedAt;
-      if (bg != null && DateTime.now().difference(bg) > const Duration(minutes: 5)) {
-        StatusService.tokenLikelyInvalid = true;
-        debugPrint('[App] ⚠️ Background > 5min — próximo write usará forceRefresh=true');
-      }
       _backgroundedAt = null;
 
+      final bgDuration = bg != null ? DateTime.now().difference(bg) : Duration.zero;
+      final longBackground = bgDuration > const Duration(minutes: 50);
+
+      if (longBackground) {
+        StatusService.tokenLikelyInvalid = true;
+        debugPrint('[App] ⚠️ Background > 50min (${bgDuration.inMinutes}min) — proactive token refresh');
+      }
+
       final resumeUser = FirebaseAuth.instance.currentUser;
-      if (resumeUser != null) {
-        _refreshTokenWithRetry(resumeUser, context: 'resume');
+      if (resumeUser != null && longBackground) {
+        _refreshTokenWithRetry(resumeUser, context: 'resume-${bgDuration.inMinutes}min');
       }
 
       // 📱 App maximizada - MEDIR RENDIMIENTO


### PR DESCRIPTION
## Summary
- Umbral `tokenLikelyInvalid`: `5min` → `50min` (alineado con TTL real del token Firebase de 1h)
- `_refreshTokenWithRetry` ahora condicional a `longBackground > 50min` — antes se llamaba en **todo** resume, incluso tras 10s
- Resume corto ya no genera `getIdToken(forceRefresh=true)` → sin llamada de red innecesaria

## Cambio real
`lib/main.dart` — bloque `AppLifecycleState.resumed` (~12 líneas). Ningún otro archivo.

Mecanismo interno (`_refreshTokenWithRetry`, `_trySilentReauthFromKeystore`, `StatusService._handleSessionExpired`) sin cambios.

## Test plan
- [ ] T4: resume corto (< 50min) — confirmar que **NO** hay llamada a `securetoken.googleapis.com`
- [ ] T5: Silent Mode > 1h → reabre → emoji actualiza — sin SnackBar rojo
- [ ] T6: Normal Mode > 1h → reabre → emoji actualiza
- [ ] T7: > 1h → reabre → tap antes de que refresh complete — ~300ms extra, actualiza

🤖 Generated with [Claude Code](https://claude.com/claude-code)