### PR TITLE
fix(ds): NunaKinTextField focused bg — mint tint on focus

### DIFF
--- a/lib/core/widgets/nunakin_text_field.dart
+++ b/lib/core/widgets/nunakin_text_field.dart
@@ -86,7 +86,7 @@ class _NunaKinTextFieldState extends State<NunaKinTextField> {
         vertical: NkSpacing.xs2,
       ),
       decoration: BoxDecoration(
-        color: NkColors.surfaceCard,
+        color: _isFocused ? NkColors.mintSoft(0.08) : NkColors.surfaceCard,
         border: Border.all(
           color: _isFocused ? NkColors.mintSoft(0.4) : NkColors.surfaceBorder,
         ),


### PR DESCRIPTION
## Problema
El fondo del campo se veía siempre igual (#0E0E10) en ambos estados (reposo y foco), sin diferenciación visual.

## Fix
Una línea en `lib/core/widgets/nunakin_text_field.dart`:

| Estado | Antes | Después |
|--------|-------|---------|
| Reposo | `surfaceCard` (white 4%) | `surfaceCard` (sin cambio) |
| Foco   | `surfaceCard` (igual) | `mintSoft(0.08)` — tinte mint sutil |

El tinte mint al enfocar implementa el "el contenedor completo se ilumina" de la spec DS v2.0 §2, sin romper la estética minimalista.

## Test plan
- [ ] Login: enfocar campo Email → fondo cambia a tinte mint sutil
- [ ] Login: desenfocar → vuelve al fondo neutro
- [ ] Registro: mismo comportamiento en los 4 campos
- [ ] Animación suave entre estados (AnimatedContainer 120ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)