### PR TITLE
feat(ds): Capa 2+3a DS v2.0 — NunaKinTextField + auth screens

### DIFF
--- a/lib/contexts/identity/presentation/pages/auth_final_page.dart
+++ b/lib/contexts/identity/presentation/pages/auth_final_page.dart
@@ -7,6 +7,7 @@ import '../../../../../app/theme/design_tokens.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:nunakin_app/features/circle/presentation/pages/home_page.dart';
 import 'package:nunakin_app/core/services/secure_credential_service.dart';
+import 'package:nunakin_app/core/widgets/nunakin_text_field.dart';
 
 class AuthFinalPage extends StatefulWidget {
   const AuthFinalPage({super.key});
@@ -36,10 +37,18 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
     super.initState();
     _updateTime();
     _startTimeUpdater();
+    _nicknameController.addListener(_updateFormValid);
+    _emailController.addListener(_updateFormValid);
+    _passwordController.addListener(_updateFormValid);
+    _confirmPasswordController.addListener(_updateFormValid);
   }
 
   @override
   void dispose() {
+    _nicknameController.removeListener(_updateFormValid);
+    _emailController.removeListener(_updateFormValid);
+    _passwordController.removeListener(_updateFormValid);
+    _confirmPasswordController.removeListener(_updateFormValid);
     _emailFocusNode.dispose();
     _nicknameFocusNode.dispose();
     super.dispose();
@@ -524,9 +533,6 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
   @override
   Widget build(BuildContext context) {
     const accentColor = NkColors.mint;
-    const primaryTextColor = NkColors.onDark;
-    const secondaryTextColor = NkColors.fgMuted;
-    const inputFillColor = NkColors.surface2;
 
     return Scaffold(
       appBar: AppBar(
@@ -577,145 +583,76 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     fontSize: 16,
-                    color: secondaryTextColor,
+                    color: NkColors.fgMuted,
                   ),
                 ),
                 const SizedBox(height: 40),
                 if (!_isLogin)
                   Column(
                     children: [
-                      TextField(
+                      NunaKinTextField(
                         key: const Key('field_nickname'),
+                        label: 'Nickname',
+                        placeholder: 'Tu apodo público (mínimo 1 caracter)',
+                        icon: Icons.person_outline,
                         controller: _nicknameController,
                         focusNode: _nicknameFocusNode,
-                        onChanged: (_) => _updateFormValid(),
-                        style: TextStyle(color: primaryTextColor),
-                        decoration: InputDecoration(
-                          labelText: 'Nickname',
-                          labelStyle: const TextStyle(color: NkColors.fgSub),
-                          floatingLabelStyle: const TextStyle(color: NkColors.mint),
-                          hintText: 'Tu apodo público (mínimo 1 caracter)',
-                          hintStyle: TextStyle(
-                              color: secondaryTextColor.withValues(alpha: 0.5)),
-                          prefixIcon: Icon(Icons.person_outline,
-                              color: secondaryTextColor),
-                          filled: true,
-                          fillColor: inputFillColor,
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide: BorderSide(color: NkColors.mintSoft(0.4), width: 0.5),
-                          ),
-                          focusedBorder: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(12),
-                            borderSide:
-                                BorderSide(color: accentColor, width: 1),
-                          ),
-                        ),
                       ),
                       const SizedBox(height: 16),
                     ],
                   ),
-                TextField(
+                NunaKinTextField(
                   key: const Key('field_email'),
+                  label: 'Email',
+                  placeholder: 'tu.email@ejemplo.com',
+                  icon: Icons.alternate_email,
                   controller: _emailController,
                   focusNode: _emailFocusNode,
-                  onChanged: (_) => _updateFormValid(),
-                  style: TextStyle(color: primaryTextColor),
-                  decoration: InputDecoration(
-                    labelText: 'Email',
-                    labelStyle: const TextStyle(color: NkColors.fgSub),
-                    floatingLabelStyle: const TextStyle(color: NkColors.mint),
-                    hintText: 'tu.email@ejemplo.com',
-                    hintStyle: TextStyle(
-                        color: secondaryTextColor.withValues(alpha: 0.5)),
-                    prefixIcon:
-                        Icon(Icons.alternate_email, color: secondaryTextColor),
-                    filled: true,
-                    fillColor: inputFillColor,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide(color: NkColors.mintSoft(0.4), width: 0.5),
-                    ),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide(color: accentColor, width: 1),
-                    ),
-                  ),
+                  keyboardType: TextInputType.emailAddress,
                 ),
                 const SizedBox(height: 16),
