### PR TITLE
feat(geofencing): custom zones as blocked buttons in both modals

### DIFF
--- a/docs/dev/REGLAS_NEGOCIO.md
+++ b/docs/dev/REGLAS_NEGOCIO.md
@@ -279,9 +279,17 @@ Los estados cuyo `id` coincide con el tipo de zona configurada aparecen **dimmed
 | `university` → 🎓 | `university` bloqueado | Entrada: `studying` 📚 · Salida: `fine` 🙂 |
 | `work` → 💼 | `work` bloqueado | Entrada: `busy` 🔴 · Salida: `fine` 🙂 |
 
-> Zonas `custom` (📍) no bloquean ningún estado. En entrada asignan `fine` con emoji `📍`.
+> Zonas `custom` (📍) no bloquean ningún estado **base** (Bien, Ocupado, etc.). En entrada asignan `fine` con emoji `📍`. **Sí aparecen como su propio botón bloqueado** (📍 + nombre de la zona) en ambos modales de selección — ver §7.3.
 
 El tap sobre un estado bloqueado muestra el modal **"Acción no permitida"** explicando que ese estado lo maneja el geofencing automáticamente.
+
+### 7.3 Zonas personalizadas (📍) en el selector
+
+Cada zona `custom` configurada aparece en **ambos modales** (Círculo y Modo Silencio) como un botón propio con emoji 📍 y el nombre de la zona, en estado **bloqueado/dimmed** — igual tratamiento que las predefinidas configuradas. El tap muestra el modal "Acción no permitida".
+
+- **Identificador interno:** `zone_<zoneId>` (pseudo-estado, no es un `StatusType` real). No colisiona con estados base ni emojis personalizados del círculo.
+- **A diferencia de las predefinidas**, una zona custom no bloquea un estado base existente: introduce su **propio** botón bloqueado.
+- Al eliminar la zona custom, su botón desaparece de ambos modales (el cache se re-sincroniza).
 
 > **Bug conocido:** `ZoneType.work` usa emoji 💼 pero `StatusType` con `id: 'work'` muestra 🏢. Hay mismatch entre `zone.type.emoji` y el `StatusType` correspondiente.
 
@@ -386,7 +394,7 @@ Cuando el Creador elimina una zona de tipo `custom`:
 | Tipo de zona | Estado miembro en zona | Selector |
 |--------------|----------------------|----------|
 | Predefinida (🏠🏫🎓🏢) | Reset a `fine` (equivalente a salida) | Botón se desbloquea |
-| Personalizada (📍) | Persiste, sin cambio | Sin cambio (nunca estuvo bloqueado) |
+| Personalizada (📍) | Persiste, sin cambio | Su botón 📍 desaparece del selector |
 
 ---
 

--- a/lib/core/services/emoji_cache_service.dart
+++ b/lib/core/services/emoji_cache_service.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'emoji_service.dart';
+import '../models/user_status.dart';
 import 'package:flutter/foundation.dart';
 
 /// Servicio para sincronizar emojis de Firebase a cache nativo (SharedPreferences)
