### PR TITLE
style(circle): remove veil fade-in on status modal open

### DIFF
--- a/lib/widgets/status_selector_overlay.dart
+++ b/lib/widgets/status_selector_overlay.dart
@@ -32,7 +32,6 @@ class StatusSelectorOverlay extends StatefulWidget {
 class _StatusSelectorOverlayState extends State<StatusSelectorOverlay>
     with SingleTickerProviderStateMixin {
   late final AnimationController _animationController;
-  late final Animation<double> _fadeAnimation;
   late final Animation<double> _scaleAnimation;
 
   Timer? _sosTimer;
@@ -50,9 +49,6 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay>
     _animationController = AnimationController(
       duration: const Duration(milliseconds: 300),
       vsync: this,
-    );
-    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
-      CurvedAnimation(parent: _animationController, curve: Curves.easeInOut),
     );
     _scaleAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
       CurvedAnimation(parent: _animationController, curve: Curves.elasticOut),
@@ -125,7 +121,8 @@ class _StatusSelectorOverlayState extends State<StatusSelectorOverlay>
         return GestureDetector(
           onTap: _closeModal,
           child: Container(
-            color: NkColors.canvas.withValues(alpha: 0.85 * _fadeAnimation.value),
+            // [B] Velo a opacidad fija — sin fade-in (quita el efecto de "difuminado" progresivo)
+            color: NkColors.canvas.withValues(alpha: 0.85),
             child: Center(
               child: GestureDetector(
                 onTap: () {},


### PR DESCRIPTION
## Animación del modal del círculo — Opción B (quitar el velo)

El "difuminado" percibido al tocar un miembro era el **fade-in del velo oscuro** (0 → 0.85 en 300ms, `easeInOut`). No era un blur real.

### Cambio (Opción B)
- Velo a **0.85 fijo** (sin fade-in progresivo) → desaparece la sensación de difuminado
- **Conserva** el scale del modal (entrada con rebote `elasticOut`)
- Elimina el binding huérfano `_fadeAnimation`

`status_selector_overlay.dart` · −5 / +2 · `flutter analyze`: sin issues.

> Aplica solo al modal del **círculo**. El modal de Modo Silencio (nativo) ya aparecía instantáneo.

### Test Plan
Verificación visual en device: tocar un miembro → el modal abre sin el velo progresivo (fondo oscuro de inmediato, modal con rebote). Cambio de UX puro, sin lógica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)