### PR TITLE
feat(ui): extract NkAppHeader widget + fix nickname fallback chain

### DIFF
--- a/docs/ui/NunaKin Design System.md
+++ b/docs/ui/NunaKin Design System.md
@@ -87,23 +87,74 @@ Este patrón es una de las soluciones de usabilidad y diseño móvil más sofist
 
 ## **4\. Tokens Visuales v2.0 (Especificaciones de Código)**
 
-### **Colores (Color Tokens)**
+### **Colores (NkColors)**
 
-* BG\_CANVAS: \#000000 (Negro absoluto, sin gradientes generales).  
-* COLOR\_BRAND: \#1CE8A1 (Mint característico \- usado para CTAs activos, acentos seleccionados).  
-* COLOR\_BRAND\_DEEP: \#0F6B4C (Mint oscuro \- usado para estados hovered, fondos de botones secundarios).  
-* COLOR\_SOS: \#E53E3E a \#C53030 (Gradiente de alerta premium para S.O.S).  
-* SURFACE\_CARD: rgba(255, 255, 255, 0.04) (Para contenedores, inputs y tarjetas).  
-* SURFACE\_BORDER: rgba(255, 255, 255, 0.08) (Bordes sutiles de 1px para delimitar superficies).  
-* TEXT\_PRIMARY: \#FFFFFF (Blanco puro para títulos y lecturas principales).  
-* TEXT\_MUTED: rgba(255, 255, 255, 0.4) (Gris suave para placeholders).
+| Token Dart | Valor | Descripción |
+| :---- | :---- | :---- |
+| `NkColors.canvas` | `#000000` | Fondo base negro absoluto — sin gradientes generales |
+| `NkColors.mint` | `#1CE8A1` | Mint de marca — CTAs activos, acentos, seleccionados |
+| `NkColors.mintDeep` | `#17C98C` | Mint oscuro — estado pressed del CTA primario |
+| `NkColors.mintSoft(α)` | `mint.withOpacity(α)` | Mint semitransparente — fondos de íconos, bordes sutiles |
+| `NkColors.onDark` | `#FFFFFF` | Texto primario sobre canvas y superficies oscuras |
+| `NkColors.fgMuted` | `rgba(255,255,255, 0.80)` | Texto secundario — subtítulos, descripciones |
+| `NkColors.fgSub` | `rgba(255,255,255, 0.60)` | Texto terciario — labels, captions |
+| `NkColors.fgHint` | `rgba(255,255,255, 0.40)` | Texto sutil — placeholders, hints |
+| `NkColors.fgDisabled` | `rgba(255,255,255, 0.25)` | Texto deshabilitado |
+| `NkColors.surface1` | `#000000` | Alias de canvas |
+| `NkColors.surface2` | `#1C1C1E` | Cards, dialogs — iOS grouped background |
+| `NkColors.surface3` | `#2C2C2E` | Inputs, fills — iOS secondary background |
+| `NkColors.surface4` | `#3A3A3C` | Hover / pressed sobre superficie |
+| `NkColors.surfaceCard` | `rgba(255,255,255, 0.04)` | Fondo de tarjetas e inputs DS v2.0 |
+| `NkColors.surfaceBorder` | `rgba(255,255,255, 0.08)` | Borde de reposo de 1px en superficies DS v2.0 |
+| `NkColors.line` | `rgba(255,255,255, 0.10)` | Divisor / borde legacy (preferir `surfaceBorder` en código nuevo) |
+| `NkColors.danger` | `#D32F2F` | Acciones destructivas — eliminar cuenta, errores críticos |
+| `NkColors.dangerSoft` | `rgba(211,47,47, 0.20)` | Fondo tenue de alerta destructiva |
+| `NkColors.mintGlow` | `rgba(28,232,161, 0.16)` | Resplandor del CTA primario |
+| `NkColors.onMint` | `#000000` | Foreground sobre botón mint sólido |
 
-### **Radios de Esquinas (Radii)**
+> **Gradiente SOS:** `#E53E3E → #C53030` — usado directamente en el widget SOS, no como token `NkColors`.
 
