### PR TITLE
fix: reload shared_preferences cache before reading Kotlin-written keys

### DIFF
--- a/lib/contexts/presence/infrastructure/shared_prefs_presence_repository.dart
+++ b/lib/contexts/presence/infrastructure/shared_prefs_presence_repository.dart
@@ -20,6 +20,18 @@ class SharedPrefsPresenceRepository implements PresenceRepository {
   @override
   Future<Result<PresenceState>> currentState() async {
     try {
+      // ════════════════════════════════════════════════════════════
+      // [FIX] DT-PREFS-STALE-CACHE — recargar antes de leer
+      // Fecha: 2026-08-02
+      // PROBLEMA: StatusUpdateWorker.kt (BN) y MainActivity.onCreate Regla 1
+      //   escriben/borran estas claves directo en el XML nativo mientras el
+      //   isolate Dart sigue vivo (motor pre-calentado en ZyncApplication).
+      //   El caché en memoria de shared_preferences no ve esas escrituras.
+      // SOLUCIÓN: reload() antes de leer — este repositorio se consulta
+      //   fuera del ciclo de resume de la app (EnterSilentMode, RaiseSOS),
+      //   donde no hay otro punto que ya haya refrescado el caché.
+      // ════════════════════════════════════════════════════════════
+      await _kv.reload();
       final isSilent = await _kv.getBool(NativeSharedKeys.isSilentModeActive) ?? false;
       if (isSilent) {
         final preSilentId = await _kv.getString(NativeSharedKeys.preSilentStatusId);

--- a/lib/core/services/silent_functionality_coordinator.dart
+++ b/lib/core/services/silent_functionality_coordinator.dart
@@ -151,7 +151,11 @@ class SilentFunctionalityCoordinator {
     //           cuando is_silent_mode_active == true.
     // ════════════════════════════════════════════════════════════
     try {
+      // [FIX] DT-PREFS-STALE-CACHE — reload() antes de leer manualId: el
+      // Worker (BN) pudo haberlo escrito directo al XML nativo mientras
+      // este isolate seguía vivo. Fecha: 2026-08-02.
       final prefs = await SharedPreferences.getInstance();
+      await prefs.reload();
       final manualId = prefs.getString(NativeSharedKeys.manualStatusId);
       if (manualId != null) {
         await prefs.setString(NativeSharedKeys.preSilentStatusId, manualId);

--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -40,7 +40,7 @@ class InCircleView extends ConsumerStatefulWidget {
   ConsumerState<InCircleView> createState() => _InCircleViewState();
 }
 
-class _InCircleViewState extends ConsumerState<InCircleView> {
+class _InCircleViewState extends ConsumerState<InCircleView> with WidgetsBindingObserver {
   final Map<String, Map<String, dynamic>> _memberDataCache = {};
   final Map<String, String> _memberNicknamesCache = {};
   // ════════════════════════════════════════════════════════════
@@ -82,6 +82,7 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _repo = MemberDataRepository(
       circleId: widget.circle.id,
       service: _circleService,
@@ -172,12 +173,32 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _repo.saveAll(_memberNicknamesCache, _memberDataCache);
     _circleListenerSubscription?.cancel();
     _customEmojisListener?.cancel();
     _joinRequestsSubscription?.cancel();
     _stopGeofencingMonitoring();
     super.dispose();
+  }
+
+  // ════════════════════════════════════════════════════════════
+  // [FIX] DT-PREFS-STALE-CACHE — re-leer estado al reabrir la app
+  // Fecha: 2026-08-02
+  // PROBLEMA: con el motor Flutter pre-calentado (ZyncApplication +
+  //   MainActivity.provideFlutterEngine), este widget sobrevive entre
+  //   reaperturas — initState() no vuelve a correr y _lastKnownStatusId
+  //   quedaba congelado en el valor leído la primera vez que montó.
+  //   Confirmado en dispositivo: el marcador de initState no aparece en
+  //   ninguna reapertura con proceso vivo, solo en cold start real.
+  // SOLUCIÓN: WidgetsBindingObserver — repetir la lectura en cada resumed.
+  // ════════════════════════════════════════════════════════════
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state == AppLifecycleState.resumed) {
+      _loadLastKnownStatusId();
+    }
   }
 
   /// Listener para detectar cuando se agregan nuevos emojis personalizados
@@ -235,6 +256,9 @@ class _InCircleViewState extends ConsumerState<InCircleView> {
   Future<void> _loadLastKnownStatusId() async {
     try {
       final prefs = await SharedPreferences.getInstance();
+      // DT-PREFS-STALE-CACHE: no depender del orden de listeners de
+      // WidgetsBindingObserver — recargar aquí mismo antes de leer.
+      await prefs.reload();
       final manualId = prefs.getString(NativeSharedKeys.manualStatusId);
       final currentId = prefs.getString(NativeSharedKeys.currentStatusId);
       final isSilent = prefs.getBool(NativeSharedKeys.isSilentModeActive) ?? false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -289,6 +289,24 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
       }
     } else if (state == AppLifecycleState.resumed) {
       // ════════════════════════════════════════════════════════════
+      // [FIX] DT-PREFS-STALE-CACHE — recargar SharedPreferences al reabrir
+      // Fecha: 2026-08-02
+      // PROBLEMA: ZyncApplication pre-calienta el motor Flutter en el
+      //   arranque del proceso y MainActivity lo reutiliza
+      //   (provideFlutterEngine) — el isolate Dart sobrevive entre
+      //   reaperturas y su caché de shared_preferences (poblado una sola
+      //   vez por proceso) no ve las escrituras que Kotlin hace directo al
+      //   XML mientras la Activity no existe: StatusUpdateWorker.kt (BN,
+      //   app cerrada con Modo Silencio activo) y MainActivity.onCreate
+      //   Regla 1 (justo antes de este evento resumed).
+      // SOLUCIÓN: recargar el singleton de SharedPreferences desde disco
+      //   en cada resumed — chokepoint donde ambos ya escribieron.
+      // ════════════════════════════════════════════════════════════
+      SharedPreferences.getInstance().then((p) => p.reload()).catchError((e) {
+        debugPrint('[App] ⚠️ Error recargando caché de SharedPreferences: $e');
+      });
+
+      // ════════════════════════════════════════════════════════════
       // [FIX v3] Forzar refresh del Auth ID token al resumir (retry indefinido)
       // Fecha: 2026-05-19
       // PROBLEMA: securetoken.googleapis.com bloqueado por más de 50s post-Doze.

--- a/lib/platform/persistence/kv_store.dart
+++ b/lib/platform/persistence/kv_store.dart
@@ -9,4 +9,9 @@ abstract class KvStore {
   Future<void> setInt(String key, int value);
   Future<void> remove(String key);
   Future<bool> containsKey(String key);
+
+  /// Recarga el store desde disco. Necesario cuando el proceso Kotlin
+  /// escribió directo al archivo nativo sin pasar por este store — ver
+  /// DT-PREFS-STALE-CACHE.
+  Future<void> reload();
 }

--- a/lib/platform/persistence/shared_prefs_kv_store.dart
+++ b/lib/platform/persistence/shared_prefs_kv_store.dart
@@ -37,4 +37,9 @@ class SharedPrefsKvStore implements KvStore {
 
   @override
   Future<bool> containsKey(String key) async => _prefs.containsKey(key);
+
+  @override
+  Future<void> reload() async {
+    await _prefs.reload();
+  }
 }


### PR DESCRIPTION
## Resumen

Cierra `[DT-PREFS-STALE-CACHE]` (hallazgo de PR #252, `docs/dev/DEUDA_TECNICA.md`).

El motor Flutter se pre-calienta en `ZyncApplication.onCreate()` y `MainActivity.provideFlutterEngine()` lo reutiliza — el isolate Dart sobrevive entre reaperturas de la app. Su caché en memoria de `shared_preferences` se puebla una sola vez por proceso y nunca ve las escrituras que Kotlin hace directo al XML mientras la Activity no existe: `StatusUpdateWorker.kt` (pick desde la notificación persistente de Modo Silencio) y `MainActivity.onCreate()` Regla 1 (borrado de flags al reabrir).

Agrega `reload()` antes de cada lectura cruzada Dart↔Kotlin, en los 5 call sites auditados:
- `main.dart` — reload del singleton compartido en `AppLifecycleState.resumed`.
- `in_circle_view.dart` — ahora observa el ciclo de vida (`WidgetsBindingObserver`) y repite `_loadLastKnownStatusId()` en cada `resumed`, con `reload()` propio (autosuficiente, no depende del orden de listeners).
- `silent_functionality_coordinator.dart` — `reload()` antes de leer `manualId` al (re)activar Modo Silencio.
- `shared_prefs_presence_repository.dart` — `reload()` vía nueva capacidad `KvStore.reload()`.

## Auditoría (5 call sites, 4 confirmados afectados)

| Call site | Veredicto |
|---|---|
| `silent_functionality_coordinator.dart` | Afectado — confirmado en device en la sesión de PR #252 |
| `in_circle_view.dart` | Afectado — `initState()` no re-ejecuta con el motor cacheado |
| `shared_prefs_presence_repository.dart` | Afectado — mismas claves, callers vivos: `EnterSilentMode`, `ExitSilentMode`, `RaiseSOS` |
| `status_service.dart` | Afectado — cubierto por el reload de `main.dart` (solo se ejecuta con la app ya en foreground) |
| `main.dart` (flag `suppress_next_geofence_check`) | **Fuera de alcance** — bug de ciclo de vida distinto (el flag no se consume porque `main()` no vuelve a correr), no de caché. Pendiente PR propio. |

## Test Plan

- [x] `flutter analyze` sobre los 6 archivos modificados — 0 errores (solo `avoid_print` preexistentes en `main.dart`, no introducidos por este cambio)
- [x] **Control positivo** — cold start real dispara el marcador de `initState` (4 hits) y consume `suppress_next_geofence_check`, confirmando que el marcador funciona
- [x] **Reproducción end-to-end en device** (`R58W315389R`, build de este PR instalado 2026-08-02 19:25):
  1. MS activo → pick "Reunión" desde BN → `StatusUpdateWorker` escribe `manual_status_id=pre_silent_status_id=meeting` directo al XML (Kotlin)
  2. Reabrir app con proceso vivo (PID idéntico antes/después) → Regla 1 borra `is_silent_mode_active`/`pre_silent_status_id`
  3. Reactivar MS sin elegir estado nuevo (el escenario exacto que expuso el bug) → log `[SilentCoordinator] 💾 pre_silent_status_id guardado: meeting` — valor fresco, no stale
  4. Reabrir modal BN nativo → `[ACTIVE-STATUS] activeStatusId=meeting (manual=meeting current=meeting preSilent=meeting)` — las 4 fuentes coinciden
  5. Verificación visual: borde verde en "Reunión", no en "Camino" (valor viejo)
  - Todo contrastado contra `adb shell run-as com.datainfers.zync cat shared_prefs/FlutterSharedPreferences.xml`, no solo observación visual

⚠️ Riesgo activo: ninguno — ambos lados (Dart y Kotlin) del contrato de claves ya estaban activos antes de este PR; este fix solo agrega `reload()` en el lado Dart. No requiere verificación adicional de flujos en transición.

🤖 Generated with [Claude Code](https://claude.com/claude-code)