### PR TITLE
fix(ui): restore account dialog and sync modal style in NoCircleView

### DIFF
--- a/lib/features/circle/presentation/widgets/no_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/no_circle_view.dart
@@ -27,6 +27,7 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
     }
     final fbUser = FirebaseAuth.instance.currentUser;
     if (fbUser?.displayName?.isNotEmpty == true) return fbUser!.displayName!;
+    if (fbUser?.email?.isNotEmpty == true) return fbUser!.email!.split('@')[0];
     return '...';
   }
 
@@ -46,12 +47,36 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
 
   void _showAccountDialog(BuildContext context) {
     final authState = ref.read(authProvider);
-    if (authState is! Authenticated) return;
-    final user = authState.user;
+    final fbUser = FirebaseAuth.instance.currentUser;
+
+    // ════════════════════════════════════════════════════════════
+    // [FIX] Dialog no aparecía si authProvider aún estaba en AuthLoading
+    // Fecha: 2026-06-04
+    // PROBLEMA: el guard `authState is! Authenticated` retornaba silenciosamente
+    //   mientras el header ya mostraba el nickname real (vía Firebase fallback),
+    //   dando la impresión de que la funcionalidad fue eliminada.
+    // SOLUCIÓN: mismo patrón fallback que _getCurrentUserNickname — si Riverpod
+    //   no tiene datos aún, usar FirebaseAuth directamente.
+    // ════════════════════════════════════════════════════════════
+    if (authState is! Authenticated && fbUser == null) return;
+
+    final nickname = authState is Authenticated
+        ? authState.user.nickname
+        : (fbUser?.displayName?.isNotEmpty == true
+            ? fbUser!.displayName!
+            : fbUser?.email?.split('@')[0] ?? '');
+    final email = authState is Authenticated
+        ? authState.user.email
+        : (fbUser?.email ?? '');
+
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: NkColors.surface2,
+        backgroundColor: NkColors.canvas,
+        shape: RoundedRectangleBorder(
+          borderRadius: NkRadius.forButton,
+          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
+        ),
         title: const Text(
           'Mi Cuenta',
           style: TextStyle(color: NkColors.onDark),
@@ -62,11 +87,11 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
           children: [
             const Text('Nickname', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
             const SizedBox(height: 4),
-            Text(user.nickname, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
+            Text(nickname, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
             const SizedBox(height: 16),
             const Text('Email', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
             const SizedBox(height: 4),
-            Text(user.email, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
+            Text(email, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
           ],
         ),
         actions: [


### PR DESCRIPTION
## Summary

- **Fix dialog silencioso**: `_showAccountDialog` retornaba sin mostrar nada cuando `authProvider` estaba en `AuthLoading`. Se agrega fallback a `FirebaseAuth.instance.currentUser` (mismo patrón que `_getCurrentUserNickname`).
- **Fix nickname `'...'`**: la cadena fallback ahora incluye `email.split('@')[0]` antes del `'...'` final, dado que esta app almacena el nickname en Firestore y `displayName` de Firebase Auth siempre está vacío.
- **Estilo modal unificado**: dialog "Mi Cuenta" alineado al estilo del modal "Silencio" — fondo `canvas` (#000), borde `mintSoft(0.4)` 1px, radius `NkRadius.forButton`.

## Archivos modificados

- `lib/features/circle/presentation/widgets/no_circle_view.dart` — solo `_showAccountDialog` y `_getCurrentUserNickname`

## Test plan

- [ ] Abrir app → pantalla sin círculo → tocar ícono de cuenta → dialog "Mi Cuenta" aparece con nickname y email correctos
- [ ] Verificar que el borde del dialog es mint semitransparente (igual que modal "Silencio")
- [ ] Verificar que el nickname en el header nunca muestra `'...'`
- [ ] Flujos no afectados: crear círculo, unirse, cerrar sesión, eliminar cuenta

🤖 Generated with [Claude Code](https://claude.com/claude-code)