### PR TITLE
fix: gate sensitive logs behind kDebugMode (Sem 9 PA95C item)

### DIFF
--- a/lib/contexts/identity/infrastructure/repositories/auth_repository_impl.dart
+++ b/lib/contexts/identity/infrastructure/repositories/auth_repository_impl.dart
@@ -1,6 +1,7 @@
 // lib/features/auth/data/repositories/auth_repository_impl.dart
 
 import 'dart:developer'; // Añadido para logging
+import 'package:flutter/foundation.dart';
 import 'package:dartz/dartz.dart';
 import '../../../../core/error/exceptions.dart';
 import '../../../../core/error/failures.dart';
@@ -36,9 +37,13 @@ class AuthRepositoryImpl implements AuthRepository {
           password: password,
           nickname: nickname,
         );
-        log('[AuthRepository] HU: remoteDataSource devolvió el usuario con UID: ${remoteUser.uid}, email: ${remoteUser.email}, nickname: ${remoteUser.nickname}');
+        if (kDebugMode) {
+          log('[AuthRepository] HU: remoteDataSource devolvió el usuario con UID: ${remoteUser.uid}, email: ${remoteUser.email}, nickname: ${remoteUser.nickname}');
+        }
         await localDataSource.cacheUser(remoteUser);
-        log('[AuthRepository] HU: Usuario cacheado con UID: ${remoteUser.uid}');
+        if (kDebugMode) {
+          log('[AuthRepository] HU: Usuario cacheado con UID: ${remoteUser.uid}');
+        }
         return Right(remoteUser);
       } on ServerException catch (e) {
         log('[AuthRepository] HU: ServerException atrapada: ${e.message}');
@@ -57,10 +62,14 @@ class AuthRepositoryImpl implements AuthRepository {
     if (await networkInfo.isConnected) {
       try {
         final remoteUser = await remoteDataSource.getCurrentUser();
-        log('[AuthRepository] HU: Usuario obtenido de remoto: ${remoteUser?.uid}, email: ${remoteUser?.email}, nickname: ${remoteUser?.nickname}');
+        if (kDebugMode) {
+          log('[AuthRepository] HU: Usuario obtenido de remoto: ${remoteUser?.uid}, email: ${remoteUser?.email}, nickname: ${remoteUser?.nickname}');
+        }
         if (remoteUser != null) {
           await localDataSource.cacheUser(remoteUser);
-          log('[AuthRepository] HU: Usuario cacheado con UID: ${remoteUser.uid}');
+          if (kDebugMode) {
+            log('[AuthRepository] HU: Usuario cacheado con UID: ${remoteUser.uid}');
+          }
           return Right(remoteUser);
         } else {
           log('[AuthRepository] HU: No hay usuario autenticado en remoto.');
@@ -72,7 +81,9 @@ class AuthRepositoryImpl implements AuthRepository {
     } else {
       try {
         final localUser = await localDataSource.getLastUser();
-        log('[AuthRepository] HU: Usuario obtenido del caché (sin conexión): ${localUser?.uid}, email: ${localUser?.email}, nickname: ${localUser?.nickname}');
+        if (kDebugMode) {
+          log('[AuthRepository] HU: Usuario obtenido del caché (sin conexión): ${localUser?.uid}, email: ${localUser?.email}, nickname: ${localUser?.nickname}');
+        }
         return Right(localUser);
       } on CacheException {
         return Left(NetworkFailure(message: 'No internet connection and no cached user.'));

--- a/lib/contexts/identity/presentation/pages/auth_final_page.dart
+++ b/lib/contexts/identity/presentation/pages/auth_final_page.dart
@@ -2,6 +2,7 @@
 
 import 'dart:developer';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../../../../../app/theme/design_tokens.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -228,8 +229,10 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
 
   // PROCESO ACTUAL: Solo Firebase Auth (comportamiento estándar)
   Future<bool> _sendPasswordResetEmail(String email) async {
-    log('[PROCESO AUTH] Iniciando envío de correo de recuperación para email: $email',
-        name: 'PasswordReset');
+    if (kDebugMode) {
+      log('[PROCESO AUTH] Iniciando envío de correo de recuperación para email: $email',
+          name: 'PasswordReset');
+    }
     log('[PROCESO AUTH] ⚠️ NOTA: Firebase Auth no valida existencia por seguridad',
         name: 'PasswordReset');
 
@@ -350,8 +353,10 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
                         onPressed: () async {
                           final email = resetEmailController.text.trim();
 
-                          log('\n[VALIDACIÓN] Email ingresado: "$email"',
-                              name: 'PasswordReset');
+                          if (kDebugMode) {
+                            log('\n[VALIDACIÓN] Email ingresado: "$email"',
+                                name: 'PasswordReset');
+                          }
 
                           // CASO 3: Validación de campo vacío
                           if (email.isEmpty) {
@@ -388,8 +393,10 @@ class _AuthFinalPageState extends State<AuthFinalPage> {
                               name: 'PasswordReset');
                           log('[TREN EJECUCIÓN] Iniciando recuperación de contraseña',
                               name: 'PasswordReset');
-                          log('[TREN EJECUCIÓN] Email a procesar: $email',
-                              name: 'PasswordReset');
+                          if (kDebugMode) {
+                            log('[TREN EJECUCIÓN] Email a procesar: $email',
+                                name: 'PasswordReset');
+                          }
                           log('[TREN EJECUCIÓN] Usando solo Firebase Auth (sin Firestore)',
                               name: 'PasswordReset');
                           log('[TREN EJECUCIÓN] =================================\n',

--- a/lib/contexts/identity/presentation/provider/auth_provider.dart
+++ b/lib/contexts/identity/presentation/provider/auth_provider.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 import 'dart:developer';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase;
 
@@ -29,8 +30,10 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   void _onAuthStateChanged(firebase.User? firebaseUser) async {
-    log("[AuthNotifier] [STREAM] Stream reported user: ${firebaseUser?.uid}");
-    log("[AuthNotifier] [STREAM] _onAuthStateChanged: firebaseUser = ${firebaseUser?.uid}, email = ${firebaseUser?.email}");
+    if (kDebugMode) {
+      log("[AuthNotifier] [STREAM] Stream reported user: ${firebaseUser?.uid}");
+      log("[AuthNotifier] [STREAM] _onAuthStateChanged: firebaseUser = ${firebaseUser?.uid}, email = ${firebaseUser?.email}");
+    }
     try {
       if (firebaseUser != null) {
         log("[AuthNotifier] [STREAM] FirebaseUser existe. Llamando a getCurrentUser...");
@@ -50,7 +53,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
               log("[AuthNotifier] ⚠️ NativeState sync error (esperado en iOS): $e");
             });
 
-            log("[AuthNotifier] [STREAM] User details fetched successfully. State -> Authenticated. user.nickname: ${user.nickname}, user.email: ${user.email}");
+            if (kDebugMode) {
+              log("[AuthNotifier] [STREAM] User details fetched successfully. State -> Authenticated. user.nickname: ${user.nickname}, user.email: ${user.email}");
+            }
             state = Authenticated(user);
           } else {
             log("[AuthNotifier] [STREAM] AuthService returned a null user. State -> Unauthenticated");
@@ -109,7 +114,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> signInOrRegister(String email, String password,
       {String nickname = ''}) async {
-    log("[AuthNotifier] [ACTION] Triggering signInOrRegister for email: $email, nickname: $nickname");
+    if (kDebugMode) {
+      log("[AuthNotifier] [ACTION] Triggering signInOrRegister for email: $email, nickname: $nickname");
+    }
     state = AuthLoading();
 
     // 🔥 SIMPLIFICADO: try/catch en vez de Either/fold
@@ -136,7 +143,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
             log("[AuthNotifier] ⚠️ NativeState sync error (esperado en iOS): $e");
           });
 
-          log("[AuthNotifier] [ACTION] Usuario recargado tras login/registro. State -> Authenticated. Nickname: ${freshUser.nickname}, Email: ${freshUser.email}");
+          if (kDebugMode) {
+            log("[AuthNotifier] [ACTION] Usuario recargado tras login/registro. State -> Authenticated. Nickname: ${freshUser.nickname}, Email: ${freshUser.email}");
+          }
           state = Authenticated(freshUser);
         } else {
           log("[AuthNotifier] [ACTION] Usuario recargado es null tras login/registro. State -> Unauthenticated");
@@ -148,7 +157,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
       }
     } catch (e) {
       if (nickname.isNotEmpty) {
-        log("[AuthNotifier] [ACTION] Registro fallido para $email. Borrando usuario Auth temporal si existe...");
+        if (kDebugMode) {
+          log("[AuthNotifier] [ACTION] Registro fallido para $email. Borrando usuario Auth temporal si existe...");
+        }
         try {
           await _firebaseAuth.currentUser?.delete();
         } catch (deleteError) {

--- a/lib/core/services/gps_service.dart
+++ b/lib/core/services/gps_service.dart
@@ -1,5 +1,6 @@
 import 'package:geolocator/geolocator.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
+import 'package:flutter/foundation.dart';
 import 'dart:developer';
 
 /// Servicio para manejo de GPS y ubicación
@@ -47,7 +48,9 @@ class GPSService {
         longitude: position.longitude,
       );
       
-      log('[GPSService] ✅ Ubicación obtenida: ${coordinates.latitude}, ${coordinates.longitude}');
+      if (kDebugMode) {
+        log('[GPSService] ✅ Ubicación obtenida: ${coordinates.latitude}, ${coordinates.longitude}');
+      }
       return coordinates;
       
     } catch (e) {

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nunakin_app/core/models/user_status.dart';
 import 'package:nunakin_app/contexts/presence/application/ports/presence_repository.dart';
@@ -212,7 +213,9 @@ class StatusService {
         log('[StatusService] 🆘 Estado SOS detectado - obteniendo ubicación GPS...');
         coordinates = await GPSService.getCurrentLocation();
         if (coordinates != null) {
-          log('[StatusService] 📍 Ubicación GPS obtenida para SOS: ${coordinates.latitude}, ${coordinates.longitude}');
+          if (kDebugMode) {
+            log('[StatusService] 📍 Ubicación GPS obtenida para SOS: ${coordinates.latitude}, ${coordinates.longitude}');
+          }
         } else {
           log('[StatusService] ⚠️ No se pudo obtener ubicación GPS para SOS');
         }

--- a/lib/features/circle/presentation/widgets/member_data_repository.dart
+++ b/lib/features/circle/presentation/widgets/member_data_repository.dart
@@ -85,7 +85,9 @@ class MemberDataRepository {
         }
         return MapEntry(uid, '...');
       } catch (e) {
-        debugPrint('[MemberDataRepository] Error fetching nickname for $uid: $e');
+        if (kDebugMode) {
+          debugPrint('[MemberDataRepository] Error fetching nickname for $uid: $e');
+        }
         return MapEntry(uid, '...');
       }
     });

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../app/theme/design_tokens.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -133,7 +134,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> with SingleTickerPr
               ? displayName
               : fbUser.email?.split('@')[0];
           _userNameController.text = _currentUserName ?? '';
-          debugPrint('[SettingsPage] ⚡ Usuario cargado desde FirebaseAuth fallback: email=[$_userEmail]');
+          if (kDebugMode) {
+            debugPrint('[SettingsPage] ⚡ Usuario cargado desde FirebaseAuth fallback: email=[$_userEmail]');
+          }
         }
       }
     } catch (e) {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,6 +1,7 @@
 // lib/services/auth_service.dart
 
 import 'dart:developer';
+import 'package:flutter/foundation.dart';
 import 'package:firebase_auth/firebase_auth.dart' as firebase;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -22,7 +23,9 @@ class AuthService {
         return null;
       }
 
-      log('[AuthService] Obteniendo datos de Firestore para: ${firebaseUser.uid}');
+      if (kDebugMode) {
+        log('[AuthService] Obteniendo datos de Firestore para: ${firebaseUser.uid}');
+      }
       DocumentSnapshot<Map<String, dynamic>> doc;
       try {
         doc = await _firestore
@@ -37,7 +40,9 @@ class AuthService {
       }
 
       if (!doc.exists) {
-        log('[AuthService] ⚠️ Usuario no existe en Firestore: ${firebaseUser.uid}');
+        if (kDebugMode) {
+          log('[AuthService] ⚠️ Usuario no existe en Firestore: ${firebaseUser.uid}');
+        }
         return null;
       }
 
@@ -64,7 +69,9 @@ class AuthService {
     String nickname = '',
   }) async {
     try {
-      log('[AuthService] Intentando signInOrRegister para: $email');
+      if (kDebugMode) {
+        log('[AuthService] Intentando signInOrRegister para: $email');
+      }
 
       // Intentar login primero
       firebase.UserCredential? userCredential;
@@ -73,7 +80,9 @@ class AuthService {
           email: email,
           password: password,
         );
-        log('[AuthService] ✅ Login exitoso para: $email');
+        if (kDebugMode) {
+          log('[AuthService] ✅ Login exitoso para: $email');
+        }
       } on firebase.FirebaseAuthException catch (e) {
         if (e.code == 'user-not-found' || e.code == 'wrong-password') {
           // Usuario no existe, registrar
@@ -82,7 +91,9 @@ class AuthService {
             email: email,
             password: password,
           );
-          log('[AuthService] ✅ Registro exitoso para: $email');
+          if (kDebugMode) {
+            log('[AuthService] ✅ Registro exitoso para: $email');
+          }
         } else {
           throw Exception('Error de autenticación: ${e.message}');
         }

--- a/lib/services/circle_service.dart
+++ b/lib/services/circle_service.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 import 'dart:developer';
+import 'package:flutter/foundation.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
@@ -637,7 +638,9 @@ class CircleService {
     if (user == null) throw Exception('Usuario no autenticado');
 
     final uid = user.uid;
-    log('[CircleService] 🗑️ Iniciando deleteAccount() para uid: $uid');
+    if (kDebugMode) {
+      log('[CircleService] 🗑️ Iniciando deleteAccount() para uid: $uid');
+    }
 
     // 1. Manejar círculo según rol (creador vs miembro común)
     final userDoc = await _firestore.collection('users').doc(uid).get();


### PR DESCRIPTION
## Summary
- Auditoria completa de logs con datos sensibles (CLAUDE.md #15). Conteo inicial estimado (17/4 archivos) resulto desactualizado/impreciso; el conteo real tras 3 pasadas de grep con patrones ampliados fue **18 lineas en 9 archivos** exponiendo email, UID o coordenadas GPS sin condicionar.
- Cada log()/debugPrint() sensible ahora esta envuelto en `if (kDebugMode) { ... }` — no se tocaron logs sin datos sensibles (validaciones booleanas, mensajes genericos).
- Se descarto un caso: `$freshUser` (auth_provider.dart) interpola el objeto User completo, pero no tiene toString() propio ni EquatableConfig.stringify=true en el proyecto, asi que el toString() default de Dart no expone las props. No requiere fix.

Sin cambios de logica de negocio — solo condiciona la salida de logs a modo debug.

## Test plan
- [x] `flutter analyze` limpio en los 9 archivos (solo lints preexistentes no relacionados: avoid_print, deprecated withOpacity, use_build_context_synchronously)
- [x] Cambio mecanico sin logica de negocio nueva — no requiere device-test adicional