### PR TITLE
refactor(geofencing): ZoneRepository port + Firestore impl (Sem 8 E1)

### DIFF
--- a/lib/app/di/modules/geofencing_module.dart
+++ b/lib/app/di/modules/geofencing_module.dart
@@ -2,11 +2,17 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:get_it/get_it.dart';
 import 'package:nunakin_app/contexts/geofencing/application/ports/geofence_status_writer.dart';
+import 'package:nunakin_app/contexts/geofencing/application/ports/zone_repository.dart';
 import 'package:nunakin_app/contexts/geofencing/application/use_cases/apply_geofence_status.dart';
 import 'package:nunakin_app/contexts/geofencing/infrastructure/firestore_geofence_status_writer.dart';
+import 'package:nunakin_app/contexts/geofencing/infrastructure/firestore_zone_repository.dart';
 import 'package:nunakin_app/shared/events/domain_event_bus.dart';
 
 Future<void> registerGeofencingModule(GetIt sl) async {
+  sl.registerLazySingleton<ZoneRepository>(
+    () => FirestoreZoneRepository(sl<FirebaseFirestore>()),
+  );
+
   sl.registerLazySingleton<GeofenceStatusWriter>(
     () => FirestoreGeofenceStatusWriter(
       sl<FirebaseFirestore>(),

--- a/lib/contexts/geofencing/application/ports/zone_repository.dart
+++ b/lib/contexts/geofencing/application/ports/zone_repository.dart
@@ -1,0 +1,29 @@
+import 'package:nunakin_app/features/geofencing/domain/entities/zone.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+/// Puerto de acceso a la persistencia de zonas geográficas.
+///
+/// Persistencia pura (CRUD Firestore). Las validaciones de negocio
+/// (límite de zonas, nombre único, permisos, reset de memberStatus
+/// post-borrado, sync de cache nativo) viven en use cases — no aquí.
+abstract class ZoneRepository {
+  /// Todas las zonas del círculo, ordenadas por `createdAt` ascendente.
+  Future<Result<List<Zone>>> getCircleZones(String circleId);
+
+  /// Una zona por id, o `null` si no existe.
+  Future<Result<Zone?>> getZone(String circleId, String zoneId);
+
+  /// Stream en tiempo real de las zonas del círculo.
+  Stream<List<Zone>> watchCircleZones(String circleId);
+
+  /// Persiste una zona nueva. Si [Zone.id] está vacío, genera el id.
+  /// Devuelve la zona persistida con su id definitivo.
+  Future<Result<Zone>> createZone(Zone zone);
+
+  /// Persiste los campos de [zone] sobre el documento existente.
+  Future<Result<Unit>> updateZone(Zone zone);
+
+  /// Elimina la zona indicada.
+  Future<Result<Unit>> deleteZone(String circleId, String zoneId);
+}

--- a/lib/contexts/geofencing/infrastructure/firestore_zone_repository.dart
+++ b/lib/contexts/geofencing/infrastructure/firestore_zone_repository.dart
@@ -1,0 +1,96 @@
+import 'dart:developer';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:nunakin_app/contexts/geofencing/application/ports/zone_repository.dart';
+import 'package:nunakin_app/features/geofencing/domain/entities/zone.dart';
+import 'package:nunakin_app/shared/failure.dart';
+import 'package:nunakin_app/shared/result.dart';
+import 'package:nunakin_app/shared/unit.dart';
+
+/// Implementación Firestore de [ZoneRepository].
+///
+/// Persistencia pura: sin validaciones de negocio ni side-effects
+/// cross-context. Errores de Firestore se mapean a [UnexpectedFailure].
+class FirestoreZoneRepository implements ZoneRepository {
+  final FirebaseFirestore _firestore;
+
+  FirestoreZoneRepository(this._firestore);
+
+  CollectionReference<Map<String, dynamic>> _zones(String circleId) =>
+      _firestore.collection('circles').doc(circleId).collection('zones');
+
+  @override
+  Future<Result<List<Zone>>> getCircleZones(String circleId) async {
+    try {
+      final snapshot =
+          await _zones(circleId).orderBy('createdAt', descending: false).get();
+      final zones = snapshot.docs.map((doc) => Zone.fromFirestore(doc)).toList();
+      return Success(zones);
+    } catch (e, st) {
+      log('[ZoneRepository] ❌ getCircleZones: $e');
+      return FailureResult(
+          UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+
+  @override
+  Future<Result<Zone?>> getZone(String circleId, String zoneId) async {
+    try {
+      final doc = await _zones(circleId).doc(zoneId).get();
+      if (!doc.exists) return const Success(null);
+      return Success(Zone.fromFirestore(doc));
+    } catch (e, st) {
+      log('[ZoneRepository] ❌ getZone: $e');
+      return FailureResult(
+          UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+
+  @override
+  Stream<List<Zone>> watchCircleZones(String circleId) {
+    return _zones(circleId)
+        .orderBy('createdAt', descending: false)
+        .snapshots()
+        .map((snapshot) =>
+            snapshot.docs.map((doc) => Zone.fromFirestore(doc)).toList());
+  }
+
+  @override
+  Future<Result<Zone>> createZone(Zone zone) async {
+    try {
+      final ref =
+          zone.id.isEmpty ? _zones(zone.circleId).doc() : _zones(zone.circleId).doc(zone.id);
+      final persisted = zone.id.isEmpty ? zone.copyWith(id: ref.id) : zone;
+      await ref.set(persisted.toFirestore());
+      return Success(persisted);
+    } catch (e, st) {
+      log('[ZoneRepository] ❌ createZone: $e');
+      return FailureResult(
+          UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+
+  @override
+  Future<Result<Unit>> updateZone(Zone zone) async {
+    try {
+      await _zones(zone.circleId).doc(zone.id).update(zone.toFirestore());
+      return Success(Unit.instance);
+    } catch (e, st) {
+      log('[ZoneRepository] ❌ updateZone: $e');
+      return FailureResult(
+          UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+
+  @override
+  Future<Result<Unit>> deleteZone(String circleId, String zoneId) async {
+    try {
+      await _zones(circleId).doc(zoneId).delete();
+      return Success(Unit.instance);
+    } catch (e, st) {
+      log('[ZoneRepository] ❌ deleteZone: $e');
+      return FailureResult(
+          UnexpectedFailure(message: e.toString(), cause: e, stackTrace: st));
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  antlr4:
+    dependency: transitive
+    description:
+      name: antlr4
+      sha256: "752b4a6e4ad97953652a2b2bbf5377f46c94b579d3372b50080c7e5858234a05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.2"
   app_badge_plus:
     dependency: "direct main"
     description:
@@ -65,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  cel:
+    dependency: transitive
+    description:
+      name: cel
+      sha256: "51d77e16424d41b5fdb0a239be4c8a0550d4dd3f952801d35375ddd90cfb49da"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4+1"
   change_app_package_name:
     dependency: "direct dev"
     description:
@@ -209,6 +225,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  fake_cloud_firestore:
+    dependency: "direct dev"
+    description:
+      name: fake_cloud_firestore
+      sha256: "804bfb59108fc93b93c28b61e8142c477bd6f188a12d06875310f0b2f01b3974"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  fake_firebase_security_rules:
+    dependency: transitive
+    description:
+      name: fake_firebase_security_rules
+      sha256: "6af54bedfd6985451a9735f2cfac91ffe0128bfc92bf15e8544cd56c6941d6cc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.4"
   ffi:
     dependency: transitive
     description:
@@ -687,6 +719,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -711,6 +759,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mock_exceptions:
+    dependency: transitive
+    description:
+      name: mock_exceptions
+      sha256: "6e3e623712d2c6106ffe9e14732912522b565ddaa82a8dcee6cd4441b5984056"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
+  more:
+    dependency: transitive
+    description:
+      name: more
+      sha256: e252628d2183cc09539b686abfbd9d8302675959b89a2a8146f5f4baca6ac5ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
   nm:
     dependency: transitive
     description:
@@ -903,6 +967,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.5"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
   riverpod:
     dependency: transitive
     description:
@@ -911,6 +983,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  rx:
+    dependency: transitive
+    description:
+      name: rx
+      sha256: "7f54bd39cc63a01c770c1de4b6ce8e135eb13119614cba2216bd9a93ccd29e56"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   sanitize_html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dev_dependencies:
   
   # Generador de splash screens nativos
   flutter_native_splash: ^2.4.2
+  fake_cloud_firestore: ^3.1.0
 
 flutter:
   uses-material-design: true

--- a/test/contexts/geofencing/infrastructure/firestore_zone_repository_test.dart
+++ b/test/contexts/geofencing/infrastructure/firestore_zone_repository_test.dart
@@ -1,0 +1,126 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/geofencing/infrastructure/firestore_zone_repository.dart';
+import 'package:nunakin_app/features/geofencing/domain/entities/zone.dart';
+
+void main() {
+  late FakeFirebaseFirestore firestore;
+  late FirestoreZoneRepository repo;
+
+  const circleId = 'circle1';
+
+  Zone sampleZone({
+    String id = '',
+    String name = 'Casa',
+    ZoneType type = ZoneType.home,
+    DateTime? createdAt,
+  }) =>
+      Zone(
+        id: id,
+        name: name,
+        latitude: -12.0,
+        longitude: -77.0,
+        radiusMeters: 100,
+        circleId: circleId,
+        createdBy: 'user1',
+        createdAt: createdAt ?? DateTime(2026, 1, 1),
+        type: type,
+        isPredefined: type.isPredefinedType,
+      );
+
+  setUp(() {
+    firestore = FakeFirebaseFirestore();
+    repo = FirestoreZoneRepository(firestore);
+  });
+
+  group('createZone', () {
+    test('genera id cuando Zone.id está vacío y persiste el documento', () async {
+      final result = await repo.createZone(sampleZone());
+
+      expect(result.isSuccess, isTrue);
+      final created = result.valueOrNull!;
+      expect(created.id, isNotEmpty);
+
+      final doc = await firestore
+          .collection('circles')
+          .doc(circleId)
+          .collection('zones')
+          .doc(created.id)
+          .get();
+      expect(doc.exists, isTrue);
+      expect(doc.data()!['name'], 'Casa');
+    });
+
+    test('respeta el id provisto cuando Zone.id no está vacío', () async {
+      final result = await repo.createZone(sampleZone(id: 'fixedId'));
+      expect(result.valueOrNull!.id, 'fixedId');
+    });
+  });
+
+  group('getCircleZones', () {
+    test('retorna las zonas ordenadas por createdAt ascendente', () async {
+      await repo.createZone(sampleZone(name: 'B', createdAt: DateTime(2026, 1, 2)));
+      await repo.createZone(sampleZone(name: 'A', createdAt: DateTime(2026, 1, 1)));
+
+      final result = await repo.getCircleZones(circleId);
+
+      expect(result.isSuccess, isTrue);
+      final zones = result.valueOrNull!;
+      expect(zones.map((z) => z.name).toList(), ['A', 'B']);
+    });
+
+    test('círculo sin zonas → lista vacía', () async {
+      final result = await repo.getCircleZones('empty');
+      expect(result.isSuccess, isTrue);
+      expect(result.valueOrNull, isEmpty);
+    });
+  });
+
+  group('getZone', () {
+    test('zona existente → Zone', () async {
+      final created = (await repo.createZone(sampleZone())).valueOrNull!;
+      final result = await repo.getZone(circleId, created.id);
+      expect(result.valueOrNull?.name, 'Casa');
+    });
+
+    test('zona inexistente → null (Success)', () async {
+      final result = await repo.getZone(circleId, 'nope');
+      expect(result.isSuccess, isTrue);
+      expect(result.valueOrNull, isNull);
+    });
+  });
+
+  group('updateZone', () {
+    test('persiste los campos modificados', () async {
+      final created = (await repo.createZone(sampleZone())).valueOrNull!;
+      final updated = created.copyWith(name: 'Casa Nueva', radiusMeters: 200);
+
+      final result = await repo.updateZone(updated);
+
+      expect(result.isSuccess, isTrue);
+      final fetched = (await repo.getZone(circleId, created.id)).valueOrNull!;
+      expect(fetched.name, 'Casa Nueva');
+      expect(fetched.radiusMeters, 200);
+    });
+  });
+
+  group('deleteZone', () {
+    test('elimina la zona', () async {
+      final created = (await repo.createZone(sampleZone())).valueOrNull!;
+
+      final result = await repo.deleteZone(circleId, created.id);
+
+      expect(result.isSuccess, isTrue);
+      expect((await repo.getZone(circleId, created.id)).valueOrNull, isNull);
+    });
+  });
+
+  group('watchCircleZones', () {
+    test('emite las zonas actuales del círculo', () async {
+      await repo.createZone(sampleZone());
+      final zones = await repo.watchCircleZones(circleId).first;
+      expect(zones.length, 1);
+      expect(zones.first.name, 'Casa');
+    });
+  });
+}

--- a/test/contexts/presence/infrastructure/firestore_presence_publisher_test.dart
+++ b/test/contexts/presence/infrastructure/firestore_presence_publisher_test.dart
@@ -1,24 +1,69 @@
-// TODO(sem2-day4): estos tests requieren `fake_cloud_firestore` en dev_dependencies.
-// Agregar a pubspec.yaml antes de activar:
-//
-//   dev_dependencies:
-//     fake_cloud_firestore: ^3.0.4   # verificar última versión compatible
-//
-// Una vez agregado, descomentar los tests y remover el @Skip.
-//
-// Escenarios a cubrir:
-//   1. Normal state → batch escribe en circles/{id}/memberStatus/{uid}
-//      y en circles/{id}/statusEvents/ sin campo 'coordinates'.
-//   2. SOSActive state → batch incluye 'coordinates' en memberStatus y statusEvents.
-
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nunakin_app/contexts/presence/domain/presence_state.dart';
+import 'package:nunakin_app/contexts/presence/infrastructure/firestore_presence_publisher.dart';
 
 void main() {
-  group('FirestorePresencePublisher', () {
-    test(
-      'pendiente: requiere fake_cloud_firestore en dev_dependencies',
-      () {},
-      skip: 'Agregar fake_cloud_firestore a pubspec.yaml para activar estos tests',
+  late FakeFirebaseFirestore firestore;
+  late FirestorePresencePublisher publisher;
+
+  const circleId = 'circle1';
+  const userId = 'user1';
+
+  setUp(() async {
+    firestore = FakeFirebaseFirestore();
+    publisher = FirestorePresencePublisher(firestore);
+    // batch.update requiere que el documento del círculo ya exista.
+    await firestore.collection('circles').doc(circleId).set({
+      'members': [userId],
+    });
+  });
+
+  test('Normal → memberStatus + statusEvents sin coordinates', () async {
+    final result = await publisher.publish(
+      state: const Normal(currentId: 'busy'),
+      userId: userId,
+      circleId: circleId,
     );
+
+    expect(result.isSuccess, isTrue);
+
+    final circle = await firestore.collection('circles').doc(circleId).get();
+    final memberStatus =
+        (circle.data()!['memberStatus'] as Map)[userId] as Map<String, dynamic>;
+    expect(memberStatus['statusType'], 'busy');
+    expect(memberStatus.containsKey('coordinates'), isFalse);
+
+    final events = await firestore
+        .collection('circles')
+        .doc(circleId)
+        .collection('statusEvents')
+        .get();
+    expect(events.docs.length, 1);
+    expect(events.docs.first.data().containsKey('coordinates'), isFalse);
+  });
+
+  test('SOSActive → coordinates presentes en memberStatus y statusEvents', () async {
+    final result = await publisher.publish(
+      state: const SOSActive(previousId: 'fine', latitude: -12.05, longitude: -77.04),
+      userId: userId,
+      circleId: circleId,
+    );
+
+    expect(result.isSuccess, isTrue);
+
+    final circle = await firestore.collection('circles').doc(circleId).get();
+    final memberStatus =
+        (circle.data()!['memberStatus'] as Map)[userId] as Map<String, dynamic>;
+    expect(memberStatus['coordinates'],
+        {'latitude': -12.05, 'longitude': -77.04});
+
+    final events = await firestore
+        .collection('circles')
+        .doc(circleId)
+        .collection('statusEvents')
+        .get();
+    expect(events.docs.first.data()['coordinates'],
+        {'latitude': -12.05, 'longitude': -77.04});
   });
 }


### PR DESCRIPTION
## Semana 8 — Entregable 1: `ZoneRepository`

Primer entregable del BC de Geofencing. Extrae el **CRUD Firestore puro** de [zone_service.dart](lib/features/geofencing/services/zone_service.dart) a un port + impl, siguiendo el patrón canónico de `PresenceRepository` (Sem 2): `Result<T>`, `application/ports/` + `infrastructure/`.

### Cambios
- **`ZoneRepository`** (port): `getCircleZones`, `getZone`, `watchCircleZones`, `createZone`, `updateZone`, `deleteZone`
- **`FirestoreZoneRepository`** (impl) + registro en DI ([geofencing_module.dart](lib/app/di/modules/geofencing_module.dart))
- **Dependency:** `fake_cloud_firestore: ^3.1.0` (dev) — aprobada (§7), sin conflictos
- **Tests:** 9 del repo (CRUD con `FakeFirebaseFirestore`) + 2 reactivados de `FirestorePresencePublisher` (estaban skip por falta de la lib). **11 verde.**

### Decisión arquitectónica (aprobada)
Repo = **persistencia pura**. Las validaciones de negocio de `zone_service` (límite de 10, nombre único, permisos, reset `memberStatus` post-delete, `syncEmojisToNativeCache`) **NO entran al repo** — van a use cases en E2/E3.

### Aditivo — no rompe nada
No se migran los 3 callers (`geofencing_service`, `zone_form`, `zones_page`) ni se toca `zone_service.dart`. Eso es el Entregable 2.

### Verificación
- `flutter analyze` (código + tests): **0 issues**
- `flutter test` (ambos archivos): **11/11 PASS**

### Test Plan
Tests unitarios del repo en verde. Al ser aditivo (sin tocar callers ni flujo real), no requiere verificación en device.

### Próximo (Sem 8 E2/E3)
Use cases que orquestan validaciones → migrar callers → `zone_service` a adapter/eliminar. Luego `ApplyGeofenceStatus` + `DomainEventBus` (cierre MS5.03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)