-* Inputs y Botones Pequeños: 14px  
-* Tarjetas e Items de Lista: 18px  
-* Modales y Bottom Sheets: 28px  
-* Chips y Pills de Estado: 999px
+### **Radios de Esquinas (NkRadius)**
+
+| Token Dart | Valor | Uso |
+| :---- | :---- | :---- |
+| `NkRadius.forSmall` | 8px | Elementos muy pequeños |
+| `NkRadius.forInput` | 14px | Inputs y botones pequeños |
+| `NkRadius.forButton` | 14px | Botones (unificado con `forInput` en v2.0) |
+| `NkRadius.forCard` | 18px | Tarjetas e items de lista |
+| `NkRadius.forModal` | 28px | Modales y bottom sheets |
+| `NkRadius.forPill` | 999px | Chips y pills de estado |
+
+### **Espaciado (NkSpacing — grid de 4pt)**
+
+| Token Dart | Valor (pt) | Uso frecuente |
+| :---- | :---- | :---- |
+| `NkSpacing.xs1` | 4 | — |
+| `NkSpacing.xs2` | 8 | — |
+| `NkSpacing.xs3` | 12 | Separación entre secciones menores, dividers |
+| `NkSpacing.s` | 16 | Gap entre ítems de lista |
+| `NkSpacing.s5` | 20 | Padding interno de tarjetas de acción |
+| `NkSpacing.m` | 24 | Padding lateral default de cards / CTAs |
+| `NkSpacing.l` | 32 | Gap entre secciones principales |
+| `NkSpacing.xl` | 40 | Espaciado mayor entre bloques |
+| `NkSpacing.xl2` | 48 | — |
+| `NkSpacing.xxl` | 64 | — |
+| `NkSpacing.touchTarget` | 44 | Touch target mínimo obligatorio (HIG) |
+
+### **Tipografía (NkTextStyle)**
+
+Fuente: sistema operativo nativo (SF Pro en iOS, Roboto en Android).
+
+| Token Dart | fontSize | fontWeight | Color default |
+| :---- | :---- | :---- | :---- |
+| `NkTextStyle.display` | 32px | w700 | `onDark` |
+| `NkTextStyle.h1` | 28px | w700 | `onDark` |
+| `NkTextStyle.h2` | 22px | w600 | `onDark` |
+| `NkTextStyle.h3` | 18px | w600 | `onDark` |
+| `NkTextStyle.body` | 16px | w400 | `onDark` |
+| `NkTextStyle.meta` | 14px | w400 | `fgMuted` |
+| `NkTextStyle.micro` | 12px | w400 | `fgSub` |
+| `NkTextStyle.mono` | 16px | w500 | `onDark` — monospace, `letterSpacing: 2.0` (códigos de invitación, debug) |
 
 ## **5\. Copywriting & Microcopy v2.0**
 

--- a/lib/contexts/identity/presentation/pages/auth_final_page.dart
+++ b/lib/contexts/identity/presentation/pages/auth_final_page.dart
@@ -8,6 +8,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:nunakin_app/features/circle/presentation/pages/home_page.dart';
 import 'package:nunakin_app/core/services/secure_credential_service.dart';
 import 'package:nunakin_app/core/widgets/nunakin_text_field.dart';
+import 'package:nunakin_app/core/widgets/nk_app_header.dart';
 
 class AuthFinalPage extends StatefulWidget {
   const AuthFinalPage({super.key});
@@ -535,22 +536,13 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
     const accentColor = NkColors.mint;
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          'NunaKin',
-          style: TextStyle(
-            fontSize: 26,
-            fontWeight: FontWeight.bold,
-            color: NkColors.mint,
-            letterSpacing: 1.2,
-          ),
-        ),
-        backgroundColor: NkColors.canvas,
-        elevation: 0,
-      ),
       backgroundColor: NkColors.canvas,
