### PR TITLE
refactor(presence): EmojiDialogActivity hardcoded keys → SharedKeys (Sem 7 PR D)

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/EmojiDialogActivity.kt
@@ -201,7 +201,8 @@ class EmojiDialogActivity : Activity() {
         val cacheMap = mutableMapOf<String, Triple<String, String, String>>()
 
         val prefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
-        val cachedJson = prefs.getString("flutter.predefined_emojis", null)
+        // Contrato Dart↔Kotlin: clave escrita por EmojiCacheService (ver SharedKeys.kt / native_keys.dart)
+        val cachedJson = prefs.getString(SharedKeys.flutter(SharedKeys.PREDEFINED_EMOJIS), null)
 
         if (cachedJson != null) {
             try {
@@ -269,7 +270,8 @@ class EmojiDialogActivity : Activity() {
      */
     private fun loadConfiguredZoneTypes(): Set<String> {
         val prefs = getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
-        val json = prefs.getString("flutter.configured_zone_types", null)
+        // Contrato Dart↔Kotlin: clave escrita por EmojiCacheService (ver SharedKeys.kt / native_keys.dart)
+        val json = prefs.getString(SharedKeys.flutter(SharedKeys.CONFIGURED_ZONE_TYPES), null)
             ?: return emptySet<String>().also {
                 Log.d(TAG, "⚠️ [ZONES] Sin cache de zonas configuradas")
             }


### PR DESCRIPTION
## Sem 7 PR D — cierre del legado de keys hardcodeadas

Último PR del PA95C Sem 7. Reemplaza los 2 string literals de keys SharedPreferences en `EmojiDialogActivity.kt` por constantes `SharedKeys` (contrato Dart↔Kotlin):

| Antes | Después |
|-------|---------|
| `"flutter.predefined_emojis"` | `SharedKeys.flutter(SharedKeys.PREDEFINED_EMOJIS)` |
| `"flutter.configured_zone_types"` | `SharedKeys.flutter(SharedKeys.CONFIGURED_ZONE_TYPES)` |

El plan nombraba solo `configured_zone_types`; se incluye el gemelo `predefined_emojis` (idéntico patrón/riesgo) para dejar el archivo sin literales `"flutter.*"`.

### Test Plan
**Excepción CLAUDE.md §8** — refactor sin lógica de negocio, sin cambio de comportamiento. Los strings concatenados son byte-idénticos a los literales originales (`"flutter." + "predefined_emojis"`). El patrón `SharedKeys.flutter(...)` ya está validado en device (fix Bug A, PR #223, mismo archivo).

### Riesgo
Bajo. Cero cambio de comportamiento. Constantes ya existentes en `SharedKeys.kt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)