### PR TITLE
docs: Sem 6/6a retrospective + Sem 7 PA95C plan

### DIFF
--- a/docs/dev/refactor-arch-2026-q2/00-plan-unificado.md
+++ b/docs/dev/refactor-arch-2026-q2/00-plan-unificado.md
@@ -8,7 +8,7 @@
 
 ---
 
-## Estado de avance — actualizado 2026-06-02
+## Estado de avance — actualizado 2026-06-09
 
 | Semana | Tema | Estado | Tag / PR |
 |--------|------|--------|----------|
@@ -17,17 +17,19 @@
 | 3 | Native Bridge | ✅ Completa | `refactor-sem3-done` |
 | 4 | Identity + Circle | ✅ Completa | `refactor-sem4-done` |
 | 5 | UI descomposición | ✅ Completa | `refactor-sem5-done` |
-| 6 | Hardening (parcial) | ✅ Completa | `refactor-sem6-done` (PR #201) |
-| — | *(Fix de producción)* | ✅ `fix/silent-mode-firestore-write` mergeado | PR #202 — raíz en GCP: Token Service API faltante en key `Android - Zync Maps` |
-| **6a** | **Design System** | **⏳ PRÓXIMA** | Rama nueva desde `main` actualizado |
-| 7 | Flujos no refactorizados | 🔲 Pendiente | — |
+| 6 | Hardening (parcial) | ✅ Completa | `refactor-sem6-done` @ `9fcfda2` (PR #201) |
+| — | *(Fix de producción)* | ✅ Mergeado | PR #202 — raíz en GCP: Token Service API faltante en key `Android - Zync Maps` |
+| **6a** | **Design System** | ✅ **Completa** | PRs #203, #205–#218 — tokens + DS v2.0 Minimalist completo |
+| **7** | **Flujos no refactorizados** | **🔲 PRÓXIMA** | 4 PRs (A–D) · doc: [07-semana-7-flujos-legacy.md](07-semana-7-flujos-legacy.md) |
 | 8 | Geofencing BC completo | 🔲 Pendiente | — |
 | 9 | Seguridad y Compliance | 🔲 Pendiente | — |
 | 10 | Launch Readiness + Freeze | 🔲 Pendiente | — |
 
-**main actual:** `dba2422` — merge PR #202
+**main actual:** `1a0edaf` — PR #217 (compact InCircleView cards)
 **Lanzamiento estimado MVP:** ~15 agosto 2026
-**Días hábiles restantes (al 2026-06-02):** ~55
+**Días hábiles restantes (al 2026-06-09):** ~47
+
+**Nota — `USE_LEGACY_BRIDGE`:** ya en `false` en `android/app/build.gradle.kts:58`. No requiere acción en Sem 9.
 
 ---
 
@@ -350,7 +352,9 @@ Ver [01-semana-1-cimientos.md](01-semana-1-cimientos.md).
 - Migrar `auth_final_page.dart` y `settings_page.dart` a use cases en lugar de servicios estáticos.
 - `navigatorKey` sigue existiendo solo para `MaterialApp`, no como punto de inyección de servicios.
 
-### 3.6 Detalles de Semana 6 — Hardening (parcial)
+### 3.6 Detalles de Semana 6 — Hardening (parcial) ✅
+
+> Doc completo: [`06-semana-6-hardening.md`](06-semana-6-hardening.md)
 
 **Objetivo**: consolidar el núcleo refactorizado antes de expandir a los contextos pendientes.
 
@@ -362,7 +366,9 @@ Ver [01-semana-1-cimientos.md](01-semana-1-cimientos.md).
 
 ---
 
-### 3.6a Detalles de Semana 6a — Design System
+### 3.6a Detalles de Semana 6a — Design System ✅
+
+> Doc completo: [`06a-semana-6a-design-system.md`](06a-semana-6a-design-system.md)
 
 **Objetivo**: codificar formalmente los tokens de diseño usados en Sem 5 como referencia numérica, y extraer los componentes base de UI en un sistema reutilizable. Sin lógica de negocio.
 

--- a/docs/dev/refactor-arch-2026-q2/06-semana-6-hardening.md
+++ b/docs/dev/refactor-arch-2026-q2/06-semana-6-hardening.md
@@ -1,0 +1,132 @@
+# Semana 6 — Hardening (parcial)
+
+> **Estado:** ✅ Completa (2026-05-27)
+> **Modelo:** Sonnet 4.6
+> **Rama:** `refactor/sem6-hardening`
+> **Tag:** `refactor-sem6-done` @ `9fcfda2`
+> **PR:** #201
+> **Prerrequisito:** `refactor-sem5-done` @ `d2cb2a7`
+
+---
+
+## Objetivo
+
+Consolidar el núcleo refactorizado (Sems 1–5) antes de expandir hacia los contextos pendientes. No se agrega funcionalidad nueva. El sprint cierra con código muerto eliminado, tests de integración del core en verde y documentación canónica actualizada.
+
+---
+
+## Contexto previo
+
+| Semana | Estado al iniciar Sem 6 |
+|--------|------------------------|
+| 1 Cimientos | ✅ KvStore + Contract + DI modular |
+| 2 Presence | ✅ State machine + PresenceViewModel + 87 tests |
+| 3 Native Bridge | ✅ BridgeRouter + USE_LEGACY_BRIDGE=false |
+| 4 Identity + Circle | ✅ contexts/identity migrado, ApplyGeofenceStatus |
+| 5 UI descomposición | ✅ in_circle_view ≤800 líneas, 6 widgets extraídos |
+
+**Deuda conocida al entrar en Sem 6:**
+- `setOfflineStatus` / `clearOfflineStatus` en `status_service.dart` son no-ops sin callers — shims muertos del bridge viejo.
+- Tests de integración BN+Silent no existían en `integration_test/`.
+- `docs/dev/architecture.md` desactualizado (describía pre-refactor).
+- No había baseline de performance documentado.
+
+---
+
+## Entregables
+
+### E1 — Eliminar shims muertos
+
+**Archivos:** `lib/core/services/status_service.dart`
+
+`setOfflineStatus()` y `clearOfflineStatus()` eran wrappers que actualizaban Firestore con estado offline/online. El NativeBridge unificado (Sem 3) absorbió ese comportamiento; los métodos quedaron como no-ops sin callers activos.
+
+**Acción:** eliminar ambos métodos y sus referencias en imports. **`StatusService.updateUserStatus` NO se toca** — tiene 9+ callers activos, se migra en Sem 7.
+
+**Criterio:** `grep -rn "setOfflineStatus\|clearOfflineStatus" lib/` → 0 resultados.
+
+---
+
+### E2 — Tests de integración BN+Silent
+
+**Archivo:** `test/contexts/presence/presence_integration_test.dart`
+
+6 tests que cubren las transiciones críticas del core refactorizado:
+
+| Test | Escenario |
+|------|-----------|
+| T2.1 | Normal → BN → Normal |
+| T2.2 | Silent → BN durante Silent → exit BN → Silent preservado |
+| T2.3 | BN manual sobreescribe BN de notificación |
+| T2.4 | Exit Silent → recupera estado pre-Silent |
+| T2.5 | SOS interrumpe Silent → exit SOS → Silent restaurado |
+| T2.6 | Idempotencia: entrar a Silent dos veces → no duplica transición |
+
+**Criterio:** `flutter test test/contexts/presence/presence_integration_test.dart --no-pub` → 6/6 PASS.
+
+---
+
+### E3 — Documentación canónica
+
+Tres archivos actualizados / creados:
+
+| Archivo | Contenido |
+|---------|-----------|
+| `docs/dev/architecture.md` | Diagrama de BCs completos (Sems 1–5), reglas de imports, contratos entre capas |
+| `docs/dev/TEST_SUITE.md` | Inventario completo de tests: unitarios, integración, manuales. Estado por semana |
+| `docs/dev/refactor-arch-2026-q2/00-plan-unificado.md` | Tabla de avance actualizada + sección Sem 6a agregada |
+
+---
+
+### E4 — Performance baseline
+
+**Archivo:** `docs/dev/performance-baseline.md`
+
+Mediciones en modo debug (Pixel 6, Android 13):
+
+| Métrica | Valor debug | Referencia |
+|---------|------------|------------|
+| Cold start (launch → circle visible) | 6304 ms | `mvp-baseline-20260506` no medido |
+| Login (tap "Ingresar" → circle visible) | 7276 ms | — |
+| App resume tras 5 min background | < 800 ms | — |
+
+**Nota:** valores en modo debug son 3–5× más lentos que release. Sirven como baseline relativo para detectar regresiones entre semanas.
+
+---
+
+## Resultado real vs. planificado
+
+| Entregable | Planificado | Ejecutado |
+|-----------|-------------|-----------|
+| E1 shims eliminados | ✅ | ✅ |
+| E2 tests BN+Silent 6/6 | ✅ | ✅ |
+| E3 docs canónica | ✅ | ✅ |
+| E4 performance baseline | ✅ | ✅ |
+| Tests E2E transición Normal→Silent→Normal | 🔲 | ➡️ Diferido a Sem 7 smoke test |
+
+Los tests E2E en dispositivo físico para el flujo completo Normal→Silent→Normal se diferieron: requieren GPS real y >1h de background, incompatibles con el ritmo de la semana. Se verifican como parte del smoke test de cierre de Sem 7.
+
+---
+
+## Métricas de cierre
+
+| Métrica | Valor |
+|---------|-------|
+| Tests unitarios/integración | 87 previos + 6 nuevos = **93 en verde** |
+| Archivos modificados | 5 (status_service + 3 docs + presence_integration_test) |
+| PRs | #201 |
+| Shims eliminados | 2 (`setOfflineStatus`, `clearOfflineStatus`) |
+
+---
+
+## Lo que NO se tocó
+
+- `StatusService.updateUserStatus` — 9+ callers activos. Se migra en Sem 7.
+- Tests E2E en device físico — diferidos a Sem 7.
+- Cualquier contexto de UI — alcance exclusivo de Sem 6a.
+
+---
+
+## Próximo: Sem 6a — Design System
+
+Ver [`06a-semana-6a-design-system.md`](06a-semana-6a-design-system.md).

--- a/docs/dev/refactor-arch-2026-q2/06a-semana-6a-design-system.md
+++ b/docs/dev/refactor-arch-2026-q2/06a-semana-6a-design-system.md
@@ -1,0 +1,175 @@
+# Semana 6a — Design System
+
+> **Estado:** ✅ Completa (2026-06-09, extendida con DS v2.0 Minimalist)
+> **Modelo:** Sonnet 4.6
+> **Rama base:** `refactor/sem6a-design-system` → `style/*` (capas DS v2)
+> **Tag:** `refactor-sem6-done` incluye Sem 6a (no tag separado)
+> **PRs:** #203 (Sem 6a formal) · #205–#218 (DS v2.0 Minimalist por capas)
+> **Prerrequisito:** `refactor-sem6-done` ✅ · `main` verde
+
+---
+
+## Objetivo
+
+Codificar formalmente los tokens de diseño como constantes Dart, extraer componentes base reutilizables, y hacer una pasada visual completa en todas las pantallas activas de la app usando el sistema unificado. Sin lógica de negocio. Sin cambios a ViewModels ni servicios.
+
+---
+
+## Contexto previo
+
+Al cerrar Sem 6, los valores visuales (colores, espaciados, radios) existían como:
+- Clases privadas `_AppColors` / `_AppTextStyles` duplicadas en cada archivo.
+- Constantes hardcodeadas (`const Color(0xFF1EE9A4)`, `BorderRadius.circular(16)`) sin nombre semántico.
+- Sin componentes base reutilizables — cada pantalla construía sus propios inputs, dialogs y headers desde cero.
+
+**UFV del DS:** `docs/ui/NunaKin Design System.md` → siempre prevalece sobre cualquier HTML o mockup.
+
+---
+
+## Fase 1 — Sem 6a Formal: tokens + migración inicial (PR #203)
+
+### Entregable
+
+`lib/app/theme/design_tokens.dart` — tokens tipados canónicos:
+
+```dart
+// Colores
+NkColors.canvas        // fondo principal
+NkColors.mint          // acento primario
+NkColors.onMint        // texto sobre mint
+NkColors.danger        // acciones destructivas
+NkColors.fgSub / fgMuted / fgHint
+NkColors.surface2 / surface3 / surface4
+
+// Espaciado
+NkSpacing.xs / s / m / l / xl
+
+// Radios
+NkRadius.forButton / forInput / forCard
+
+// Tipografía
+NkTextStyle.h1 / h2 / h3 / meta / caption
+```
+
+### 13 archivos migrados en PR #203
+
+| Archivo |
+|---------|
+| `silent_mode_button.dart` |
+| `in_circle_footer.dart` |
+| `in_circle_view.dart` |
+| `member_status_grid.dart` |
+| `create_circle_view.dart` |
+| `join_circle_view.dart` |
+| `no_circle_view.dart` |
+| `pending_request_view.dart` |
+| `emoji_management_page.dart` |
+| `status_selector_overlay.dart` |
+| `emoji_modal.dart` |
+| `splash_screen.dart` |
+| `zones_page.dart` |
+
+**Resultado:** 0 errores, 0 warnings. Solo 286 `info` preexistentes (print, withOpacity deprecated).
+
+---
+
+## Fase 2 — DS v2.0 Minimalist: capas 1–3c
+
+El DS v2.0 es una pasada visual completa sobre la UI existente aplicando la estética minimalist definida en `docs/ui/NunaKin Design System.md`. Se ejecutó en 4 capas.
+
+---
+
+### Capa 1 — `design_tokens.dart` versionado (PR #208)
+
+Revisión y consolidación de `lib/app/theme/design_tokens.dart`:
+- Tokens de espaciado extendidos (`NkSpacing.s5`, `xs3`).
+- `NkColors.mintSoft(double alpha)` — función para mint con opacidad variable.
+- `NkRadius.forInput` unificado.
+- `NkTextStyle` alineado con especificaciones `docs/ui/NunaKin Design System.md`.
+
+---
+
+### Capa 2 — `NunaKinTextField` (PR #209)
+
+Nuevo componente base en `lib/core/widgets/nunakin_text_field.dart`:
+- Campo de texto con estética DS (fondo `surfaceCard`, borde mint en focus `mintSoft(0.08)`).
+- Parámetros: `controller`, `label`, `hint`, `obscureText`, `suffixIcon`, `onSubmitted`.
+- **No expone `onChanged`** — el caller usa `controller.addListener()`.
+- Migración de `auth_final_page.dart` a `NunaKinTextField` incluida en mismo PR.
+
+**Fix PR #211:** focused background era constante `surfaceCard` — se corrigió a `_isFocused ? mintSoft(0.08) : surfaceCard`.
+
+---
+
+### Capa 3a — `NoCircleView` DS (PRs #210, #212–#213)
+
+- Glass cards para "Crear círculo" / "Unirse a círculo" (`color: const Color(0x18FFFFFF)`).
+- Header con botón "Cerrar sesión" alineado al DS.
+- `NkAppHeader` extraído como widget base en `lib/core/widgets/nk_app_header.dart` (PR #215) — reutilizado por `NoCircleView` y `auth_final_page`.
+
+---
+
+### Capa 3b — `auth_final_page.dart` DS (parte de PR #209 + PR #215)
+
+- Títulos 28px bold, labels `fgSub`, floating label mint.
+- Bordes 0.5px (unfocused) / 1px (focused).
+- Auth field background `0x18FFFFFF` (alineado con card color).
+- NunaKin brand en header de autenticación.
+
+---
+
+### Capa 3c — `InCircleView` + sub-widgets DS (PRs #216–#217)
+
+Aplicación de DS Capa 3c a `in_circle_view.dart` y sus widgets extraídos en Sem 5:
+
+| Widget | Cambio principal |
+|--------|-----------------|
+| `in_circle_view.dart` | Colores, fonts, bordes alineados a NkTokens |
+| `member_status_grid.dart` | Cards compactas, avatar + nickname con tokens |
+| `circle_info_card.dart` | Info card con borde mint suave |
+| `in_circle_header.dart` | Botón "Ajustes" outlined #052A1D |
+| `in_circle_footer.dart` | Botones iguales, padding NkSpacing |
+| `join_requests_banner.dart` | Color y spacing via tokens |
+
+Verificado en dispositivo físico: PASS visual ✅.
+
+---
+
+### Capa adicional — `NkDialog` unificado (PR #218)
+
+Nuevo componente en `lib/core/widgets/nk_dialog.dart`:
+- `NkDialog.confirm(context, ...)` — confirmación con acciones Cancelar/Confirmar.
+- `NkDialog.inform(context, ...)` — informativo con una acción + soporte de `contentWidget`.
+- `confirmDestructive: true` → botón confirm en `NkColors.danger`.
+- **UFV de estilo:** modal "Silencio" en `in_circle_footer.dart`.
+
+5 call sites migrados: `in_circle_footer`, `no_circle_view`, `zones_page`, `zone_selection_not_allowed_dialog`, `settings_page`.
+
+3 call sites dejados intactos (parciales): `auth_wrapper` (ícono en título), `zone_form` (GPS requerido con ícono), `settings_page._showReauthDialog` (StatefulBuilder + TextField de contraseña).
+
+---
+
+## Resultado final
+
+| Métrica | Antes (Sem 6 cierre) | Después (Sem 6a cierre) |
+|---------|----------------------|------------------------|
+| Archivos con colores hardcodeados | ~18 | 0 (solo valores literales en tokens) |
+| Clases privadas `_AppColors`/`_AppTextStyles` | 5 duplicadas | 0 (todas reemplazadas por NkTokens) |
+| Componentes base reutilizables | 0 | 4 (`NunaKinTextField`, `NkAppHeader`, `NkDialog`, `SilentModeButton`) |
+| PRs DS | — | #203, #205–#218 |
+| Tests | 93 verde | 93 verde (sin regresiones) |
+
+---
+
+## Invariantes que NO cambiaron
+
+- Lógica de negocio en ViewModels y use cases — intacta.
+- `EmojiDialogActivity.kt` — sin cambios visuales.
+- `status_service.dart` — sin cambios (scope de Sem 7).
+- Esquema de navegación — sin cambios.
+
+---
+
+## Próximo: Sem 7 — Flujos no refactorizados
+
+Ver [`07-semana-7-flujos-legacy.md`](07-semana-7-flujos-legacy.md).

--- a/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-1.md
+++ b/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-1.md
@@ -1,0 +1,156 @@
+# Sem 7 · Día 1 (PR A) — Eliminar sync prematuro en `main.dart`
+
+> **Estado:** Listo para ejecutar (PA95C)
+> **Confianza:** 99%
+> **Modelo:** Sonnet 4.6
+> **Rama:** `refactor/sem7-emoji-cache-race`
+> **Duración estimada:** 30 min
+> **Prerrequisito:** PR #218 (NkDialog) mergeado · `main` verde · árbol limpio
+
+---
+
+## Problema
+
+`lib/main.dart` llama a `EmojiCacheService.syncEmojisToNativeCache()` durante la inicialización de la app, antes de que Firebase Auth haya completado y antes de que el `circleId` del usuario sea conocido.
+
+Cuando ese sync se ejecuta sin círculo activo, escribe `configured_zone_types = []` en las SharedPrefs nativas. `EmojiDialogActivity.kt` lee esa lista al abrirse — y si está vacía, no muestra las zonas configuradas del círculo.
+
+Este es el **cold-start race** documentado en los bugs de la fase 4/5.
+
+---
+
+## Causa raíz confirmada
+
+`InCircleView.initState()` ya llama al mismo `EmojiCacheService.syncEmojisToNativeCache()` **después** de que:
+1. Firebase Auth ha completado (el widget solo se monta si el usuario está autenticado).
+2. El `Circle` object está disponible (se pasa como parámetro al widget).
+
+La llamada en `main.dart` es redundante y nociva.
+
+---
+
+## Call graph (estado actual)
+
+```
+main.dart::_initializeServices()
+  │
+  ├─ EmojiCacheService.syncEmojisToNativeCache()   ← ELIMINAR
+  │     │
+  │     └─ SharedPrefs.setStringList("flutter.configured_zone_types", [...])
+  │           Auth puede ser null aquí → writes [] al nativo
+  │
+  └─ ... (resto de init)
+
+InCircleView.initState()                            ← KEEPER
+  │
+  └─ EmojiCacheService.syncEmojisToNativeCache()
+        Auth garantizado ✅ · Circle disponible ✅
+```
+
+---
+
+## Paso 0 — Prerequisito
+
+```bash
+git status          # debe estar limpio
+git pull origin main
+git checkout -b refactor/sem7-emoji-cache-race
+```
+
+---
+
+## Paso 1 — Identificar la línea exacta
+
+```bash
+grep -n "syncEmojisToNativeCache" lib/main.dart
+```
+
+Debería aparecer una línea en la función `_initializeServices()` o similar (aprox. línea 108 según último análisis).
+
+---
+
+## Paso 2 — Eliminar la llamada
+
+**Antes:**
+```dart
+// En _initializeServices() o initState() de _MyAppState
+await EmojiCacheService.syncEmojisToNativeCache();
+```
+
+**Después:** línea eliminada.
+
+Si la línea tiene un comentario explicativo, eliminar el comentario también. Si hay un `try/catch` que solo envuelve esa llamada, eliminar el `try/catch` completo.
+
+**Lo que NO se elimina:**
+- El import de `EmojiCacheService` si tiene otros usos en `main.dart`.
+- Cualquier otra inicialización en la misma función.
+
+---
+
+## Paso 3 — Verificar que el import no queda huérfano
+
+```bash
+grep -n "EmojiCacheService" lib/main.dart
+```
+
+Si solo aparecía en la línea eliminada → eliminar el import. Si hay otros usos → mantener el import.
+
+---
+
+## Paso 4 — `flutter analyze` + commit
+
+```bash
+flutter analyze lib/main.dart
+# Esperar: 0 errores nuevos
+
+git add lib/main.dart
+git commit -m "refactor(presence): remove premature emoji sync from main.dart init"
+```
+
+---
+
+## Paso 5 — PR → merge → cleanup
+
+```bash
+gh pr create --title "refactor(presence): remove premature emoji sync from main.dart" \
+  --body "Elimina EmojiCacheService.syncEmojisToNativeCache() de main.dart init. \
+La misma llamada ya existe en InCircleView.initState() con Auth y Circle garantizados. \
+Resuelve cold-start race que escribía configured_zone_types=[] antes de conocer el círculo."
+
+# Tras merge:
+git checkout main && git pull origin main
+git branch -d refactor/sem7-emoji-cache-race
+git push origin --delete refactor/sem7-emoji-cache-race
+```
+
+---
+
+## Protocolo de caminos negativos
+
+| Camino | Acción | ¿Reversible? |
+|--------|--------|--------------|
+| `InCircleView` no se monta (usuario sin círculo) | `syncEmojisToNativeCache` no se llama → `configured_zone_types` queda del último sync válido | ✅ Best-effort |
+| Auth completa pero Circle aún no cargó | El sync dentro de `initState` espera el `Circle` object (parámetro) — no puede ejecutarse antes | ✅ Garantizado |
+| Primer cold start sin datos en prefs | `EmojiDialogActivity` muestra lista vacía (comportamiento sin cambio vs. antes del bug original) | ✅ Aceptable |
+
+Ningún camino negativo ejecuta `signOut`, `clearCredentials` ni operaciones irreversibles.
+
+---
+
+## Flujos impactados
+
+| Flujo | Antes | Después | Riesgo |
+|-------|-------|---------|--------|
+| Cold start → App sin círculo | `syncEmojisToNativeCache()` → puede escribir `[]` | No ejecuta sync | ✅ Mejora |
+| Cold start → App con círculo | sync prematuro + sync en `initState` (doble) | Solo sync en `initState` | ✅ Elimina redundancia |
+| `EmojiDialogActivity` al abrir | puede leer `[]` si sync prematuro corrió primero | Lee datos del sync en `initState` (correcto) | ✅ Corrección directa del bug |
+
+---
+
+## Criterio de done
+
+- [ ] `grep -n "syncEmojisToNativeCache" lib/main.dart` → 0 resultados
+- [ ] `flutter analyze lib/main.dart` → 0 errores nuevos
+- [ ] Commit limpio en `refactor/sem7-emoji-cache-race`
+- [ ] PR mergeado · ramas local y remota eliminadas · `git pull origin main`
+- [ ] Continuar con Día 2 (PR B)

--- a/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-2.md
+++ b/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-2.md
@@ -1,0 +1,204 @@
+# Sem 7 · Día 2 (PR B) — `quick_actions` + `widget_service` → `SetManualStatus`
+
+> **Estado:** Listo para ejecutar (PA95C)
+> **Confianza:** 95%
+> **Modelo:** Sonnet 4.6
+> **Rama:** `refactor/sem7-quick-actions-set-manual`
+> **Duración estimada:** 1h
+> **Prerrequisito:** PR A (Día 1) mergeado · `main` verde · árbol limpio
+
+---
+
+## Problema
+
+`quick_actions_handler.dart` y `widget_service.dart` llaman a `StatusService.updateUserStatus()` directamente, bypasseando el use case `SetManualStatus` introducido en Sem 2. Esto significa que las Quick Actions del launcher y el home screen widget de Android no pasan por la state machine de presencia — no registran la transición como "manual", no emiten eventos al `DomainEventBus` y no respetan el guard de Silent Mode.
+
+---
+
+## Causa raíz
+
+Ambos archivos son anteriores al refactor de Sems 1–6. Usan el servicio estático porque era el único punto de entrada de la arquitectura antigua.
+
+`SetManualStatus` ya existe, ya está testeado y ya está registrado en DI:
+
+```dart
+// lib/app/di/modules/presence_module.dart
+sl.registerFactory<SetManualStatus>(() => SetManualStatus(
+  presenceRepository: sl(),
+  firestorePublisher: sl(),
+));
+```
+
+---
+
+## Call graph (estado actual → objetivo)
+
+**Antes:**
+```
+QuickActionsHandler.handleAction(statusId)
+  └─ StatusService.updateUserStatus(statusId, userId, circleId)
+       └─ Firestore write directo (sin state machine)
+
+WidgetService.updateStatus(statusId)
+  └─ StatusService.updateUserStatus(statusId, userId, circleId)
+       └─ Firestore write directo (sin state machine)
+```
+
+**Después:**
+```
+QuickActionsHandler.handleAction(statusId)
+  └─ sl<SetManualStatus>().call(statusId, userId, circleId)
+       └─ PresenceRepository.setManualStatus()  ← state machine
+            └─ DomainEventBus.publish()
+            └─ FirestorePresencePublisher.publish()
+
+WidgetService.updateStatus(statusId)
+  └─ sl<SetManualStatus>().call(statusId, userId, circleId)
+       └─ (mismo flujo)
+```
+
+---
+
+## Paso 0 — Prerequisito
+
+```bash
+git status
+git pull origin main
+git checkout -b refactor/sem7-quick-actions-set-manual
+```
+
+---
+
+## Paso 1 — Auditar `quick_actions_handler.dart`
+
+```bash
+grep -n "StatusService\|updateUserStatus" lib/quick_actions/quick_actions_handler.dart
+```
+
+Identificar:
+1. Líneas donde se llama a `StatusService`.
+2. Cómo se obtiene `userId` y `circleId` en el handler.
+3. Si el handler ya tiene acceso a `sl()` o necesita importar `injection_container.dart`.
+
+---
+
+## Paso 2 — Auditar `widget_service.dart`
+
+```bash
+grep -n "StatusService\|updateUserStatus" lib/widgets/widget_service.dart
+```
+
+Mismo análisis que Paso 1.
+
+---
+
+## Paso 3 — Obtener `userId` y `circleId`
+
+Ambos archivos necesitan `userId` y `circleId` para llamar a `SetManualStatus`.
+
+**Fuentes disponibles (ya existen):**
+
+| Dato | Fuente | API |
+|------|--------|-----|
+| `userId` | Firebase Auth (siempre disponible cuando se ejecuta la acción) | `FirebaseAuth.instance.currentUser?.uid` |
+| `circleId` | KvStore | `sl<KvStore>().getString(StorageKeys.circleId)` |
+
+Si `circleId` es null (usuario sin círculo): early return — no hay acción válida.
+
+---
+
+## Paso 4 — Reemplazar las llamadas
+
+**En `quick_actions_handler.dart`:**
+
+```dart
+// Antes
+await StatusService.updateUserStatus(statusId, userId, circleId);
+
+// Después
+final circleId = sl<KvStore>().getString(StorageKeys.circleId);
+if (circleId == null) {
+  debugPrint('[QuickActions] circleId nulo — sin acción');
+  return;
+}
+await sl<SetManualStatus>().call(
+  SetManualStatusParams(
+    statusId: statusId,
+    userId: userId,
+    circleId: circleId,
+  ),
+);
+```
+
+Ajustar el nombre de los parámetros si `SetManualStatusParams` tiene una firma diferente (verificar en `lib/contexts/presence/application/use_cases/set_manual_status.dart`).
+
+**En `widget_service.dart`:** mismo patrón.
+
+---
+
+## Paso 5 — Actualizar imports
+
+En cada archivo modificado:
+- Agregar import de `set_manual_status.dart` (use case).
+- Agregar import de `injection_container.dart` si no existe.
+- Agregar import de `native_keys.dart` (para `StorageKeys`).
+- Eliminar import de `status_service.dart` si ya no tiene otros usos.
+
+---
+
+## Paso 6 — `flutter analyze` + commit
+
+```bash
+flutter analyze lib/quick_actions/quick_actions_handler.dart lib/widgets/widget_service.dart
+# Esperar: 0 errores nuevos
+
+git add lib/quick_actions/quick_actions_handler.dart lib/widgets/widget_service.dart
+git commit -m "refactor(presence): migrate quick_actions and widget_service to SetManualStatus"
+```
+
+---
+
+## Paso 7 — PR → merge → cleanup
+
+```bash
+gh pr create --title "refactor(presence): quick_actions + widget_service → SetManualStatus" \
+  --body "Reemplaza StatusService.updateUserStatus() directo por sl<SetManualStatus>() en \
+quick_actions_handler.dart y widget_service.dart. Ambos callers ahora pasan por la state \
+machine de presencia (Sem 2) y emiten eventos al DomainEventBus."
+
+# Tras merge:
+git checkout main && git pull origin main
+git branch -d refactor/sem7-quick-actions-set-manual
+```
+
+---
+
+## Protocolo de caminos negativos
+
+| Camino | Acción | ¿Reversible? |
+|--------|--------|--------------|
+| `circleId` es null (usuario sin círculo activo) | `return` temprano — sin actualización | ✅ Correcto |
+| `userId` es null (sesión expirada) | `return` temprano — sin actualización | ✅ Correcto |
+| `SetManualStatus` falla (red) | El use case retorna `Left(Failure)` — loguear con `debugPrint` · no hacer `signOut` | ✅ Best-effort |
+| `sl<SetManualStatus>()` no registrado | `StateError` en debug — indicaría falla en DI setup | ✅ Detectado en dev |
+
+---
+
+## Flujos impactados
+
+| Flujo | Antes | Después | Riesgo |
+|-------|-------|---------|--------|
+| Quick Action desde launcher | Firestore write directo | A través de state machine | ✅ Mejora (respeta Silent Mode) |
+| Home screen widget tap | Igual | Igual | ✅ Mejora |
+| Quick Action durante Silent Mode | StatusService no respeta guard de Silent | `SetManualStatus` con guard en state machine | ✅ Corrección |
+| Quick Action con usuario sin círculo | `updateUserStatus` puede fallar silenciosamente | `return` temprano explícito | ✅ Más robusto |
+
+---
+
+## Criterio de done
+
+- [ ] `grep -rn "StatusService.updateUserStatus" lib/quick_actions/` → 0 resultados
+- [ ] `grep -rn "StatusService.updateUserStatus" lib/widgets/widget_service.dart` → 0 resultados
+- [ ] `flutter analyze` → 0 errores nuevos en archivos modificados
+- [ ] Commit limpio · PR mergeado · ramas eliminadas · `git pull origin main`
+- [ ] Continuar con Día 3 (PR C — Opus)

--- a/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-3.md
+++ b/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-3.md
@@ -1,0 +1,219 @@
+# Sem 7 · Día 3 (PR C) — `notification_status_selector.dart` (Opus)
+
+> **Estado:** Listo para ejecutar (PA95C)
+> **Confianza:** 92%
+> **Modelo:** ⚠️ Opus 4.7 — obligatorio (486 líneas, lógica de BN + Silent compleja)
+> **Rama:** `refactor/sem7-notification-selector`
+> **Duración estimada:** 2–3h
+> **Prerrequisito:** PR B (Día 2) mergeado · `main` verde · árbol limpio
+> **Smoke test:** obligatorio antes de PR D (Día 4)
+
+---
+
+## Problema
+
+`notification_status_selector.dart` (486 líneas) es el modal que aparece en la notificación persistente cuando el usuario recibe un estado BN (Background Notification). Tiene dos defectos estructurales:
+
+1. **Emojis hardcodeados:** usa `StatusType.fallbackPredefined` — una lista estática que no refleja los emojis personalizados del círculo. El modal siempre muestra los mismos 5 emojis de fábrica.
+
+2. **Update por vía estática:** llama a `StatusService.updateUserStatus()` directamente, bypasseando la state machine y el `DomainEventBus`.
+
+---
+
+## Alcance — qué cambia, qué NO cambia
+
+| | Cambia | No cambia |
+|--|--------|-----------|
+| Fuente de emojis | `fallbackPredefined` → `EmojiService.getAllEmojisForCircle(circleId)` | ✅ Lógica de qué emojis resaltar (activo/BN) |
+| Caller de update | `StatusService.updateUserStatus()` → `sl<SetManualStatus>()` | ✅ Lógica de cuándo mostrar/ocultar el modal |
+| Estado visual | Sin cambios | ✅ Layout, animaciones, colores |
+| Comportamiento BN vs Silent | Sin cambios | ✅ No se toca la lógica de modos |
+
+---
+
+## Paso 0 — Prerequisito
+
+```bash
+git status
+git pull origin main
+git checkout -b refactor/sem7-notification-selector
+```
+
+---
+
+## Paso 1 — Leer el archivo completo
+
+```dart
+// Leer lib/widgets/notification_status_selector.dart completo (486 líneas)
+```
+
+Catalogar:
+- Líneas donde aparece `StatusType.fallbackPredefined` (fuente de emojis).
+- Líneas donde aparece `StatusService.updateUserStatus`.
+- Cómo se inicializa el widget: parámetros recibidos, estado que mantiene.
+- Si ya recibe `circleId` como parámetro o si lo obtiene internamente.
+
+---
+
+## Paso 2 — Verificar firma de `EmojiService.getAllEmojisForCircle`
+
+```bash
+grep -n "getAllEmojisForCircle" lib/core/services/emoji_service.dart
+```
+
+Confirmar:
+- Tipo de retorno (probablemente `Future<List<StatusType>>` o `Future<List<UserStatus>>`).
+- Parámetros requeridos.
+- Si es async o síncrono.
+
+---
+
+## Paso 3 — Identificar cómo se obtiene `circleId`
+
+Opciones en orden de preferencia:
+1. Ya viene como parámetro del widget → usarlo directamente.
+2. No viene → leerlo de `sl<KvStore>().getString(StorageKeys.circleId)`.
+
+Si `circleId` es null: mostrar `StatusType.fallbackPredefined` como fallback (mantiene funcionalidad mínima; no romper el modal).
+
+---
+
+## Paso 4 — Reemplazar la fuente de emojis
+
+**Antes (en `initState` o `build`):**
+```dart
+final emojis = StatusType.fallbackPredefined;
+```
+
+**Después:**
+```dart
+// En initState / estado async del widget
+Future<void> _loadEmojis() async {
+  final circleId = sl<KvStore>().getString(StorageKeys.circleId);
+  if (circleId == null) {
+    setState(() => _emojis = StatusType.fallbackPredefined);
+    return;
+  }
+  final emojis = await EmojiService.getAllEmojisForCircle(circleId);
+  if (mounted) setState(() => _emojis = emojis);
+}
+```
+
+El widget pasa de usar una lista estática a una lista cargada async. El estado de carga (loading spinner) debe ser invisible al usuario o usar la lista fallback hasta que cargue — NO bloquear el modal.
+
+---
+
+## Paso 5 — Reemplazar el caller de update
+
+Mismo patrón que PR B:
+
+```dart
+// Antes
+await StatusService.updateUserStatus(statusId, userId, circleId);
+
+// Después
+await sl<SetManualStatus>().call(
+  SetManualStatusParams(
+    statusId: statusId,
+    userId: userId,
+    circleId: circleId,
+  ),
+);
+```
+
+---
+
+## Paso 6 — Actualizar imports
+
+- Agregar: `emoji_service.dart`, `set_manual_status.dart`, `injection_container.dart`, `native_keys.dart`.
+- Eliminar: `status_service.dart` y el import de `StatusType` si solo se usaba para `fallbackPredefined` y el tipo ya está disponible por otra vía.
+
+---
+
+## Paso 7 — `flutter analyze` + commit
+
+```bash
+flutter analyze lib/widgets/notification_status_selector.dart
+# Esperar: 0 errores nuevos
+
+git add lib/widgets/notification_status_selector.dart
+git commit -m "refactor(presence): notification_status_selector → real circle emojis + SetManualStatus"
+```
+
+---
+
+## Paso 8 — Smoke test en device (obligatorio antes de PR D)
+
+| Paso | Escenario | Criterio de PASS |
+|------|-----------|------------------|
+| 1 | Login → Circle visible | ✅ App funcional |
+| 2 | Otro miembro envía estado BN | Modal de barra aparece |
+| 3 | Modal muestra emojis | Lista incluye emojis personalizados del círculo (no solo los 5 predefinidos) |
+| 4 | Seleccionar emoji en modal | Estado actualiza en Firestore · miembros ven cambio |
+| 5 | Activar Silent Mode → otro miembro envía BN | Modal sigue apareciendo y funcionando |
+| 6 | Seleccionar emoji durante Silent | Estado actualiza sin romper el modo |
+
+Si algún paso falla: **NO continuar a PR D**. Diagnosticar y corregir primero.
+
+---
+
+## Paso 9 — PR → merge → cleanup (solo tras smoke test PASS)
+
+```bash
+gh pr create --title "refactor(presence): notification_status_selector → real emojis + SetManualStatus" \
+  --body "Reemplaza StatusType.fallbackPredefined por EmojiService.getAllEmojisForCircle(circleId). \
+Reemplaza StatusService.updateUserStatus() por sl<SetManualStatus>(). \
+El modal de notificación BN ahora muestra y usa los emojis reales del círculo. \
+Smoke test PASS en device físico."
+
+# Tras merge:
+git checkout main && git pull origin main
+git branch -d refactor/sem7-notification-selector
+```
+
+---
+
+## Protocolo de caminos negativos
+
+| Camino | Acción | ¿Reversible? |
+|--------|--------|--------------|
+| `getAllEmojisForCircle` falla por red | Mostrar `StatusType.fallbackPredefined` como fallback — log, no crash | ✅ Best-effort |
+| `circleId` null | Mostrar fallback predefined — modal funciona con lista básica | ✅ Degradación graceful |
+| `SetManualStatus` falla | `Left(Failure)` → `debugPrint` · modal se cierra normalmente | ✅ No destructivo |
+| Widget desmontado antes de que `getAllEmojisForCircle` complete | Guard `if (mounted)` antes de `setState` | ✅ Estándar Flutter |
+
+Ningún camino negativo ejecuta `signOut` ni acciones irreversibles.
+
+---
+
+## Flujos impactados
+
+| Flujo | Antes | Después | Riesgo |
+|-------|-------|---------|--------|
+| Modal BN recibe notificación | Muestra 5 emojis hardcodeados | Muestra emojis del círculo | ✅ Mejora funcional |
+| Usuario selecciona emoji en modal BN | `StatusService` estático | `SetManualStatus` con state machine | ✅ Mejora arquitectural |
+| Silent Mode activo + BN llega | Modal aparece (comportamiento no cambia) | Igual | ✅ Sin cambio |
+| `circleId` no disponible en frío | Lista hardcodeada | Mismo fallback que antes | ✅ Sin regresión |
+
+---
+
+## Criterio de done
+
+- [ ] `grep -rn "fallbackPredefined" lib/widgets/notification_status_selector.dart` → 0 resultados
+- [ ] `grep -rn "StatusService.updateUserStatus" lib/widgets/notification_status_selector.dart` → 0 resultados
+- [ ] Smoke test 6 pasos PASS en device físico
+- [ ] `flutter analyze` → 0 errores nuevos
+- [ ] Commit limpio · PR mergeado · ramas eliminadas · `git pull origin main`
+- [ ] Continuar con Día 4 (PR D)
+
+---
+
+## Por qué Opus en este PR
+
+`notification_status_selector.dart` tiene:
+- 486 líneas de lógica de estado UI compleja (BN vs Silent vs Normal).
+- Estado async que se carga al montar el widget y puede actualizarse mientras el modal está abierto.
+- Interacción con el lifecycle de la notificación nativa (el widget puede desmontarse en cualquier momento).
+- Dos cambios estructurales simultáneos (fuente de emojis + caller de update) que interactúan.
+
+Sonnet puede ejecutar el cambio pero el riesgo de perder un caso edge en el manejo de estado es mayor. Opus reduce ese riesgo.

--- a/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-4.md
+++ b/docs/dev/refactor-arch-2026-q2/07-semana-7-Dia-4.md
@@ -1,0 +1,218 @@
+# Sem 7 · Día 4 (PR D) — `EmojiDialogActivity.kt`: string literal → constante
+
+> **Estado:** Listo para ejecutar (PA95C)
+> **Confianza:** 97%
+> **Modelo:** Sonnet 4.6
+> **Rama:** `refactor/sem7-emoji-dialog-storage-key`
+> **Duración estimada:** 30 min
+> **Prerrequisito:** PR C (Día 3) mergeado + smoke test PASS · `main` verde · árbol limpio
+
+---
+
+## Problema
+
+`EmojiDialogActivity.kt` lee la lista de zonas configuradas desde SharedPrefs usando el string literal:
+
+```kotlin
+// android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt ~línea 260
+preferences.getStringSet("flutter.configured_zone_types", emptySet())
+```
+
+Este string hardcodeado es una **dependencia implícita** en la clave `StorageKeys.configuredZoneTypes` del lado Flutter. Si esa clave cambia en `lib/platform/persistence/native_keys.dart` (o si se refactoriza el nombre), `EmojiDialogActivity` quedará silenciosamente desincronizada — sin error en tiempo de compilación.
+
+---
+
+## Solución
+
+Definir la constante en Kotlin con un comentario de contrato que apunte a la fuente de verdad:
+
+```kotlin
+private companion object {
+    // Fuente de verdad: lib/platform/persistence/native_keys.dart → StorageKeys.configuredZoneTypes
+    // Valor: "flutter.configured_zone_types"
+    const val KEY_CONFIGURED_ZONE_TYPES = "flutter.configured_zone_types"
+}
+```
+
+Reemplazar todas las ocurrencias del literal por `KEY_CONFIGURED_ZONE_TYPES`.
+
+---
+
+## Análisis de alternativas descartadas
+
+| Alternativa | Por qué se descarta |
+|-------------|-------------------|
+| Importar `StorageKeys` Dart en Kotlin | No es posible sin FFI/Pigeon. El contrato se documenta, no se importa. |
+| Definir la constante en `MainActivity.kt` y pasarla a `EmojiDialogActivity` | Añade acoplamiento entre Activities sin ganancia real. Constante local es suficiente. |
+| Pigeon para compartir keys entre Dart y Kotlin | Overhead de Sem 8 — fuera de scope. El comentario de contrato es la solución correcta para ahora. |
+
+---
+
+## Paso 0 — Prerequisito
+
+```bash
+git status
+git pull origin main
+git checkout -b refactor/sem7-emoji-dialog-storage-key
+```
+
+---
+
+## Paso 1 — Localizar todas las ocurrencias del literal
+
+```bash
+grep -n "flutter.configured_zone_types" \
+  android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+```
+
+Anotar todas las líneas. Puede aparecer más de una vez si hay distintos puntos de lectura.
+
+---
+
+## Paso 2 — Verificar el valor en `native_keys.dart`
+
+```bash
+grep -n "configuredZoneTypes\|configured_zone_types" \
+  lib/platform/persistence/native_keys.dart
+```
+
+Confirmar que el valor del lado Dart es exactamente `"flutter.configured_zone_types"`. Si difiere, usar el valor del lado Dart (es la fuente de verdad).
+
+---
+
+## Paso 3 — Agregar `companion object` con la constante
+
+Localizar la clase `EmojiDialogActivity` y agregar dentro de ella:
+
+```kotlin
+class EmojiDialogActivity : AppCompatActivity() {
+
+    // ... código existente ...
+
+    private companion object {
+        // Fuente de verdad: lib/platform/persistence/native_keys.dart → StorageKeys.configuredZoneTypes
+        const val KEY_CONFIGURED_ZONE_TYPES = "flutter.configured_zone_types"
+    }
+}
+```
+
+Si ya existe un `companion object`: agregar la constante dentro del bloque existente.
+
+---
+
+## Paso 4 — Reemplazar el literal
+
+**Antes:**
+```kotlin
+preferences.getStringSet("flutter.configured_zone_types", emptySet())
+```
+
+**Después:**
+```kotlin
+preferences.getStringSet(KEY_CONFIGURED_ZONE_TYPES, emptySet())
+```
+
+Reemplazar todas las ocurrencias identificadas en Paso 1.
+
+---
+
+## Paso 5 — Build Android + commit
+
+```bash
+# Verificar que el build Kotlin compila sin errores
+flutter build apk --debug 2>&1 | tail -20
+# O equivalente: ./gradlew assembleDebug desde android/
+
+git add android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+git commit -m "refactor(native): replace hardcoded SharedPrefs key with named constant in EmojiDialogActivity"
+```
+
+---
+
+## Paso 6 — PR → merge → cleanup
+
+```bash
+gh pr create \
+  --title "refactor(native): EmojiDialogActivity SharedPrefs key → named constant" \
+  --body "Reemplaza el string literal 'flutter.configured_zone_types' por la constante \
+KEY_CONFIGURED_ZONE_TYPES con comentario de contrato apuntando a StorageKeys en Dart. \
+Elimina dependencia implícita en string — cualquier cambio de key en Dart ahora es \
+visible al buscar el comentario."
+
+# Tras merge:
+git checkout main && git pull origin main
+git branch -d refactor/sem7-emoji-dialog-storage-key
+git push origin --delete refactor/sem7-emoji-dialog-storage-key
+```
+
+---
+
+## Paso 7 — Verificación final de Sem 7
+
+Tras el merge de PR D, ejecutar el checklist completo de Sem 7:
+
+```bash
+# 1. Cero literales de key hardcodeados en Kotlin
+grep -rn "flutter.configured_zone_types" android/
+
+# 2. Cero usos de fallbackPredefined en notification_status_selector
+grep -rn "fallbackPredefined" lib/widgets/notification_status_selector.dart
+
+# 3. Cero usos de StatusService en quick_actions y widget_service
+grep -rn "StatusService.updateUserStatus" lib/quick_actions/ lib/widgets/widget_service.dart
+
+# 4. Cero llamadas a syncEmojisToNativeCache en main
+grep -rn "syncEmojisToNativeCache" lib/main.dart
+
+# 5. Tests en verde
+flutter test test/contexts/presence/presence_integration_test.dart --no-pub
+```
+
+---
+
+## Tag de cierre de Sem 7
+
+```bash
+git tag -a refactor-sem7-done -m "Sem 7 Flujos Legacy — 4 PRs cerrados"
+git push origin refactor-sem7-done
+```
+
+---
+
+## Actualizar `00-plan-unificado.md`
+
+Marcar Sem 7 como ✅ en la tabla de avance:
+
+```markdown
+| 7 | Flujos no refactorizados | ✅ Completa | `refactor-sem7-done` |
+```
+
+---
+
+## Protocolo de caminos negativos
+
+| Camino | Acción | ¿Reversible? |
+|--------|--------|--------------|
+| `getStringSet(KEY_CONFIGURED_ZONE_TYPES, emptySet())` devuelve vacío | Comportamiento idéntico al actual con string literal — no hay regresión | ✅ Sin cambio funcional |
+| Typo en la constante | Build error en Kotlin — detectado antes de runtime | ✅ Error temprano |
+| `EmojiDialogActivity` en otro Activity Stack no ve la constante | `companion object` es `private` al contexto correcto — si se necesita compartir, moverla a objeto externo | ✅ Adjustable |
+
+---
+
+## Flujos impactados
+
+| Flujo | Antes | Después | Riesgo |
+|-------|-------|---------|--------|
+| `EmojiDialogActivity` lee zonas | String literal `"flutter.configured_zone_types"` | Constante `KEY_CONFIGURED_ZONE_TYPES` | ✅ Funcionalmente idéntico |
+| Refactor de `StorageKeys` en Dart | Desincronización silenciosa | Comentario de contrato señala la fuente | ✅ Mejora trazabilidad |
+
+---
+
+## Criterio de done
+
+- [ ] `grep -rn "flutter.configured_zone_types" android/` → solo aparece en el comentario de contrato (no como literal en código)
+- [ ] Build Android debug sin errores
+- [ ] Commit limpio · PR mergeado · ramas eliminadas · `git pull origin main`
+- [ ] Tag `refactor-sem7-done` pusheado
+- [ ] `00-plan-unificado.md` actualizado
+- [ ] Checklist completo de Sem 7 verde (ver §Verificación final)

--- a/docs/dev/refactor-arch-2026-q2/07-semana-7-flujos-legacy.md
+++ b/docs/dev/refactor-arch-2026-q2/07-semana-7-flujos-legacy.md
@@ -1,0 +1,169 @@
+# Semana 7 — Flujos no refactorizados
+
+> **Estado:** 🔲 Pendiente de inicio (2026-06-09)
+> **Modelo:** Sonnet 4.6 (PR A, B, D) · Opus para PR C (486 líneas, lógica compleja)
+> **Rama base:** `main` @ `1a0edaf` (post PR #217)
+> **Prerrequisito:** Sem 6a ✅ · `main` verde · PR #218 mergeado
+
+---
+
+## Objetivo
+
+Eliminar el 40% del código legado que el refactor de Sems 1–6 no alcanzó. Cuatro archivos/call sites que aún usan `StatusService` estático, `StatusType.fallbackPredefined` hardcodeado o keys de SharedPrefs como strings literales. Al cierre de Sem 7, el frente Flutter ↔ Kotlin para selección de estado estará completamente alineado a la arquitectura nueva.
+
+---
+
+## Contexto previo
+
+Las Sems 1–6 construyeron la infraestructura nueva (state machine, use cases, KvStore, NativeBridge). Sem 7 cierra el círculo migrado los últimos callers que todavía bypasean esa infraestructura.
+
+| Síntoma | Causa raíz | Donde vive |
+|---------|-----------|------------|
+| Cold-start race: `configured_zone_types = []` en Firestore | `EmojiCacheService.syncEmojisToNativeCache()` en `main.dart` se llama antes de que Auth garantice el círculo | `lib/main.dart` ~línea 108 |
+| Modal de barra de estado (BN) ignora emojis personalizados del círculo | `notification_status_selector.dart` usa `StatusType.fallbackPredefined` hardcodeado en lugar del repositorio | `lib/widgets/notification_status_selector.dart` |
+| Quick Actions y home screen widget actualizan estado por vía estática | `quick_actions_handler.dart` y `widget_service.dart` llaman a `StatusService.updateUserStatus()` directo | `lib/quick_actions/` · `lib/widgets/` |
+| `EmojiDialogActivity.kt` depende de un string hardcodeado | Lee `"flutter.configured_zone_types"` literal — desincronizable si `StorageKeys` cambia | `android/app/src/main/kotlin/.../EmojiDialogActivity.kt` ~línea 260 |
+
+---
+
+## Infraestructura disponible (ya existe)
+
+| Componente | Ubicación | Uso en Sem 7 |
+|-----------|-----------|-------------|
+| `SetManualStatus` | `lib/app/di/modules/presence_module.dart` (registrado como Factory) | PR B, PR C |
+| `EmojiService.getAllEmojisForCircle(circleId)` | `lib/core/services/emoji_service.dart` | PR C |
+| `StorageKeys.configuredZoneTypes` | `lib/platform/persistence/native_keys.dart` | PR D |
+| `KvStore` / `sl<KvStore>()` | `lib/app/di/modules/platform_module.dart` | PR B, PR D |
+| `InCircleView.initState()` → ya llama `EmojiCacheService.syncEmojisToNativeCache()` con Auth garantizado | `lib/features/circle/presentation/widgets/in_circle_view.dart` | PR A (justificación de seguridad) |
+
+---
+
+## Entregables — 4 PRs en orden
+
+### PR A — `main.dart`: eliminar sync prematuro
+
+**Riesgo:** bajo  
+**Modelo:** Sonnet 4.6  
+**Duración estimada:** 30 min  
+**Doc detalle:** [`07-semana-7-Dia-1.md`](07-semana-7-Dia-1.md)
+
+Eliminar la línea `EmojiCacheService.syncEmojisToNativeCache()` en `main.dart` (~línea 108). Esta llamada se ejecuta durante la inicialización de la app antes de que Auth complete, lo que puede escribir `configured_zone_types = []` al nativo antes de conocer el círculo del usuario.
+
+`InCircleView.initState()` ya llama al mismo sync con Auth y círculo garantizados — la cobertura no se pierde.
+
+---
+
+### PR B — `quick_actions` + `widget_service` → `SetManualStatus`
+
+**Riesgo:** bajo  
+**Modelo:** Sonnet 4.6  
+**Duración estimada:** 1h  
+**Doc detalle:** [`07-semana-7-Dia-2.md`](07-semana-7-Dia-2.md)
+
+Dos archivos que llaman a `StatusService.updateUserStatus()` directamente:
+- `lib/quick_actions/quick_actions_handler.dart`
+- `lib/widgets/widget_service.dart`
+
+Reemplazar por `sl<SetManualStatus>().call(statusId, userId, circleId)`. El `circleId` está disponible en `KvStore` via `StorageKeys.circleId`.
+
+---
+
+### PR C — `notification_status_selector.dart` (Opus)
+
+**Riesgo:** medio  
+**Modelo:** Opus 4.7  
+**Duración estimada:** 2–3h  
+**Doc detalle:** [`07-semana-7-Dia-3.md`](07-semana-7-Dia-3.md)
+
+486 líneas. Dos cambios estructurales:
+1. Reemplazar `StatusType.fallbackPredefined` por `EmojiService.getAllEmojisForCircle(circleId)` — el modal de BN mostrará los emojis reales del círculo.
+2. Reemplazar `StatusService.updateUserStatus()` por `sl<SetManualStatus>()`.
+
+Este es el PR más complejo de la semana: el modal de notificaciones tiene estado propio, lógica de BN vs Silent, y se muestra desde código nativo. **Requiere smoke test en device antes de PR D.**
+
+---
+
+### PR D — `EmojiDialogActivity.kt`: string → StorageKeys
+
+**Riesgo:** bajo  
+**Modelo:** Sonnet 4.6  
+**Duración estimada:** 30 min  
+**Doc detalle:** [`07-semana-7-Dia-4.md`](07-semana-7-Dia-4.md)
+
+En `EmojiDialogActivity.kt` ~línea 260: reemplazar el string literal `"flutter.configured_zone_types"` por la constante equivalente. Kotlin no puede importar `StorageKeys.kt` directamente si vive en el módulo Flutter, por lo que se define una `companion object` local o un `object` Kotlin con la misma constante — con un comentario de contrato que señala la fuente de verdad.
+
+**Prerrequisito:** PR C mergeado y verificado en device.
+
+---
+
+## Orden de ejecución
+
+```
+PR A (bajo, 30min) → PR B (bajo, 1h) → PR C (medio, Opus, 2-3h)
+  → smoke test en device → PR D (bajo, 30min)
+```
+
+PR A y PR B pueden ejecutarse en la misma sesión. PR C en sesión separada con Opus. PR D solo tras smoke test de PR C.
+
+---
+
+## Smoke test de cierre (post PR C, pre PR D)
+
+| Paso | Escenario | Criterio |
+|------|-----------|----------|
+| 1 | Login → Circle visible | ✅ |
+| 2 | Enviar notificación BN a otro miembro | Modal de barra muestra emojis del círculo (no hardcodeados) |
+| 3 | Seleccionar emoji desde barra | Estado actualiza en Firestore + miembros ven cambio |
+| 4 | Quick Action desde home screen widget | Estado actualiza correctamente |
+| 5 | Activar Silent Mode → enviar BN | Modal BN sigue funcionando en Silent |
+| 6 | Cold start desde notificación BN | `configured_zone_types` cargado correctamente (no vacío) |
+
+---
+
+## Criterio de done — Sem 7
+
+- [ ] `grep -rn "StatusService.updateUserStatus" lib/` → 0 resultados en quick_actions y widget_service
+- [ ] `grep -rn "fallbackPredefined" lib/` → 0 resultados en notification_status_selector
+- [ ] `grep -rn "flutter.configured_zone_types" android/` → 0 literales (reemplazado por constante)
+- [ ] `EmojiCacheService.syncEmojisToNativeCache()` eliminado de `main.dart`
+- [ ] Smoke test 6 pasos PASS en device físico
+- [ ] `flutter analyze` → 0 errores nuevos
+- [ ] Tests existentes: 93+ en verde
+- [ ] Tag `refactor-sem7-done`
+- [ ] `00-plan-unificado.md` actualizado
+
+---
+
+## Métricas objetivo
+
+| Métrica | Antes | Meta |
+|---------|-------|------|
+| Callers de `StatusService.updateUserStatus` en quick_actions/widget | 2 | 0 |
+| Usos de `StatusType.fallbackPredefined` | 1 | 0 |
+| Keys de SharedPrefs como strings literales en Kotlin | 1 (`"flutter.configured_zone_types"`) | 0 |
+| Cold-start race `configured_zone_types = []` | Reproducible | No reproducible |
+
+---
+
+## Invariantes que NO cambian
+
+- `StatusService.updateUserStatus` en `status_service.dart` — sigue existiendo (otros callers fuera de scope).
+- Lógica de BN/Silent en `notification_status_selector.dart` — solo se cambia la fuente de emojis y el caller de update.
+- `EmojiDialogActivity.kt` — solo se cambia el string de key, sin tocar la lógica de renderizado.
+- Tests existentes (93) — deben permanecer en verde al final de cada PR.
+
+---
+
+## Lo que NO se toca (scope de Sem 8)
+
+- `GeofencingService` → `ZoneRepository` BC — Sem 8.
+- `DomainEventBus` integración completa — Sem 8.
+- Tests E2E en device físico (Normal→Silent→Normal con GPS real) — Sem 7 smoke test cubre el happy path; E2E formal es Sem 10.
+
+---
+
+## Referencias
+
+- Plan unificado: [`00-plan-unificado.md`](00-plan-unificado.md) §3.7
+- Infraestructura reutilizada: `lib/app/di/modules/presence_module.dart`, `lib/platform/persistence/native_keys.dart`
+- Memoria sesión: `memory/project_session_20260609_sem7_plan.md`

--- a/lib/core/widgets/nk_dialog.dart
+++ b/lib/core/widgets/nk_dialog.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import '../../app/theme/design_tokens.dart';
+
+/// Diálogo unificado del Design System NunaKin.
+///
+/// UFV de estilo: modal "Silencio" en in_circle_footer.dart.
+///
+/// Uso básico:
+///   final ok = await NkDialog.confirm(context, title: 'Silencio', body: '...');
+///   await NkDialog.inform(context, title: 'Mi Cuenta', contentWidget: myCol);
+class NkDialog {
+  NkDialog._();
+
+  // ─── Confirm ──────────────────────────────────────────────────────────────
+
+  /// Muestra un diálogo de confirmación con dos acciones (cancelar / confirmar).
+  /// Retorna `true` si el usuario confirma, `false` o `null` en caso contrario.
+  static Future<bool?> confirm(
+    BuildContext context, {
+    required String title,
+    required String body,
+    String cancelLabel = 'Cancelar',
+    String confirmLabel = 'Confirmar',
+    bool confirmDestructive = false,
+    bool barrierDismissible = true,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      barrierColor: NkColors.canvas.withValues(alpha: 0.75),
+      barrierDismissible: barrierDismissible,
+      builder: (ctx) => Dialog(
+        backgroundColor: NkColors.canvas,
+        insetPadding: const EdgeInsets.symmetric(
+          horizontal: NkSpacing.m,
+          vertical: NkSpacing.m,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: NkRadius.forButton,
+          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(NkSpacing.s5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: NkTextStyle.h3),
+              const SizedBox(height: 12),
+              Text(
+                body,
+                style: NkTextStyle.meta.copyWith(color: NkColors.fgMuted),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(false),
+                    style: TextButton.styleFrom(
+                      foregroundColor: NkColors.fgSub,
+                    ),
+                    child: Text(cancelLabel),
+                  ),
+                  const SizedBox(width: 8),
+                  TextButton(
+                    onPressed: () => Navigator.of(ctx).pop(true),
+                    style: TextButton.styleFrom(
+                      foregroundColor: confirmDestructive
+                          ? NkColors.danger
+                          : NkColors.mint,
+                    ),
+                    child: Text(
+                      confirmLabel,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ─── Inform ───────────────────────────────────────────────────────────────
+
+  /// Muestra un diálogo informativo con una sola acción de cierre.
+  /// Acepta [body] (texto plano) o [contentWidget] (widget custom).
+  /// Si se pasan ambos, [contentWidget] tiene prioridad.
+  static Future<void> inform(
+    BuildContext context, {
+    required String title,
+    String? body,
+    Widget? contentWidget,
+    String closeLabel = 'Entendido',
+    Color? closeColor,
+  }) {
+    assert(body != null || contentWidget != null,
+        'NkDialog.inform requiere body o contentWidget');
+    return showDialog<void>(
+      context: context,
+      barrierColor: NkColors.canvas.withValues(alpha: 0.75),
+      barrierDismissible: true,
+      builder: (ctx) => Dialog(
+        backgroundColor: NkColors.canvas,
+        insetPadding: const EdgeInsets.symmetric(
+          horizontal: NkSpacing.m,
+          vertical: NkSpacing.m,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: NkRadius.forButton,
+          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(NkSpacing.s5),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: NkTextStyle.h3),
+              const SizedBox(height: 12),
+              if (contentWidget != null)
+                contentWidget
+              else
+                Text(
+                  body!,
+                  style: NkTextStyle.meta.copyWith(color: NkColors.fgMuted),
+                ),
+              const SizedBox(height: 18),
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () => Navigator.of(ctx).pop(),
+                  style: TextButton.styleFrom(
+                    foregroundColor: closeColor ?? NkColors.mint,
+                  ),
+                  child: Text(
+                    closeLabel,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/circle/presentation/widgets/in_circle_footer.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_footer.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import '../../../../app/theme/design_tokens.dart';
 import '../../../../core/services/silent_functionality_coordinator.dart';
+import '../../../../core/widgets/nk_dialog.dart';
 import 'silent_mode_button.dart';
 
 class InCircleFooter extends StatefulWidget {
@@ -17,56 +18,12 @@ class _InCircleFooterState extends State<InCircleFooter> {
   bool _isUpdating = false;
 
   Future<void> _confirmAndActivateSilentMode() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      barrierColor: NkColors.canvas.withValues(alpha: 0.75),
-      barrierDismissible: true,
-      builder: (dialogContext) {
-        return Dialog(
-          backgroundColor: NkColors.canvas,
-          insetPadding: const EdgeInsets.symmetric(horizontal: NkSpacing.m, vertical: NkSpacing.m),
-          shape: RoundedRectangleBorder(
-            borderRadius: NkRadius.forButton,
-            side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(NkSpacing.s5),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text(
-                  'Silencio',
-                  style: NkTextStyle.h3,
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  'La app se minimizará y quedará activa en segundo plano. '
-                  'Podrás cambiar tu estado desde la notificación persistente.',
-                  style: NkTextStyle.meta.copyWith(color: NkColors.fgMuted),
-                ),
-                const SizedBox(height: 18),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(false),
-                      style: TextButton.styleFrom(foregroundColor: NkColors.fgSub),
-                      child: const Text('Cancelar'),
-                    ),
-                    const SizedBox(width: 8),
-                    TextButton(
-                      onPressed: () => Navigator.of(dialogContext).pop(true),
-                      style: TextButton.styleFrom(foregroundColor: NkColors.mint),
-                      child: const Text('Activar', style: TextStyle(fontWeight: FontWeight.bold)),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        );
-      },
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Silencio',
+      body: 'La app se minimizará y quedará activa en segundo plano. '
+          'Podrás cambiar tu estado desde la notificación persistente.',
+      confirmLabel: 'Activar',
     );
 
     if (confirmed == true && mounted) {

--- a/lib/features/circle/presentation/widgets/no_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/no_circle_view.dart
@@ -8,6 +8,7 @@ import '../../../../contexts/identity/presentation/pages/auth_final_page.dart';
 import '../../../../core/services/session_cache_service.dart';
 import '../../../../services/circle_service.dart';
 import '../../../../app/theme/design_tokens.dart';
+import '../../../../core/widgets/nk_dialog.dart';
 import 'create_circle_view.dart';
 import 'join_circle_view.dart';
 
@@ -73,79 +74,50 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
         ? authState.user.email
         : (fbUser?.email ?? '');
 
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: NkColors.canvas,
-        shape: RoundedRectangleBorder(
-          borderRadius: NkRadius.forButton,
-          side: BorderSide(color: NkColors.mintSoft(0.4), width: 1),
-        ),
-        title: const Text(
-          'Mi Cuenta',
-          style: TextStyle(color: NkColors.onDark),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text('Nickname', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
-            const SizedBox(height: 4),
-            Text(nickname, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
-            const SizedBox(height: 16),
-            const Text('Email', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
-            const SizedBox(height: 4),
-            Text(email, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
-          ],
-        ),
-        actions: [
+    NkDialog.inform(
+      context,
+      title: 'Mi Cuenta',
+      contentWidget: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Nickname', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
+          const SizedBox(height: 4),
+          Text(nickname, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
+          const SizedBox(height: 16),
+          const Text('Email', style: TextStyle(color: NkColors.fgHint, fontSize: 12)),
+          const SizedBox(height: 4),
+          Text(email, style: const TextStyle(color: NkColors.onDark, fontSize: 16)),
+          const SizedBox(height: 16),
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
               _showDeleteAccountDialog(context);
             },
-            child: const Text('Eliminar Cuenta', style: TextStyle(color: NkColors.danger)),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('Cerrar', style: TextStyle(color: NkColors.mint)),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showDeleteAccountDialog(BuildContext parentContext) {
-    showDialog(
-      context: parentContext,
-      barrierDismissible: false,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: NkColors.surface2,
-        shape: RoundedRectangleBorder(borderRadius: NkRadius.forButton),
-        title: const Text('Eliminar Cuenta', style: TextStyle(color: NkColors.onDark)),
-        content: const Text(
-          '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
-          style: TextStyle(color: NkColors.fgSub),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Cancelar', style: TextStyle(color: NkColors.fgSub)),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(dialogContext).pop();
-              // FIX: Usar mounted del State y this.context en lugar del context del diálogo
-              if (mounted) {
-                _executeDeleteAccount(context);
-              }
-            },
-            style: TextButton.styleFrom(foregroundColor: NkColors.danger),
+            style: TextButton.styleFrom(
+              padding: EdgeInsets.zero,
+              foregroundColor: NkColors.danger,
+            ),
             child: const Text('Eliminar Cuenta'),
           ),
         ],
       ),
+      closeLabel: 'Cerrar',
     );
+  }
+
+  void _showDeleteAccountDialog(BuildContext parentContext) async {
+    final confirmed = await NkDialog.confirm(
+      parentContext,
+      title: 'Eliminar Cuenta',
+      body: '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
+      confirmLabel: 'Eliminar Cuenta',
+      confirmDestructive: true,
+      barrierDismissible: false,
+    );
+    if (confirmed == true && mounted) {
+      _executeDeleteAccount(context);
+    }
   }
 
   Future<void> _executeDeleteAccount(BuildContext context) async {
@@ -351,70 +323,39 @@ class _NoCircleViewState extends ConsumerState<NoCircleView> {
     );
   }
 
-  void _showLogoutDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: NkColors.surface2,
-        title: const Text(
-          'Cerrar Sesión',
-          style: TextStyle(color: NkColors.onDark),
-        ),
-        content: const Text(
-          '¿Estás seguro de que quieres cerrar sesión?',
-          style: TextStyle(color: NkColors.fgSub),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text(
-              'Cancelar',
-              style: TextStyle(color: NkColors.fgSub),
-            ),
-          ),
-          TextButton(
-            key: const Key('dialog_btn_logout_confirm'),
-            onPressed: () async {
-              Navigator.of(context).pop();
-              try {
-                print('🔴 [LOGOUT] Iniciando logout desde NoCircleView (sin círculo)...');
-
-                // PASO 1: Limpiar cache PRIMERO (evita parpadeo de NoCircleView)
-                print('🔴 [LOGOUT] Limpiando SessionCache...');
-                await SessionCacheService.clearSession();
-
-                // PASO 2: Cerrar sesión Firebase
-                await FirebaseAuth.instance.signOut();
-                print('🔴 [LOGOUT] Firebase signOut completado');
-
-                // PASO 3: Navegar directo a login (sin SnackBar)
-                if (context.mounted) {
-                  Navigator.of(context).pushAndRemoveUntil(
-                    MaterialPageRoute(builder: (_) => const AuthFinalPage()),
-                    (route) => false,
-                  );
-                  print('✅ [LOGOUT] Navegación completada');
-                }
-              } catch (e) {
-                print('❌ [LOGOUT] Error: $e');
-                // Solo mostrar error si realmente falla
-                if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text('Error al cerrar sesión: $e'),
-                      backgroundColor: NkColors.danger,
-                      duration: const Duration(seconds: 2),
-                    ),
-                  );
-                }
-              }
-            },
-            style: TextButton.styleFrom(foregroundColor: NkColors.danger),
-            child: const Text('Cerrar Sesión'),
-          ),
-        ],
-      ),
+  void _showLogoutDialog(BuildContext outerContext) async {
+    final confirmed = await NkDialog.confirm(
+      outerContext,
+      title: 'Cerrar Sesión',
+      body: '¿Estás seguro de que quieres cerrar sesión?',
+      confirmLabel: 'Cerrar Sesión',
     );
+    if (confirmed != true) return;
+    try {
+      print('🔴 [LOGOUT] Iniciando logout desde NoCircleView (sin círculo)...');
+      print('🔴 [LOGOUT] Limpiando SessionCache...');
+      await SessionCacheService.clearSession();
+      await FirebaseAuth.instance.signOut();
+      print('🔴 [LOGOUT] Firebase signOut completado');
+      if (outerContext.mounted) {
+        Navigator.of(outerContext).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const AuthFinalPage()),
+          (route) => false,
+        );
+        print('✅ [LOGOUT] Navegación completada');
+      }
+    } catch (e) {
+      print('❌ [LOGOUT] Error: $e');
+      if (outerContext.mounted) {
+        ScaffoldMessenger.of(outerContext).showSnackBar(
+          SnackBar(
+            content: Text('Error al cerrar sesión: $e'),
+            backgroundColor: NkColors.danger,
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    }
   }
 
   @override

--- a/lib/features/geofencing/presentation/pages/zones_page.dart
+++ b/lib/features/geofencing/presentation/pages/zones_page.dart
@@ -9,6 +9,7 @@ import '../../services/zone_service.dart';
 import '../widgets/zone_form.dart';
 import '../widgets/geofencing_debug_widget.dart';
 import '../../../../app/theme/design_tokens.dart';
+import '../../../../core/widgets/nk_dialog.dart';
 
 /// Página de gestión de zonas geográficas
 /// Lista todas las zonas del círculo con opciones CRUD
@@ -244,40 +245,19 @@ class _ZonesPageState extends ConsumerState<ZonesPage> {
     );
   }
 
-  void _confirmDelete(BuildContext context, Zone zone) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        backgroundColor: NkColors.surface2,
-        title: const Text(
-          'Eliminar zona',
-          style: TextStyle(color: NkColors.onDark),
-        ),
-        content: Text(
-          '¿Estás seguro de eliminar "${zone.name}"?\n\nEsta acción no se puede deshacer.',
-          style: const TextStyle(color: NkColors.fgMuted),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'CANCELAR',
-              style: TextStyle(color: NkColors.fgSub),
-            ),
-          ),
-          TextButton(
-            onPressed: () async {
-              Navigator.pop(context);
-              await _deleteZone(context, zone);
-            },
-            child: const Text(
-              'ELIMINAR',
-              style: TextStyle(color: NkColors.danger),
-            ),
-          ),
-        ],
-      ),
+  void _confirmDelete(BuildContext context, Zone zone) async {
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Eliminar zona',
+      body: '¿Estás seguro de eliminar "${zone.name}"?\n\nEsta acción no se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      cancelLabel: 'Cancelar',
+      confirmDestructive: true,
+      barrierDismissible: false,
     );
+    if (confirmed == true && context.mounted) {
+      await _deleteZone(context, zone);
+    }
   }
 
   Future<void> _deleteZone(BuildContext context, Zone zone) async {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -9,6 +9,7 @@ import '../../../../contexts/identity/presentation/pages/auth_final_page.dart';
 import '../../../../core/widgets/quick_actions_config_widget.dart';
 import '../../../../core/services/silent_functionality_coordinator.dart'; // Point 1 SPEC
 import '../../../../core/services/session_cache_service.dart'; // FIX: Para limpiar cache en logout
+import '../../../../core/widgets/nk_dialog.dart';
 import 'emoji_management_page.dart'; // Gestión de estados/emojis
 import '../../../geofencing/presentation/pages/zones_page.dart'; // Gestión de zonas geográficas
 import '../../../../services/circle_service.dart'; // Para obtener Circle object
@@ -315,36 +316,19 @@ class _SettingsPageState extends ConsumerState<SettingsPage> with SingleTickerPr
     }
   }
 
-  /// Point 1 SPEC: Muestra diálogo de confirmación para cerrar sesión
-  void _showDeleteAccountDialog(BuildContext context) {
-    showDialog(
-      context: context,
+  /// Point 1 SPEC: Muestra diálogo de confirmación para eliminar cuenta
+  void _showDeleteAccountDialog(BuildContext context) async {
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Eliminar Cuenta',
+      body: '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
+      confirmLabel: 'Eliminar Cuenta',
+      confirmDestructive: true,
       barrierDismissible: false,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: _AppColors.cardBackground,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Eliminar Cuenta', style: TextStyle(color: _AppColors.textPrimary)),
-        content: const Text(
-          '¿Estás seguro? Esta acción es irreversible. Se eliminarán tu cuenta y todos tus datos.',
-          style: TextStyle(color: _AppColors.textSecondary),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Cancelar', style: TextStyle(color: _AppColors.textSecondary)),
-          ),
-          TextButton(
-            onPressed: () async {
-              Navigator.of(dialogContext).pop();
-              if (mounted) {
-                _executeDeleteAccount(this.context);
-              }
-            },
-            child: const Text('Eliminar Cuenta', style: TextStyle(color: _AppColors.sosRed)),
-          ),
-        ],
-      ),
     );
+    if (confirmed == true && mounted) {
+      _executeDeleteAccount(this.context);
+    }
   }
 
   Future<void> _executeDeleteAccount(BuildContext context) async {
@@ -527,110 +511,66 @@ class _SettingsPageState extends ConsumerState<SettingsPage> with SingleTickerPr
   }
 
   void _showCircleLostInfoDialog(BuildContext context) {
-    showDialog(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: _AppColors.cardBackground,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Ya no estás en tu círculo', style: TextStyle(color: _AppColors.textPrimary)),
-        content: const Text(
-          'Al cancelar la eliminación saliste de tu círculo. Para volver, pídele a alguien del grupo que te comparta el código de invitación.',
-          style: TextStyle(color: _AppColors.textSecondary),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Entendido', style: TextStyle(color: _AppColors.accent)),
-          ),
-        ],
-      ),
+    NkDialog.inform(
+      context,
+      title: 'Ya no estás en tu círculo',
+      body: 'Al cancelar la eliminación saliste de tu círculo. Para volver, pídele a alguien del grupo que te comparta el código de invitación.',
     );
   }
 
-  void _showLogoutDialog(BuildContext context, WidgetRef ref) {
-    showDialog(
-      context: context,
-      barrierDismissible: false, // Evitar cerrar el diálogo accidentalmente durante el proceso
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: _AppColors.cardBackground,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        title: const Text('Cerrar Sesión', style: TextStyle(color: _AppColors.textPrimary)),
-        content: const Text('¿Estás seguro?', style: TextStyle(color: _AppColors.textSecondary)),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: const Text('Cancelar', style: TextStyle(color: _AppColors.textSecondary)),
-          ),
-          TextButton(
-            onPressed: () async {
-              // 1. Cerrar el diálogo PRIMERO
-              Navigator.of(dialogContext).pop();
-
-              // 2. Mostrar indicador de carga
-              if (context.mounted) {
-                showDialog(
-                  context: context,
-                  barrierDismissible: false,
-                  builder: (_) => const Center(
-                    child: CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation<Color>(NkColors.mint),
-                    ),
-                  ),
-                );
-              }
-
-              try {
-                // 3. Limpiar notificaciones y servicios (Point 1.1 - paso 2 y 3)
-                print('🔴 [LOGOUT] Iniciando proceso de logout desde Settings...');
-                print('🔴 [LOGOUT] Paso 1/3: Desactivando funcionalidad silenciosa...');
-
-                await SilentFunctionalityCoordinator.deactivateAfterLogout().timeout(
-                  const Duration(seconds: 10),
-                  onTimeout: () {
-                    print('⚠️ [LOGOUT] Timeout en deactivateAfterLogout, continuando...');
-                  },
-                );
-
-                // FIX: Limpiar SessionCache INMEDIATAMENTE para evitar parpadeo
-                print('🔴 [LOGOUT] Limpiando SessionCache...');
-                await SessionCacheService.clearSession();
-
-                print('🔴 [LOGOUT] Paso 2/3: Cerrando sesión de Firebase...');
-
-                // 4. Invalidar sesión (Point 1.1 - paso 1)
-                await FirebaseAuth.instance.signOut().timeout(
-                  const Duration(seconds: 10),
-                  onTimeout: () {
-                    print('⚠️ [LOGOUT] Timeout en signOut, continuando...');
-                  },
-                );
-
-                print('🔴 [LOGOUT] Paso 3/3: Redirigiendo a login...');
-              } catch (e) {
-                print('❌ [LOGOUT] Error durante logout: $e');
-                // Continuar con navegación incluso si hay error
-              } finally {
-                // 5. SIEMPRE navegar a login (Point 1.1 - paso 4)
-                // Garantizar que la navegación ocurra sin importar errores anteriores
-                if (context.mounted) {
-                  // Cerrar indicador de carga si existe
-                  Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
-
-                  // Navegar a AuthFinalPage
-                  Navigator.of(context).pushAndRemoveUntil(
-                    MaterialPageRoute(builder: (_) => const AuthFinalPage()),
-                    (route) => false,
-                  );
-
-                  print('✅ [LOGOUT] Logout completado exitosamente');
-                }
-              }
-            },
-            child: const Text('Cerrar Sesión', style: TextStyle(color: _AppColors.sosRed)),
-          ),
-        ],
-      ),
+  void _showLogoutDialog(BuildContext context, WidgetRef ref) async {
+    final confirmed = await NkDialog.confirm(
+      context,
+      title: 'Cerrar Sesión',
+      body: '¿Estás seguro?',
+      confirmLabel: 'Cerrar Sesión',
+      barrierDismissible: false,
     );
+    if (confirmed != true) return;
+
+    if (context.mounted) {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(
+          child: CircularProgressIndicator(
+            valueColor: AlwaysStoppedAnimation<Color>(NkColors.mint),
+          ),
+        ),
+      );
+    }
+
+    try {
+      print('🔴 [LOGOUT] Iniciando proceso de logout desde Settings...');
+      print('🔴 [LOGOUT] Paso 1/3: Desactivando funcionalidad silenciosa...');
+      await SilentFunctionalityCoordinator.deactivateAfterLogout().timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          print('⚠️ [LOGOUT] Timeout en deactivateAfterLogout, continuando...');
+        },
+      );
+      print('🔴 [LOGOUT] Limpiando SessionCache...');
+      await SessionCacheService.clearSession();
+      print('🔴 [LOGOUT] Paso 2/3: Cerrando sesión de Firebase...');
+      await FirebaseAuth.instance.signOut().timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          print('⚠️ [LOGOUT] Timeout en signOut, continuando...');
+        },
+      );
+      print('🔴 [LOGOUT] Paso 3/3: Redirigiendo a login...');
+    } catch (e) {
+      print('❌ [LOGOUT] Error durante logout: $e');
+    } finally {
+      if (context.mounted) {
+        Navigator.of(context, rootNavigator: true).popUntil((route) => route.isFirst);
+        Navigator.of(context).pushAndRemoveUntil(
+          MaterialPageRoute(builder: (_) => const AuthFinalPage()),
+          (route) => false,
+        );
+        print('✅ [LOGOUT] Logout completado exitosamente');
+      }
+    }
   }
   // --- FIN DE LÓGICA (SIN CAMBIOS) ---
 

--- a/lib/widgets/zone_selection_not_allowed_dialog.dart
+++ b/lib/widgets/zone_selection_not_allowed_dialog.dart
@@ -1,58 +1,12 @@
 import 'package:flutter/material.dart';
+import '../core/widgets/nk_dialog.dart';
 
 /// Diálogo informativo cuando el usuario intenta seleccionar manualmente
 /// un emoji asociado a una zona configurada por geofencing.
 Future<void> showZoneSelectionNotAllowedDialog(BuildContext context) {
-  return showDialog<void>(
-    context: context,
-    barrierColor: Colors.black.withValues(alpha: 0.75),
-    barrierDismissible: true,
-    builder: (context) => Dialog(
-      backgroundColor: Colors.black,
-      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-        side: BorderSide(
-          color: const Color(0xFF1CE4B3).withValues(alpha: 0.4),
-          width: 1,
-        ),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              'Acción no permitida',
-              style: TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-                color: Colors.white,
-              ),
-            ),
-            const SizedBox(height: 12),
-            const Text(
-              'No puedes seleccionar zonas manualmente. El estado de zonas se actualiza automáticamente por geofencing.',
-              style: TextStyle(fontSize: 14, color: Color(0xCCFFFFFF)),
-            ),
-            const SizedBox(height: 18),
-            Align(
-              alignment: Alignment.centerRight,
-              child: TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                style: TextButton.styleFrom(
-                  foregroundColor: const Color(0xFF1CE4B3),
-                ),
-                child: const Text(
-                  'Entendido',
-                  style: TextStyle(fontWeight: FontWeight.bold),
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    ),
+  return NkDialog.inform(
+    context,
+    title: 'Acción no permitida',
+    body: 'No puedes seleccionar zonas manualmente. El estado de zonas se actualiza automáticamente por geofencing.',
   );
 }


### PR DESCRIPTION
## Summary

- 06-semana-6-hardening.md: retrospectiva Sem 6 (PR #201, tag refactor-sem6-done)
- 06a-semana-6a-design-system.md: retrospectiva DS v2.0 Minimalist (PRs #203, #205-#218, NkDialog)
- 07-semana-7-flujos-legacy.md: overview Sem 7 - 4 PRs (A-D), migracion callers legacy
- 07-semana-7-Dia-1.md: PR A - eliminar sync prematuro en main.dart (confianza 99%)
- 07-semana-7-Dia-2.md: PR B - quick_actions + widget_service SetManualStatus (95%)
- 07-semana-7-Dia-3.md: PR C - notification_status_selector emojis reales (Opus, 92%)
- 07-semana-7-Dia-4.md: PR D - EmojiDialogActivity key constante (97%)
- 00-plan-unificado.md: Sem 6a completa, Sem 7 PROXIMA, main 1a0edaf

## Test plan

- [ ] Revisar formato y contenido de cada MD contra semanas anteriores
- [ ] Verificar links internos entre archivos