### PR TITLE
style: unify dialogs via NkDialog DS widget

### DIFF
--- a/lib/core/widgets/nk_dialog.dart
+++ b/lib/core/widgets/nk_dialog.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import '../../app/theme/design_tokens.dart';
+
+/// Diálogo unificado del Design System NunaKin.
+///
+/// UFV de estilo: modal "Silencio" en in_circle_footer.dart.
+///
+/// Uso básico:
+///   final ok = await NkDialog.confirm(context, title: 'Silencio', body: '...');
+///   await NkDialog.inform(context, title: 'Mi Cuenta', contentWidget: myCol);
+class NkDialog {
+  NkDialog._();
+
+  // ─── Confirm ──────────────────────────────────────────────────────────────
+
+  /// Muestra un diálogo de confirmación con dos acciones (cancelar / confirmar).
+  /// Retorna `true` si el usuario confirma, `false` o `null` en caso contrario.
+  static Future<bool?> confirm(
+    BuildContext context, {
+    required String title,
+    required String body,
+    String cancelLabel = 'Cancelar',
+    String confirmLabel = 'Confirmar',
+    bool confirmDestructive = false,
+    bool barrierDismissible = true,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      barrierColor: NkColors.canvas.withValues(alpha: 0.75),
+      barrierDismissible: barrierDismissible,
+      builder: (ctx) => Dialog(
+        backgroundColor: NkColors.canvas,
+        insetPadding: const EdgeInsets.symmetric(
+          horizontal: NkSpacing.m,
+          vertical: NkSpacing.m,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: NkRadius.forButton,
+          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(NkSpacing.s5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: NkTextStyle.h3),
+              const SizedBox(height: 12),
+              Text(
+                body,
+                style: NkTextStyle.meta.copyWith(color: NkColors.fgMuted),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(false),
+                    style: TextButton.styleFrom(
+                      foregroundColor: NkColors.fgSub,
+                    ),
+                    child: Text(cancelLabel),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(true),
+                    style: TextButton.styleFrom(
+                      foregroundColor: confirmDestructive
+                          ? NkColors.danger
+                          : NkColors.mint,
+                    ),
+                    child: Text(
+                      confirmLabel,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ─── Inform ───────────────────────────────────────────────────────────────
+
+  /// Muestra un diálogo informativo con una sola acción de cierre.
+  /// Acepta [body] (texto plano) o [contentWidget] (widget custom).
+  /// Si se pasan ambos, [contentWidget] tiene prioridad.
+  static Future<void> inform(
+    BuildContext context, {
+    required String title,
+    String? body,
+    Widget? contentWidget,
+    String closeLabel = 'Entendido',
+    Color? closeColor,
+  }) {
+    assert(body != null || contentWidget != null,
+        'NkDialog.inform requiere body o contentWidget');
+    return showDialog<void>(
+      context: context,
+      barrierColor: NkColors.canvas.withValues(alpha: 0.75),
+      barrierDismissible: true,
+      builder: (ctx) => Dialog(
+        backgroundColor: NkColors.canvas,
+        insetPadding: const EdgeInsets.symmetric(
+          horizontal: NkSpacing.m,
+          vertical: NkSpacing.m,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: NkRadius.forButton,
+          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(NkSpacing.s5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: NkTextStyle.h3),
+              const SizedBox(height: 12),
+              if (contentWidget != null)
+                contentWidget
+              else
+                Text(
+                  body!,
+                  style: NkTextStyle.meta.copyWith(color: NkColors.fgMuted),
+                ),
+              const SizedBox(height: 18),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  style: TextButton.styleFrom(
+                    foregroundColor: closeColor ?? NkColors.mint,
+                  ),
+                  child: Text(
+                    closeLabel,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/circle/presentation/widgets/in_circle_footer.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_footer.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import '../../../../app/theme/design_tokens.dart';
 import '../../../../core/services/silent_functionality_coordinator.dart';
+import '../../../../core/widgets/nk_dialog.dart';
 import 'silent_mode_button.dart';
 
 class InCircleFooter extends StatefulWidget {
@@ -17,56 +18,12 @@ class _InCircleFooterState extends State<InCircleFooter> {
   bool _isUpdating = false;
 
   Future<void> _confirmAndActivateSilentMode() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      barrierColor: NkColors.canvas.withValues(alpha: 0.75),
-      barrierDismissible: true,
-      builder: (dialogContext) {
-        return Dialog(
-          backgroundColor: NkColors.canvas,
-          insetPadding: const EdgeInsets.symmetric(horizontal: NkSpacing.m, vertical: NkSpacing.m),
-          shape: RoundedRectangleBorder(
-            borderRadius: NkRadius.forButton,
-            side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(NkSpacing.s5),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  'Silencio',
-                  style: NkTextStyle.h3,
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  'La app se minimizará y quedará activa en segundo plano. '
-                  'Podrás cambiar tu estado desde la notificación persistente.',
-                  style: NkTextStyle.meta.copyWith(color: NkColors.fgMuted),
-                ),
-                const SizedBox(height: 18),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(false),
-                      style: TextButton.styleFrom(foregroundColor: NkColors.fgSub),
-                      child: const Text('Cancelar'),
-                    ),
-                    const SizedBox(width: 8),
-                    TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(true),
-                      style: TextButton.styleFrom(foregroundColor: NkColors.mint),
-                      child: const Text('Activar', style: TextStyle(fontWeight: FontWeight.bold)),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        );
-      },
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Silencio',
+      body: 'La app se minimizará y quedará activa en segundo plano. '
+          'Podrás cambiar tu estado desde la notificación persistente.',
+      confirmLabel: 'Activar',
     );
 
     if (confirmed == true && mounted) {

--- a/lib/features/circle/presentation/widgets/no_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/no_circle_view.dart
@@ -8,6 +8,7 @@ import '../../../../contexts/identity/presentation/pages/auth_final_page.dart';
 import '../../../../core/services/session_cache_service.dart';
 import '../../../../services/circle_service.dart';
 import '../../../../app/theme/design_tokens.dart';
+import '../../../../core/widgets/nk_dialog.dart';
 import 'create_circle_view.dart';
 import 'join_circle_view.dart';
 
@@ -73,79 +74,50 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
         ? authState.user.email
         : (fbUser?.email ?? '');
 
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: NkColors.canvas,
-        shape: RoundedRectangleBorder(
-          borderRadius: NkRadius.forButton,
-          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
-        ),
-        title: const Text(
-          'Mi Cuenta',
-          style: TextStyle(color: NkColors.onDark),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text('Nickname', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
-            const SizedBox(height: 4),
-            Text(nickname, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
-            const SizedBox(height: 16),
-            const Text('Email', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
-            const SizedBox(height: 4),
-            Text(email, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
-          ],
-        ),
-        actions: [
+    NkDialog.inform(
+      context,
+      title: 'Mi Cuenta',
+      contentWidget: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Nickname', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
+          const SizedBox(height: 4),
+          Text(nickname, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
+          const SizedBox(height: 16),
+          const Text('Email', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
+          const SizedBox(height: 4),
+          Text(email, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
+          const SizedBox(height: 16),
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
               _showDeleteAccountDialog(context);
             },
-            child: const Text('Eliminar Cuenta', style: TextStyle(color: NkColors.danger)),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cerrar', style: TextStyle(color: NkColors.mint)),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showDeleteAccountDialog(BuildContext parentContext) {
-    showDialog(
-      context: parentContext,
-      barrierDismissible: false,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: NkColors.surface2,
-        shape: RoundedRectangleBorder(borderRadius: NkRadius.forButton),
-        title: const Text('Eliminar Cuenta', style: TextStyle(color: NkColors.onDark)),
-        content: const Text(
-          '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
-          style: TextStyle(color: NkColors.fgSub),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Cancelar', style: TextStyle(color: NkColors.fgSub)),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(dialogContext).pop();
-              // FIX: Usar mounted del State y this.context en lugar del context del diálogo
-              if (mounted) {
-                _executeDeleteAccount(context);
-              }
-            },
-            style: TextButton.styleFrom(foregroundColor: NkColors.danger),
+            style: TextButton.styleFrom(
+              padding: EdgeInsets.zero,
+              foregroundColor: NkColors.danger,
+            ),
             child: const Text('Eliminar Cuenta'),
           ),
         ],
       ),
+      closeLabel: 'Cerrar',
     );
+  }
+
+  void _showDeleteAccountDialog(BuildContext parentContext) async {
+    final confirmed = await NkDialog.confirm(
+      parentContext,
+      title: 'Eliminar Cuenta',
+      body: '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
+      confirmLabel: 'Eliminar Cuenta',
+      confirmDestructive: true,
+      barrierDismissible: false,
+    );
+    if (confirmed == true && mounted) {
+      _executeDeleteAccount(context);
+    }
   }
 
   Future<void> _executeDeleteAccount(BuildContext context) async {
@@ -351,70 +323,39 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
     );
   }
 
-  void _showLogoutDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: NkColors.surface2,
-        title: const Text(
-          'Cerrar Sesión',
-          style: TextStyle(color: NkColors.onDark),
-        ),
-        content: const Text(
-          '¿Estás seguro de que quieres cerrar sesión?',
-          style: TextStyle(color: NkColors.fgSub),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text(
-              'Cancelar',
-              style: TextStyle(color: NkColors.fgSub),
-            ),
-          ),
-          TextButton(
-            key: const Key('dialog_btn_logout_confirm'),
-            onPressed: () async {
-              Navigator.of(context).pop();
-              try {
-                print('🔴 [LOGOUT] Iniciando logout desde NoCircleView (sin círculo)...');
-
-                // PASO 1: Limpiar cache PRIMERO (evita parpadeo de NoCircleView)
-                print('🔴 [LOGOUT] Limpiando SessionCache...');
-                await SessionCacheService.clearSession();
-
-                // PASO 2: Cerrar sesión Firebase
-                await FirebaseAuth.instance.signOut();
-                print('🔴 [LOGOUT] Firebase signOut completado');
-
-                // PASO 3: Navegar directo a login (sin SnackBar)
-                if (context.mounted) {
-                  Navigator.of(context).pushAndRemoveUntil(
-                    MaterialPageRoute(builder: (_) => const AuthFinalPage()),
-                    (route) => false,
-                  );
-                  print('✅ [LOGOUT] Navegación completada');
-                }
-              } catch (e) {
-                print('❌ [LOGOUT] Error: $e');
-                // Solo mostrar error si realmente falla
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text('Error al cerrar sesión: $e'),
-                      backgroundColor: NkColors.danger,
-                      duration: const Duration(seconds: 2),
-                    ),
-                  );
-                }
-              }
-            },
-            style: TextButton.styleFrom(foregroundColor: NkColors.danger),
-            child: const Text('Cerrar Sesión'),
-          ),
-        ],
-      ),
+  void _showLogoutDialog(BuildContext outerContext) async {
+    final confirmed = await NkDialog.confirm(
+      outerContext,
+      title: 'Cerrar Sesión',
+      body: '¿Estás seguro de que quieres cerrar sesión?',
+      confirmLabel: 'Cerrar Sesión',
     );
+    if (confirmed != true) return;
+    try {
+      print('🔴 [LOGOUT] Iniciando logout desde NoCircleView (sin círculo)...');
+      print('🔴 [LOGOUT] Limpiando SessionCache...');
+      await SessionCacheService.clearSession();
+      await FirebaseAuth.instance.signOut();
+      print('🔴 [LOGOUT] Firebase signOut completado');
+      if (outerContext.mounted) {
+        Navigator.of(outerContext).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const AuthFinalPage()),
+          (route) => false,
+        );
+        print('✅ [LOGOUT] Navegación completada');
+      }
+    } catch (e) {
+      print('❌ [LOGOUT] Error: $e');
+      if (outerContext.mounted) {
+        ScaffoldMessenger.of(outerContext).showSnackBar(
+          SnackBar(
+            content: Text('Error al cerrar sesión: $e'),
+            backgroundColor: NkColors.danger,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    }
   }
 
   @override

--- a/lib/features/geofencing/presentation/pages/zones_page.dart
+++ b/lib/features/geofencing/presentation/pages/zones_page.dart
@@ -9,6 +9,7 @@ import '../../services/zone_service.dart';
 import '../widgets/zone_form.dart';
 import '../widgets/geofencing_debug_widget.dart';
 import '../../../../app/theme/design_tokens.dart';
+import '../../../../core/widgets/nk_dialog.dart';
 
 /// Página de gestión de zonas geográficas
 /// Lista todas las zonas del círculo con opciones CRUD
@@ -244,40 +245,19 @@ class _ZonesPageState extends ConsumerState<ZonesPage> {
     );
   }
 
-  void _confirmDelete(BuildContext context, Zone zone) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: NkColors.surface2,
-        title: const Text(
-          'Eliminar zona',
-          style: TextStyle(color: NkColors.onDark),
-        ),
-        content: Text(
-          '¿Estás seguro de eliminar "${zone.name}"?\n\nEsta acción no se puede deshacer.',
-          style: const TextStyle(color: NkColors.fgMuted),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'CANCELAR',
-              style: TextStyle(color: NkColors.fgSub),
-            ),
-          ),
-          TextButton(
-            onPressed: () async {
-              Navigator.pop(context);
-              await _deleteZone(context, zone);
-            },
-            child: const Text(
-              'ELIMINAR',
-              style: TextStyle(color: NkColors.danger),
-            ),
-          ),
-        ],
-      ),
+  void _confirmDelete(BuildContext context, Zone zone) async {
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Eliminar zona',
+      body: '¿Estás seguro de eliminar "${zone.name}"?\n\nEsta acción no se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      cancelLabel: 'Cancelar',
+      confirmDestructive: true,
+      barrierDismissible: false,
     );
+    if (confirmed == true && context.mounted) {
+      await _deleteZone(context, zone);
+    }
   }
 
   Future<void> _deleteZone(BuildContext context, Zone zone) async {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -9,6 +9,7 @@ import '../../../../contexts/identity/presentation/pages/auth_final_page.dart';
 import '../../../../core/widgets/quick_actions_config_widget.dart';
 import '../../../../core/services/silent_functionality_coordinator.dart'; // Point 1 SPEC
 import '../../../../core/services/session_cache_service.dart'; // FIX: Para limpiar cache en logout
+import '../../../../core/widgets/nk_dialog.dart';
 import 'emoji_management_page.dart'; // Gestión de estados/emojis
 import '../../../geofencing/presentation/pages/zones_page.dart'; // Gestión de zonas geográficas
 import '../../../../services/circle_service.dart'; // Para obtener Circle object
@@ -315,36 +316,19 @@ class _SettingsPageState extends ConsumerState<SettingsPage> with SingleTickerPr
     }
   }
 
-  /// Point 1 SPEC: Muestra diálogo de confirmación para cerrar sesión
-  void _showDeleteAccountDialog(BuildContext context) {
-    showDialog(
-      context: context,
+  /// Point 1 SPEC: Muestra diálogo de confirmación para eliminar cuenta
+  void _showDeleteAccountDialog(BuildContext context) async {
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Eliminar Cuenta',
+      body: '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
+      confirmLabel: 'Eliminar Cuenta',
+      confirmDestructive: true,
       barrierDismissible: false,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: _AppColors.cardBackground,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Eliminar Cuenta', style: TextStyle(color: _AppColors.textPrimary)),
-        content: const Text(
-          '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
-          style: TextStyle(color: _AppColors.textSecondary),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Cancelar', style: TextStyle(color: _AppColors.textSecondary)),
-          ),
-          TextButton(
-            onPressed: () async {
-              Navigator.of(dialogContext).pop();
-              if (mounted) {
-                _executeDeleteAccount(this.context);
-              }
-            },
-            child: const Text('Eliminar Cuenta', style: TextStyle(color: _AppColors.sosRed)),
-          ),
-        ],
-      ),
     );
+    if (confirmed == true && mounted) {
+      _executeDeleteAccount(this.context);
+    }
   }
 
   Future<void> _executeDeleteAccount(BuildContext context) async {
@@ -527,110 +511,66 @@ class _SettingsPageState extends ConsumerState<SettingsPage> with SingleTickerPr
   }
 
   void _showCircleLostInfoDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: _AppColors.cardBackground,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Ya no estás en tu círculo', style: TextStyle(color: _AppColors.textPrimary)),
-        content: const Text(
-          'Al cancelar la eliminación saliste de tu círculo. Para volver, pídele a alguien del grupo que te comparta el código de invitación.',
-          style: TextStyle(color: _AppColors.textSecondary),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Entendido', style: TextStyle(color: _AppColors.accent)),
-          ),
-        ],
-      ),
+    NkDialog.inform(
+      context,
+      title: 'Ya no estás en tu círculo',
+      body: 'Al cancelar la eliminación saliste de tu círculo. Para volver, pídele a alguien del grupo que te comparta el código de invitación.',
     );
   }
 
-  void _showLogoutDialog(BuildContext context, WidgetRef ref) {
-    showDialog(
-      context: context,
-      barrierDismissible: false, // Evitar cerrar el diálogo accidentalmente durante el proceso
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: _AppColors.cardBackground,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Cerrar Sesión', style: TextStyle(color: _AppColors.textPrimary)),
-        content: const Text('¿Estás seguro?', style: TextStyle(color: _AppColors.textSecondary)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Cancelar', style: TextStyle(color: _AppColors.textSecondary)),
-          ),
-          TextButton(
-            onPressed: () async {
-              // 1. Cerrar el diálogo PRIMERO
-              Navigator.of(dialogContext).pop();
-
-              // 2. Mostrar indicador de carga
-              if (context.mounted) {
-                showDialog(
-                  context: context,
-                  barrierDismissible: false,
-                  builder: (_) => const Center(
-                    child: CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation<Color>(NkColors.mint),
-                    ),
-                  ),
-                );
-              }
-
-              try {
-                // 3. Limpiar notificaciones y servicios (Point 1.1 - paso 2 y 3)
-                print('🔴 [LOGOUT] Iniciando proceso de logout desde Settings...');
-                print('🔴 [LOGOUT] Paso 1/3: Desactivando funcionalidad silenciosa...');
-
-                await SilentFunctionalityCoordinator.deactivateAfterLogout().timeout(
-                  const Duration(seconds: 10),
-                  onTimeout: () {
-                    print('⚠️ [LOGOUT] Timeout en deactivateAfterLogout, continuando...');
-                  },
-                );
-
-                // FIX: Limpiar SessionCache INMEDIATAMENTE para evitar parpadeo
-                print('🔴 [LOGOUT] Limpiando SessionCache...');
-                await SessionCacheService.clearSession();
-
-                print('🔴 [LOGOUT] Paso 2/3: Cerrando sesión de Firebase...');
-
-                // 4. Invalidar sesión (Point 1.1 - paso 1)
-                await FirebaseAuth.instance.signOut().timeout(
-                  const Duration(seconds: 10),
-                  onTimeout: () {
-                    print('⚠️ [LOGOUT] Timeout en signOut, continuando...');
-                  },
-                );
-
-                print('🔴 [LOGOUT] Paso 3/3: Redirigiendo a login...');
-              } catch (e) {
-                print('❌ [LOGOUT] Error durante logout: $e');
-                // Continuar con navegación incluso si hay error
-              } finally {
-                // 5. SIEMPRE navegar a login (Point 1.1 - paso 4)
-                // Garantizar que la navegación ocurra sin importar errores anteriores
-                if (context.mounted) {
-                  // Cerrar indicador de carga si existe
-                  Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
-
-                  // Navegar a AuthFinalPage
-                  Navigator.of(context).pushAndRemoveUntil(
-                    MaterialPageRoute(builder: (_) => const AuthFinalPage()),
-                    (route) => false,
-                  );
-
-                  print('✅ [LOGOUT] Logout completado exitosamente');
-                }
-              }
-            },
-            child: const Text('Cerrar Sesión', style: TextStyle(color: _AppColors.sosRed)),
-          ),
-        ],
-      ),
+  void _showLogoutDialog(BuildContext context, WidgetRef ref) async {
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Cerrar Sesión',
+      body: '¿Estás seguro?',
+      confirmLabel: 'Cerrar Sesión',
+      barrierDismissible: false,
     );
