### PR TITLE
fix: sync green border indicator after BN status pick

### DIFF
--- a/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
+++ b/android/app/src/main/kotlin/com/datainfers/zync/StatusUpdateWorker.kt
@@ -156,12 +156,44 @@ class StatusUpdateWorker(
             //   o hace bail-out por timestamp mismatch, no se setea (Flutter ya
             //   habrá procesado vía canal e invocado el suppress in-memory).
             // ════════════════════════════════════════════════════════════
-            applicationContext
+            val flutterPrefs = applicationContext
                 .getSharedPreferences("FlutterSharedPreferences", Context.MODE_PRIVATE)
-                .edit()
+
+            // ════════════════════════════════════════════════════════════
+            // [FIX] Borde verde desincronizado tras pick de BN
+            // Fecha: 2026-08-02
+            // PROBLEMA: este Worker (único encolador, ver EmojiDialogActivity.kt;
+            //   la notificación persistente que lo dispara solo existe con Modo
+            //   Silencio activo) solo escribía current_status_id. El indicador de
+            //   estado activo (EmojiDialogActivity.kt / in_circle_view.dart)
+            //   resuelve con prioridad pre_silent_status_id mientras MS está
+            //   activo — nunca se actualizaba, dejando el borde verde congelado
+            //   en la selección previa a pesar de que Firestore ya reflejaba la
+            //   nueva.
+            // SOLUCIÓN: dado que este Worker solo corre con MS activo, actualizar
+            //   pre_silent_status_id en cada pick (siempre selección deliberada).
+            //   TAMBIÉN actualizar manual_status_id, aunque en el momento de
+            //   escribirla MS siga activo y por tanto no gobierne el indicador
+            //   todavía: MainActivity.onCreate() autodesactiva MS al reabrir la
+            //   app (Regla 1) y borra pre_silent_status_id/is_silent_mode_active
+            //   SIN sincronizar manual_status_id (a diferencia de ExitSilentMode,
+            //   que sí lo hace). Si luego el usuario reactiva MS sin elegir un
+            //   estado nuevo antes, SilentFunctionalityCoordinator siembra el
+            //   próximo pre_silent_status_id desde manual_status_id — si quedó
+            //   viejo, reintroduce este mismo bug por esa vía.
+            // ════════════════════════════════════════════════════════════
+            val isSilentModeActive = flutterPrefs.getBoolean(
+                SharedKeys.flutter(SharedKeys.IS_SILENT_MODE_ACTIVE), false
+            )
+            val editor = flutterPrefs.edit()
                 .putBoolean(SharedKeys.flutter(SharedKeys.SUPPRESS_NEXT_GEOFENCE_CHECK), true)
                 .putString(SharedKeys.flutter(SharedKeys.CURRENT_STATUS_ID), statusType)
-                .apply()
+                .putString(SharedKeys.flutter(SharedKeys.MANUAL_STATUS_ID), statusType)
+            if (isSilentModeActive) {
+                editor.putString(SharedKeys.flutter(SharedKeys.PRE_SILENT_STATUS_ID), statusType)
+            }
+            editor.apply()
+            Log.d(TAG, "[DIAG-W6b] SharedPrefs actualizado — manual_status_id='$statusType' pre_silent_status_id=${if (isSilentModeActive) "'$statusType'" else "sin tocar (MS inactivo)"}")
 
             // Limpiar pending_status para que Flutter no lo reprocese al reabrir la app
             prefs.edit().clear().apply()

--- a/lib/core/services/status_service.dart
+++ b/lib/core/services/status_service.dart
@@ -368,6 +368,25 @@ class StatusService {
         // ════════════════════════════════════════════════════════════
         await prefs.setString(NativeSharedKeys.manualStatusId, newStatus.id);
         log('[StatusService] 💾 manual_status_id guardado: ${newStatus.id}');
+
+        // ════════════════════════════════════════════════════════════
+        // [FIX] Borde verde desincronizado tras selección con MS activo
+        // Fecha: 2026-08-02
+        // PROBLEMA: pre_silent_status_id es el snapshot que EmojiDialogActivity
+        //   e in_circle_view leen con prioridad cuando is_silent_mode_active es
+        //   true (ver SilentFunctionalityCoordinator). Se escribe una sola vez
+        //   al activar Modo Silencio y nunca se actualizaba ante una selección
+        //   posterior — el indicador quedaba congelado en el estado previo a MS
+        //   aunque Firestore y current_status_id ya reflejaran el nuevo.
+        // SOLUCIÓN: si Modo Silencio sigue activo, esta selección también es
+        //   deliberada — actualizar pre_silent_status_id en el mismo commit.
+        //   Simétrico al fix en StatusUpdateWorker.kt (camino con proceso muerto).
+        // ════════════════════════════════════════════════════════════
+        final isSilentModeActive = prefs.getBool(NativeSharedKeys.isSilentModeActive) ?? false;
+        if (isSilentModeActive) {
+          await prefs.setString(NativeSharedKeys.preSilentStatusId, newStatus.id);
+          log('[StatusService] 💾 pre_silent_status_id actualizado (MS activo): ${newStatus.id}');
+        }
       } catch (e) {
         log('[StatusService] ⚠️ Error guardando current_status_id: $e');
       }

--- a/lib/platform/persistence/native_keys.dart
+++ b/lib/platform/persistence/native_keys.dart
@@ -14,13 +14,25 @@ abstract final class NativeSharedKeys {
   /// StatusUpdateWorker.kt (Kotlin). Leído por: EmojiDialogActivity.kt.
   static const currentStatusId = 'current_status_id';
 
-  /// Último estado seleccionado manualmente. Solo escrito por StatusService.
+  /// Último estado seleccionado manualmente. Escrito por: StatusService (Dart)
+  /// y StatusUpdateWorker.kt (pick desde BN — fix 2026-08-02). Se escribe
+  /// incluso mientras MS está activo: MainActivity.onCreate() autodesactiva MS
+  /// al reabrir la app (Regla 1) sin sincronizar esta clave desde
+  /// pre_silent_status_id (a diferencia de ExitSilentMode, que sí lo hace) —
+  /// si quedara vieja, una reactivación posterior de MS sembraría
+  /// pre_silent_status_id con un valor incorrecto.
   /// Leído por: SilentCoordinator, InCircleView.
   static const manualStatusId = 'manual_status_id';
 
-  /// Snapshot del estado antes de entrar a Silent Mode.
-  /// Escrito por: SilentCoordinator. Leído por: InCircleView.
-  /// Eliminado por: MainActivity al desactivar Silent Mode.
+  /// Snapshot del estado activo mientras Silent Mode está encendido — no es
+  /// solo el estado previo a activar MS: se re-escribe ante cada selección
+  /// deliberada mientras MS sigue activo (fix 2026-08-02, borde verde
+  /// congelado en la BN). Escrito por: SilentCoordinator (al activar),
+  /// StatusService (Dart, selección con MS activo) y StatusUpdateWorker.kt
+  /// (pick desde BN, siempre con MS activo). Leído por: InCircleView,
+  /// EmojiDialogActivity.kt. Eliminado por: MainActivity al desactivar Silent
+  /// Mode — dos vías: ExitSilentMode (logout, sincroniza manualStatusId) y
+  /// MainActivity.onCreate() Regla 1 (reapertura de app, NO lo sincroniza).
   static const preSilentStatusId = 'pre_silent_status_id';
 
   /// Flag de Silent Mode activo (namespace Flutter).


### PR DESCRIPTION
## Summary
- Bug reportado: tras dejar la app en Modo Silencioso ~24h y elegir un estado desde la notificación persistente (BN), Firestore se actualizaba correctamente pero el indicador (borde verde) del modal quedaba congelado en la selección anterior a activar MS.
- Causa raíz: `StatusUpdateWorker.kt` (único encolador que dispara la BN — la notificación persistente solo existe con Modo Silencio activo) escribía Firestore + `current_status_id`, pero nunca `pre_silent_status_id`, que es la clave que gobierna el indicador mientras MS está activo (`EmojiDialogActivity.kt:126`, `in_circle_view.dart:243`).
- Fix: `StatusUpdateWorker.kt` ahora actualiza `manual_status_id` siempre y `pre_silent_status_id` cuando MS está activo. `status_service.dart` refleja lo mismo del lado Dart (selección in-app con MS activo).
- `manual_status_id` se escribe aunque en ese momento no gobierne el indicador (MS activo lo hace vía `pre_silent_status_id`): `MainActivity.onCreate()` autodesactiva MS al reabrir la app (Regla 1) sin resincronizar `manual_status_id` — dejarla vieja reintroduciría el bug en una reactivación posterior de MS sin selección manual de por medio.
- No dependía del tiempo transcurrido (las 24h fueron incidentales) — reproducible en segundos.

## Hallazgo relacionado, fuera de alcance de este PR
Durante la verificación se encontró un bug **distinto y preexistente**: el plugin `shared_preferences` de Flutter cachea valores en memoria desde `getInstance()`, y no los releé cuando Kotlin escribe directo al archivo sin pasar por el plugin — si el proceso Flutter no se reinicia entre medio, Dart puede leer un valor stale. Esto afecta un escenario compuesto (reapertura de app + reactivación de MS sin proceso muerto), no el bug original. Se registrará como ítem de deuda técnica separado para un PA95C dedicado — requiere auditar todos los call sites Dart que leen claves escritas por Kotlin, no solo el afectado aquí.

## Test plan
- [x] **Prueba 1** — MS activo, selección desde BN, verificado en device (SM A145M) con lectura directa de `SharedPreferences` (no solo observación visual): las 4 claves quedan sincronizadas. PASS.
- [x] **Prueba 3 (compuesta)** — reapertura de app (autodesactiva MS) → reactivar MS sin elegir estado nuevo → verificar borde en BN. FAIL, pero por la causa raíz distinta documentada arriba (caché Dart de `shared_preferences`), no por este fix — confirmado que la escritura nativa (`manual_status_id='driving'`) fue correcta vía `adb`, el problema es la lectura Dart posterior desde caché stale.

**Excepción CLAUDE.md §8 solicitada:** el Test Plan no está 100% en verde, pero el ítem que falla tiene causa raíz distinta y documentada, no es regresión de este cambio. El bug reportado originalmente (Prueba 1) está resuelto y verificado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)