### PR TITLE
feat: gate SOS on emailVerified (Sem 9 PA95C item A)

### DIFF
--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -26,6 +26,7 @@ class StatusService {
   static bool tokenLikelyInvalid = false;
 
   static const String _zoneManualSelectionNotAllowedError = 'zone_manual_selection_not_allowed';
+  static const String _emailNotVerifiedError = 'email_not_verified';
   static const Set<String> _blockedZoneStatusIds = {
     StatusIds.home,
     StatusIds.school,
@@ -196,6 +197,14 @@ class StatusService {
           (previousWasAutoUpdated || previousManualOverride) && !wasInZone && newStatus.id != StatusIds.fine;
 
       log('[StatusService] 📍 Usuario estaba en zona: $wasInZone${wasInZone ? ' ($previousZoneName)' : ''}');
+
+      // Sem 9 PA95C item A: SOS requiere email verificado (bloqueo de seguridad).
+      // Se usa el flag cacheado de FirebaseAuth (sin reload()) para no agregar
+      // una dependencia de red a un camino crítico.
+      if (newStatus.id == StatusIds.sos && !user.emailVerified) {
+        log('[StatusService] 🚫 SOS bloqueado: email no verificado');
+        return StatusUpdateResult.error(_emailNotVerifiedError);
+      }
 
       // Point 16: Obtener ubicación GPS si es estado SOS
       Coordinates? coordinates;

--- a/lib/core/widgets/emoji_modal.dart
+++ b/lib/core/widgets/emoji_modal.dart
@@ -433,7 +433,21 @@ class _StatusSelectorOverlayLoaderState
 
   void _onSosTriggered() {
     final sos = StatusType.fallbackPredefined.firstWhere((s) => s.id == 'sos');
-    StatusService.updateUserStatus(sos);
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    StatusService.updateUserStatus(sos).then((result) {
+      if (!result.isSuccess) {
+        scaffoldMessenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              result.errorMessage == 'email_not_verified'
+                  ? '🚫 Verifica tu correo para poder usar SOS'
+                  : '❌ Error al enviar SOS: ${result.errorMessage ?? 'desconocido'}',
+            ),
+            backgroundColor: NkColors.danger,
+          ),
+        );
+      }
+    });
   }
 
   @override

--- a/lib/widgets/home_screen_widget.dart
+++ b/lib/widgets/home_screen_widget.dart
@@ -116,8 +116,12 @@ class _HomeScreenWidgetState extends ConsumerState<HomeScreenWidget> with Ticker
 
     try {
       // Usar StatusService con el StatusType correcto
-      await StatusService.updateUserStatus(statusType);
-      await _showSuccessFeedback(statusType.emoji);
+      final result = await StatusService.updateUserStatus(statusType);
+      if (result.isSuccess) {
+        await _showSuccessFeedback(statusType.emoji);
+      } else {
+        await _showErrorFeedback();
+      }
     } catch (e) {
       await _showErrorFeedback();
     } finally {


### PR DESCRIPTION
## Summary
- `status_service.dart`: agrega gate central en `updateUserStatus` — si `newStatus.id == StatusIds.sos` y `!user.emailVerified`, retorna error `email_not_verified` antes de tocar GPS/Firestore. Cubre las 3 superficies reales que disparan SOS (modal in-app, home screen widget, notificacion BN) con un solo cambio.
- `home_screen_widget.dart`: corrige bug latente — el try/catch asumia exito por ausencia de excepcion, pero `updateUserStatus` retorna un Result en vez de lanzar. Ahora chequea `result.isSuccess`.
- `emoji_modal.dart`: `_onSosTriggered()` era fire-and-forget total (cero manejo de resultado). Agrega SnackBar visible cuando el SOS queda bloqueado.
- Decision de producto confirmada: solo mensaje de error por ahora, sin boton de reenvio de verificacion (no existe ese flujo aun) — queda como deuda tecnica separada.

Sin reload() de Firebase Auth: se usa el flag cacheado para no agregar una dependencia de red a un camino de seguridad critico.

## Test plan
- [x] `flutter analyze` limpio en los 3 archivos
- [ ] Device test: SOS desde modal in-app con cuenta NO verificada -> bloqueado, SnackBar visible
- [ ] Device test: SOS desde modal in-app con cuenta verificada -> funciona normal
- [ ] Device test: SOS desde home screen widget con cuenta NO verificada -> feedback de error (no "exito")
- [ ] Device test: SOS desde notificacion BN con cuenta NO verificada -> no se escribe el estado (verificar log)