+    if (confirmed != true) return;
+
+    if (context.mounted) {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(
+          child: CircularProgressIndicator(
+            valueColor: AlwaysStoppedAnimation<Color>(NkColors.mint),
+          ),
+        ),
+      );
+    }
+
+    try {
+      print('🔴 [LOGOUT] Iniciando proceso de logout desde Settings...');
+      print('🔴 [LOGOUT] Paso 1/3: Desactivando funcionalidad silenciosa...');
+      await SilentFunctionalityCoordinator.deactivateAfterLogout().timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          print('⚠️ [LOGOUT] Timeout en deactivateAfterLogout, continuando...');
+        },
+      );
+      print('🔴 [LOGOUT] Limpiando SessionCache...');
+      await SessionCacheService.clearSession();
+      print('🔴 [LOGOUT] Paso 2/3: Cerrando sesión de Firebase...');
+      await FirebaseAuth.instance.signOut().timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          print('⚠️ [LOGOUT] Timeout en signOut, continuando...');
+        },
+      );
+      print('🔴 [LOGOUT] Paso 3/3: Redirigiendo a login...');
+    } catch (e) {
+      print('❌ [LOGOUT] Error durante logout: $e');
+    } finally {
+      if (context.mounted) {
+        Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const AuthFinalPage()),
+          (route) => false,
+        );
+        print('✅ [LOGOUT] Logout completado exitosamente');
+      }
+    }
   }
   // --- FIN DE LÓGICA (SIN CAMBIOS) ---
 