-                TextField(
+                NunaKinTextField(
                   key: const Key('field_password'),
+                  label: 'Contraseña',
+                  placeholder: '',
+                  icon: Icons.lock_outline,
                   controller: _passwordController,
-                  onChanged: (_) => _updateFormValid(),
                   obscureText: _isPasswordObscured,
-                  style: TextStyle(color: primaryTextColor),
-                  decoration: InputDecoration(
-                    labelText: 'Contraseña',
-                    labelStyle: const TextStyle(color: NkColors.fgSub),
-                    floatingLabelStyle: const TextStyle(color: NkColors.mint),
-                    prefixIcon:
-                        Icon(Icons.lock_outline, color: secondaryTextColor),
-                    filled: true,
-                    fillColor: inputFillColor,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide(color: NkColors.mintSoft(0.4), width: 0.5),
+                  suffixIcon: IconButton(
+                    icon: Icon(
+                      _isPasswordObscured
+                          ? Icons.visibility_off_outlined
+                          : Icons.visibility_outlined,
+                      color: NkColors.fgSub,
                     ),
-                    focusedBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide(color: accentColor, width: 1),
-                    ),
-                    suffixIcon: IconButton(
-                      icon: Icon(
-                        _isPasswordObscured
-                            ? Icons.visibility_off_outlined
-                            : Icons.visibility_outlined,
-                        color: secondaryTextColor,
-                      ),
-                      onPressed: () {
-                        setState(() {
-                          _isPasswordObscured = !_isPasswordObscured;
-                        });
-                      },
-                    ),
+                    onPressed: () {
+                      setState(() {
+                        _isPasswordObscured = !_isPasswordObscured;
+                      });
+                    },
                   ),
                 ),
                 if (!_isLogin) ...[
                   const SizedBox(height: 16),
-                  TextField(
+                  NunaKinTextField(
                     key: const Key('field_confirm_password'),
+                    label: 'Confirmar Contraseña',
+                    placeholder: '',
+                    icon: Icons.lock_outline,
                     controller: _confirmPasswordController,
-                    onChanged: (_) => _updateFormValid(),
                     obscureText: _isConfirmPasswordObscured,
-                    style: TextStyle(color: primaryTextColor),
-                    decoration: InputDecoration(
-                      labelText: 'Confirmar Contraseña',
-                      labelStyle: const TextStyle(color: NkColors.fgSub),
-                      floatingLabelStyle: const TextStyle(color: NkColors.mint),
-                      prefixIcon: Icon(Icons.lock_outline, color: secondaryTextColor),
-                      filled: true,
-                      fillColor: inputFillColor,
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(color: NkColors.mintSoft(0.4), width: 0.5),
+                    suffixIcon: IconButton(
+                      icon: Icon(
+                        _isConfirmPasswordObscured
+                            ? Icons.visibility_off_outlined
+                            : Icons.visibility_outlined,
+                        color: NkColors.fgSub,
                       ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                        borderSide: BorderSide(color: accentColor, width: 1),
-                      ),
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _isConfirmPasswordObscured
-                              ? Icons.visibility_off_outlined
-                              : Icons.visibility_outlined,
-                          color: secondaryTextColor,
-                        ),
-                        onPressed: () {
-                          setState(() {
-                            _isConfirmPasswordObscured = !_isConfirmPasswordObscured;
-                          });
-                        },
-                      ),
+                      onPressed: () {
+                        setState(() {
+                          _isConfirmPasswordObscured = !_isConfirmPasswordObscured;
+                        });
+                      },
                     ),
                   ),
                 ],
@@ -787,7 +724,7 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
                             _isLogin
                                 ? '¿No tienes una cuenta? '
                                 : '¿Ya tienes una cuenta? ',
-                            style: TextStyle(color: secondaryTextColor),
+                            style: TextStyle(color: NkColors.fgMuted),
                           ),
                           TextButton(
                             key: const Key('btn_toggle_mode'),

--- a/lib/core/widgets/nunakin_text_field.dart
+++ b/lib/core/widgets/nunakin_text_field.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import '../../app/theme/design_tokens.dart';
+
+class NunaKinTextField extends StatefulWidget {
+  final String label;
+  final String placeholder;
+  final IconData icon;
+  final bool obscureText;
+  final TextEditingController? controller;
+  final Widget? suffixIcon;
+  final FocusNode? focusNode;
+  final TextInputType? keyboardType;
+
+  const NunaKinTextField({
+    super.key,
+    required this.label,
+    required this.placeholder,
+    required this.icon,
+    this.obscureText = false,
+    this.controller,
+    this.suffixIcon,
+    this.focusNode,
+    this.keyboardType,
+  });
+
+  @override
+  State<NunaKinTextField> createState() => _NunaKinTextFieldState();
+}
+
+class _NunaKinTextFieldState extends State<NunaKinTextField> {
+  late TextEditingController _controller;
+  late FocusNode _focusNode;
+  bool _ownsController = false;
+  bool _ownsFocusNode = false;
+  bool _hasText = false;
+  bool _isFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.controller != null) {
+      _controller = widget.controller!;
+    } else {
+      _controller = TextEditingController();
+      _ownsController = true;
+    }
+    if (widget.focusNode != null) {
+      _focusNode = widget.focusNode!;
+    } else {
+      _focusNode = FocusNode();
+      _ownsFocusNode = true;
+    }
+    _hasText = _controller.text.isNotEmpty;
+    _controller.addListener(_onTextChanged);
+    _focusNode.addListener(_onFocusChanged);
+  }
+
+  void _onTextChanged() {
+    final hasText = _controller.text.isNotEmpty;
+    if (hasText != _hasText) {
+      setState(() => _hasText = hasText);
+    }
+  }
+
+  void _onFocusChanged() {
+    setState(() => _isFocused = _focusNode.hasFocus);
+  }
+
+  @override
+  void dispose() {
+    _focusNode.removeListener(_onFocusChanged);
+    _controller.removeListener(_onTextChanged);
+    if (_ownsFocusNode) _focusNode.dispose();
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isLabelVisible = _hasText || _isFocused;
+
+    return AnimatedContainer(
+      duration: NkDuration.hover,
+      padding: const EdgeInsets.symmetric(
+        horizontal: NkSpacing.s,
+        vertical: NkSpacing.xs2,
+      ),
+      decoration: BoxDecoration(
+        color: NkColors.surfaceCard,
+        border: Border.all(
+          color: _isFocused ? NkColors.mintSoft(0.4) : NkColors.surfaceBorder,
+        ),
+        borderRadius: NkRadius.forInput,
+      ),
+      child: Row(
+        children: [
+          Icon(
+            widget.icon,
+            color: _isFocused ? NkColors.mint : NkColors.fgHint,
+            size: 20,
+          ),
+          const SizedBox(width: NkSpacing.xs3),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AnimatedSize(
+                  duration: NkDuration.hover,
+                  curve: NkCurve.standard,
+                  child: SizedBox(
+                    height: isLabelVisible ? null : 0,
+                    child: isLabelVisible
+                        ? Padding(
+                            padding: const EdgeInsets.only(bottom: 2.0),
+                            child: Text(
+                              widget.label.toUpperCase(),
+                              style: const TextStyle(
+                                color: NkColors.mint,
+                                fontSize: 9,
+                                fontWeight: FontWeight.w700,
+                                letterSpacing: 1.2,
+                              ),
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ),
+                TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  obscureText: widget.obscureText,
+                  keyboardType: widget.keyboardType,
+                  style: const TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: NkColors.onDark,
+                  ),
+                  decoration: InputDecoration(
+                    hintText: isLabelVisible ? null : widget.placeholder,
+                    hintStyle: const TextStyle(
+                      color: NkColors.fgHint,
+                      fontWeight: FontWeight.w400,
+                    ),
+                    border: InputBorder.none,
+                    isDense: true,
+                    contentPadding: const EdgeInsets.symmetric(vertical: 4),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (widget.suffixIcon != null) widget.suffixIcon!,
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **Capa 2:** crea `lib/core/widgets/nunakin_text_field.dart` — widget con floating label manual (`AnimatedSize` + `AnimatedContainer`), tokens DS v2.0 (`surfaceCard`/`surfaceBorder`/`mint`/`NkRadius.input`), soporte de `focusNode` externo opcional
- **Capa 3a:** aplica `NunaKinTextField` en los 4 campos de `auth_final_page.dart` (nickname, email, password, confirm password); `onChanged` reemplazado por `controller.addListener(_updateFormValid)` en `initState`/`dispose`

## Comportamiento preservado
- Keys `field_nickname`, `field_email`, `field_password`, `field_confirm_password` intactas
- `_nicknameFocusNode` y `_emailFocusNode` pasados vía parámetro `focusNode` — `requestFocus()` en toggle login/register sigue funcionando
- Toggle de visibilidad de contraseña (suffixIcon `IconButton`) funciona vía `setState` del padre
- Validación del formulario (`_isFormValid`) sin cambio de comportamiento

## Test plan
- [ ] Login: escribir email + contraseña → botón se activa, `_isFormValid` true
- [ ] Login: campo vacío → botón desactivado
- [ ] Registro: los 4 campos completos → botón activo
- [ ] Floating label: aparece al enfocar o escribir, desaparece al limpiar y desenfocar
- [ ] Ojo de contraseña: toggle muestra/oculta texto
- [ ] Toggle login↔registro: focus salta al primer campo correcto

🤖 Generated with [Claude Code](https://claude.com/claude-code)