-      body: Center(
-        child: SingleChildScrollView(
+      body: Column(
+        children: [
+          const NkAppHeader(),
+          Expanded(
+            child: Center(
+              child: SingleChildScrollView(
           child: Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(
@@ -782,6 +774,9 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
             ),
           ),
         ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/core/widgets/nk_app_header.dart
+++ b/lib/core/widgets/nk_app_header.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../splash/splash_screen.dart' show ZyncLogoPainter;
+import '../../app/theme/design_tokens.dart';
+
+class NkAppHeader extends StatelessWidget {
+  final String? subtitle;
+  final Widget? trailing;
+
+  const NkAppHeader({super.key, this.subtitle, this.trailing});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 40, 16, 16),
+      color: NkColors.canvas,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CustomPaint(painter: ZyncLogoPainter(color: NkColors.mint)),
+                    ),
+                    const SizedBox(width: 6),
+                    const Text(
+                      'NunaKin',
+                      style: TextStyle(
+                        fontSize: 26,
+                        fontWeight: FontWeight.bold,
+                        color: NkColors.mint,
+                        letterSpacing: -0.5,
+                      ),
+                    ),
+                  ],
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    subtitle!,
+                    style: NkTextStyle.body.copyWith(color: NkColors.fgSub),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          if (trailing != null) trailing!,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/circle/presentation/widgets/no_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/no_circle_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import '../../../../core/splash/splash_screen.dart' show ZyncLogoPainter;
+import '../../../../core/widgets/nk_app_header.dart';
 import '../../../../contexts/identity/presentation/provider/auth_provider.dart';
 import '../../../../contexts/identity/presentation/provider/auth_state.dart';
 import '../../../../contexts/identity/presentation/pages/auth_final_page.dart';
@@ -25,9 +25,13 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
       final u = authState.user;
       if (u.nickname.isNotEmpty) return u.nickname;
       if (u.name.isNotEmpty) return u.name;
+      if (u.email.isNotEmpty) return u.email.split('@')[0];
     }
     final fbUser = FirebaseAuth.instance.currentUser;
-    if (fbUser?.displayName?.isNotEmpty == true) return fbUser!.displayName!;
+    if (fbUser != null) {
+      if (fbUser.displayName?.isNotEmpty == true) return fbUser.displayName!;
+      return fbUser.email?.split('@')[0] ?? '...';
+    }
     return '...';
   }
 
@@ -417,61 +421,22 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        // AppBar personalizado (igual que InCircleView)
-        Container(
-          padding: const EdgeInsets.fromLTRB(16, 40, 16, 16),
-          color: NkColors.canvas,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        SizedBox(
-                          width: 20,
-                          height: 20,
-                          child: CustomPaint(painter: ZyncLogoPainter(color: NkColors.mint)),
-                        ),
-                        const SizedBox(width: 6),
-                        const Text(
-                          'NunaKin',
-                          style: TextStyle(
-                            fontSize: 26,
-                            fontWeight: FontWeight.bold,
-                            color: NkColors.mint,
-                            letterSpacing: -0.5,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      _getCurrentUserNickname(),
-                      style: NkTextStyle.body.copyWith(color: NkColors.fgSub),
-                    ),
-                  ],
-                ),
-              ),
-              ElevatedButton.icon(
-                key: const Key('btn_logout'),
-                onPressed: () => _showLogoutDialog(context),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFF02130D),
-                  foregroundColor: NkColors.mint,
-                  side: BorderSide(color: NkColors.mintSoft(0.3), width: 1),
-                  padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                  textStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-                  shape: RoundedRectangleBorder(borderRadius: NkRadius.forInput),
-                  elevation: 0,
-                ),
-                icon: const Icon(Icons.logout, size: 18),
-                label: const Text('Cerrar sesión'),
-              ),
-            ],
+        NkAppHeader(
+          subtitle: _getCurrentUserNickname(),
+          trailing: ElevatedButton.icon(
+            key: const Key('btn_logout'),
+            onPressed: () => _showLogoutDialog(context),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF02130D),
+              foregroundColor: NkColors.mint,
+              side: BorderSide(color: NkColors.mintSoft(0.3), width: 1),
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+              textStyle: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+              shape: RoundedRectangleBorder(borderRadius: NkRadius.forInput),
+              elevation: 0,
+            ),
+            icon: const Icon(Icons.logout, size: 18),
+            label: const Text('Cerrar sesión'),
           ),
         ),
 
@@ -555,7 +520,7 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  'Crear un Círculo',
+                                  'Crear un círculo',
                                   style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: NkColors.onDark),
                                 ),
                                 SizedBox(height: 3),
@@ -621,7 +586,7 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  'Unirse a un Círculo',
+                                  'Unirse a un círculo',
                                   style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: NkColors.onDark),
                                 ),
                                 SizedBox(height: 3),


### PR DESCRIPTION
## Summary

- **Nuevo widget** `NkAppHeader(subtitle?, trailing?)` en `lib/core/widgets/` — logo + \"NunaKin\" + subtitle opcional + botón opcional
- **`no_circle_view`** migrado: bloque header inline (57 líneas) reemplazado por `NkAppHeader`
- **`auth_final_page`** migrado: `AppBar` nativo eliminado, `const NkAppHeader()` sin params
- **Fix nickname** en `no_circle_view._getCurrentUserNickname`: cadena de fallback completada (`nickname → name → email.split('@')[0]`), idéntica a `in_circle_view`
- **DS MD §4** reescrito como tablas con nombres Dart canónicos; nuevas secciones `NkSpacing` (§4.3) y `NkTextStyle` (§4.4); tokens `surface3` y `danger` documentados

> `InCircleHeader` no fue tocado — queda para siguiente paso.

## Archivos afectados

| Archivo | Cambio |
|---|---|
| `lib/core/widgets/nk_app_header.dart` | Creado |
| `lib/features/circle/presentation/widgets/no_circle_view.dart` | Header migrado + fix nickname |
| `lib/contexts/identity/presentation/pages/auth_final_page.dart` | AppBar → NkAppHeader |
| `docs/ui/NunaKin Design System.md` | §4 actualizado |

## Test plan

- [ ] T1 — NoCircleView header visual: logo + "NunaKin" + nickname (no '...')
- [ ] T2 — NoCircleView botón "Cerrar sesión": dialog + cancel + confirm
- [ ] T3 — NoCircleView resto de pantalla intacto (tarjetas, footer, navegación)
- [ ] T4 — AuthFinalPage header nuevo: logo + "NunaKin", sin trailing, sin subtitle, scroll OK
- [ ] T5 — AuthFinalPage flujo auth intacto: login, registro, toggle, reset password
- [ ] T6 — Regresión InCircleView: header sin cambios visuales

🤖 Generated with [Claude Code](https://claude.com/claude-code)