### PR TITLE
fix(circle): resolve stale custom emoji on first selection

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -191,12 +191,29 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
         .snapshots()
         .listen((snapshot) {
       if (!mounted) return;
-
-      // Recargar la lista completa de emojis cuando hay cambios
-      _loadPredefinedEmojis();
+      // Usar el snapshot directamente evita la race: EmojiService.clearCache()
+      // limpia _cachedCustomByCircle al crear/borrar un emoji, y getCustomEmojis()
+      // puede consultar el servidor antes de que confirme el write nuevo.
+      // El snapshot del listener siempre incluye el write local de Firestore.
+      _rebuildFromCustomSnapshot(snapshot);
     }, onError: (error) {
       debugPrint('[InCircleView] Error en listener de emojis: $error');
     });
+  }
+
+  Future<void> _rebuildFromCustomSnapshot(QuerySnapshot snapshot) async {
+    try {
+      final predefined = await EmojiService.getPredefinedEmojis();
+      final custom = snapshot.docs
+          .map((doc) => StatusType.fromFirestore(doc))
+          .toList();
+      if (mounted) {
+        setState(() => _predefinedEmojis = [...predefined, ...custom]);
+      }
+    } catch (e) {
+      debugPrint('[InCircleView] Error reconstruyendo desde snapshot: $e');
+      _loadPredefinedEmojis(); // fallback al camino legacy
+    }
   }
 
   /// Iniciar monitoreo de geofencing para el círculo actual


### PR DESCRIPTION
## Summary

- Race condition en `_listenToCustomEmojis`: el cache custom se limpia al crear un emoji, y el re-fetch golpea el servidor antes de confirmación → `MemberDataParser` no encuentra el ID → fallback a `fine` (Bien) en la primera selección
- Fix: usar el snapshot del listener directamente en `_rebuildFromCustomSnapshot()` — siempre incluye el write local de Firestore, sin race posible
- 1 archivo modificado: `in_circle_view.dart`

## Test plan

- [ ] Crear estado personalizado nuevo en Settings
- [ ] Volver al círculo
- [ ] Abrir modal de emoji → seleccionar el nuevo estado
- [ ] Verificar que el estado se muestra correcto en el **primer intento** (sin pasar por "Bien")

🤖 Generated with [Claude Code](https://claude.com/claude-code)