--- a/lib/widgets/zone_selection_not_allowed_dialog.dart
+++ b/lib/widgets/zone_selection_not_allowed_dialog.dart
@@ -1,58 +1,12 @@
 import 'package:flutter/material.dart';
+import '../core/widgets/nk_dialog.dart';
 
 /// Diálogo informativo cuando el usuario intenta seleccionar manualmente
 /// un emoji asociado a una zona configurada por geofencing.
 Future<void> showZoneSelectionNotAllowedDialog(BuildContext context) {
-  return showDialog<void>(
-    context: context,
-    barrierColor: Colors.black.withValues(alpha: 0.75),
-    barrierDismissible: true,
-    builder: (context) => Dialog(
-      backgroundColor: Colors.black,
-      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-        side: BorderSide(
-          color: const Color(0xFF1CE4B3).withValues(alpha: 0.4),
-          width: 1,
-        ),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'Acción no permitida',
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              'No puedes seleccionar zonas manualmente. El estado de zonas se actualiza automáticamente por geofencing.',
-              style: TextStyle(fontSize: 14, color: Color(0xCCFFFFFF)),
-            ),
-            const SizedBox(height: 18),
-            Align(
-              alignment: Alignment.centerRight,
-              child: TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                style: TextButton.styleFrom(
-                  foregroundColor: const Color(0xFF1CE4B3),
-                ),
-                child: const Text(
-                  'Entendido',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    ),
+  return NkDialog.inform(
+    context,
+    title: 'Acción no permitida',
+    body: 'No puedes seleccionar zonas manualmente. El estado de zonas se actualiza automáticamente por geofencing.',
   );
 }


### PR DESCRIPTION
## Summary
- Crea `lib/core/widgets/nk_dialog.dart` con `NkDialog.confirm` y `NkDialog.inform` (UFV = modal Silencio en in_circle_footer.dart)
- Migra 5 call sites: `in_circle_footer`, `no_circle_view`, `zones_page`, `zone_selection_not_allowed_dialog`, `settings_page`
- Parciales dejados intactos: `auth_wrapper`, `zone_form` (ícono en título), `settings_page._showReauthDialog` (StatefulBuilder + TextField)

## Test plan
- [ ] Modal "Silencio" aparece con estilo DS correcto (borde mint, fondo canvas)
- [ ] Confirmar activa Silent Mode; Cancelar no hace nada
- [ ] "Eliminar zona" muestra confirm destructivo (texto rojo) — solo creador ve el botón
- [ ] "Eliminar Cuenta" en NoCircleView: confirm destructivo → spinner → logout
- [ ] "Cerrar sesión" en NoCircleView: confirm → navega a login
- [ ] "Cerrar sesión" en Settings: confirm → spinner → navega a login
- [ ] "Eliminar Cuenta" en Settings: confirm destructivo → reauth dialog aparece
- [ ] "Ya no estás en tu círculo" en Settings: inform con un solo botón "Entendido"
- [ ] `showZoneSelectionNotAllowedDialog` muestra inform con "Entendido"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)