@@ -39,6 +40,20 @@ class EmojiCacheService {
 
             // Combinar predefinidos + personalizados
             allEmojis = [...predefinedEmojis, ...customEmojis];
+
+            // Zonas custom (📍) → ítems sintéticos del grid (id 'zone_<docId>'),
+            // para que el modal nativo las muestre igual que el modal del Círculo.
+            final zonesSnap = await FirebaseFirestore.instance
+                .collection('circles').doc(circleId).collection('zones').get();
+            for (final doc in zonesSnap.docs) {
+              if (doc.data()['type'] == 'custom') {
+                final name = doc.data()['name'] as String? ?? 'Zona';
+                allEmojis.add(StatusType(
+                  id: 'zone_${doc.id}', emoji: '📍', label: name, shortLabel: name,
+                  category: 'custom', order: 999, isPredefined: false, canDelete: false,
+                ));
+              }
+            }
             debugPrint(
                 '[EmojiCacheService] 📦 Cargados ${predefinedEmojis.length} predefinidos + ${customEmojis.length} personalizados');
           } else {
@@ -93,8 +108,12 @@ class EmojiCacheService {
 
         for (final doc in zonesSnapshot.docs) {
           final type = doc.data()['type'] as String?;
-          if (type != null && ['home', 'school', 'university', 'work'].contains(type)) {
+          if (type == null) continue;
+          if (['home', 'school', 'university', 'work'].contains(type)) {
             configuredTypes.add(type);
+          } else if (type == 'custom') {
+            // Zona custom → su id sintético bloquea el botón 'zone_<docId>'
+            configuredTypes.add('zone_${doc.id}');
           }
         }
       }

--- a/lib/core/widgets/emoji_modal.dart
+++ b/lib/core/widgets/emoji_modal.dart
@@ -383,18 +383,34 @@ class _StatusSelectorOverlayLoaderState
           .get()
           .timeout(const Duration(seconds: 5));
 
-      final configuredTypes = zonesSnapshot.docs
-          .where((doc) {
-            final type = doc.data()['type'] as String?;
-            return type != null &&
-                ['home', 'school', 'university', 'work'].contains(type);
-          })
-          .map((doc) => doc.data()['type'] as String)
-          .toSet();
+      // Zonas predefinidas → bloquean su StatusType base (home/school/…).
+      // Zonas custom (📍) → botón sintético propio, bloqueado (id 'zone_<docId>').
+      final configuredTypes = <String>{};
+      final customZoneStatuses = <StatusType>[];
+      for (final doc in zonesSnapshot.docs) {
+        final type = doc.data()['type'] as String?;
+        if (type == null) continue;
+        if (['home', 'school', 'university', 'work'].contains(type)) {
+          configuredTypes.add(type);
+        } else if (type == 'custom') {
+          final name = doc.data()['name'] as String? ?? 'Zona';
+          customZoneStatuses.add(StatusType(
+            id: 'zone_${doc.id}',
+            emoji: '📍',
+            label: name,
+            shortLabel: name,
+            category: 'custom',
+            order: 999,
+            isPredefined: false,
+            canDelete: false,
+          ));
+          configuredTypes.add('zone_${doc.id}');
+        }
+      }
 
       if (mounted) {
         setState(() {
-          _available = allEmojis;
+          _available = [...allEmojis, ...customZoneStatuses];
           _blockedZoneTypes = configuredTypes;
         });
       }


### PR DESCRIPTION
## Zonas custom (📍) en ambos modales — Opción A (bloqueadas)

Una zona **personalizada** configurada ahora aparece como su **propio botón bloqueado/dimmed** (📍 + nombre) en el modal del **Círculo** y en el de **Modo Silencio**, igual que las predefinidas configuradas. Tap → "Acción no permitida".

### Diseño — id sintético
Cada zona custom → pseudo-`StatusType` `id: 'zone_<zoneId>'`, emoji 📍, label = nombre. Prefijo `zone_` evita colisión con estados base e ids de emojis personalizados.

### Cambios
| Archivo | Qué |
|---------|-----|
| `emoji_modal.dart` | modal Círculo: agrega zonas custom a `_available` + sus ids a `_blockedZoneTypes` |
| `emoji_cache_service.dart` | modal Modo Silencio: zonas custom al cache `predefined_emojis` + sus ids a `configured_zone_types` |
| `EmojiDialogActivity.kt` | **sin cambios** — ids desconocidos ya van a la sección custom del grid y se bloquean por `configured_zone_types` |
| `status_selector_overlay.dart` | **sin cambios** — ya bloquea por `blockedZoneTypes.contains(status.id)` y muestra el diálogo |
| `REGLAS_NEGOCIO.md` | §7.2 matizada + §7.3 nueva + §9.4 actualizada |

### Verificación
- `flutter analyze` (2 archivos): **0 issues**. Sin Kotlin → sin build nativo.

### Test Plan — ⚠️ smoke en device
1. Crear zona custom → aparece bloqueada (📍 + nombre) en modal **Círculo**
2. Igual en modal **Modo Silencio** (notificación)
3. Tap → "Acción no permitida"
4. Predefinidas configuradas siguen bloqueándose igual
5. Eliminar zona custom → su botón desaparece de ambos modales

### Nota
`syncEmojisToNativeCache` y `_syncZoneTypesToNativeCache` leen `zones` por separado (2 lecturas). Optimizable a una sola lectura compartida — bajo impacto, anotar como limpieza menor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)