### PR TITLE
fix: Creador label shown by list position, not real creatorId

### DIFF
--- a/lib/features/circle/presentation/widgets/in_circle_view.dart
+++ b/lib/features/circle/presentation/widgets/in_circle_view.dart
@@ -430,6 +430,7 @@ class _InCircleViewState extends ConsumerState<InCircleView> with WidgetsBinding
                     nicknamesCache: _memberNicknamesCache,
                     memberDataCache: _memberDataCache,
                     isLoading: _isLoadingNicknames,
+                    creatorId: circle.creatorId,
                     currentUserId: FirebaseAuth.instance.currentUser?.uid,
                     currentUserNickname: _getCurrentUserNickname(ref),
                     lastKnownStatusId: _lastKnownStatusId,

--- a/lib/features/circle/presentation/widgets/member_status_grid.dart
+++ b/lib/features/circle/presentation/widgets/member_status_grid.dart
@@ -11,6 +11,7 @@ class MemberStatusGrid extends StatelessWidget {
   final Map<String, String> nicknamesCache;
   final Map<String, Map<String, dynamic>> memberDataCache;
   final bool isLoading;
+  final String? creatorId;
   final String? currentUserId;
   final String? currentUserNickname;
   final String? lastKnownStatusId;
@@ -24,6 +25,7 @@ class MemberStatusGrid extends StatelessWidget {
     required this.nicknamesCache,
     required this.memberDataCache,
     required this.isLoading,
+    required this.creatorId,
     required this.currentUserId,
     required this.currentUserNickname,
     required this.lastKnownStatusId,
@@ -43,9 +45,7 @@ class MemberStatusGrid extends StatelessWidget {
           const Center(child: CircularProgressIndicator(color: NkColors.mint))
         else
           Column(
-            children: sortedMemberIds.asMap().entries.map((entry) {
-              final index = entry.key;
-              final memberId = entry.value;
+            children: sortedMemberIds.map((memberId) {
               final isCurrentUser = currentUserId == memberId;
               final nickname = isCurrentUser
                   ? (currentUserNickname ?? nicknamesCache[memberId] ?? '...')
@@ -67,7 +67,7 @@ class MemberStatusGrid extends StatelessWidget {
                   memberId: memberId,
                   nickname: nickname,
                   isCurrentUser: isCurrentUser,
-                  isFirst: index == 0,
+                  isCreator: memberId == creatorId,
                   memberData: memberData,
                   onTap: isCurrentUser
                       ? () {
@@ -96,7 +96,7 @@ class _MemberListItem extends StatelessWidget {
   final String memberId;
   final String nickname;
   final bool isCurrentUser;
-  final bool isFirst;
+  final bool isCreator;
   final Map<String, dynamic> memberData;
   final VoidCallback? onTap;
   final void Function(BuildContext context, Map<String, dynamic> coords, String memberName)
@@ -108,7 +108,7 @@ class _MemberListItem extends StatelessWidget {
     required this.memberId,
     required this.nickname,
     required this.isCurrentUser,
-    required this.isFirst,
+    required this.isCreator,
     required this.memberData,
     this.onTap,
     required this.onOpenMaps,
@@ -252,7 +252,7 @@ class _MemberListItem extends StatelessWidget {
                                   style: const TextStyle(
                                       fontSize: 11, color: NkColors.fgHint),
                                 ),
-                              if (isFirst && status != 'loading')
+                              if (isCreator && status != 'loading')
                                 Text(
                                   '• Creador',
                                   style: TextStyle(


### PR DESCRIPTION
## Summary
- \`member_status_grid.dart\`: the "• Creador" badge was shown when \`isFirst\` (index 0 in the sorted member list) was true — but \`_getSortedMembers()\` always puts the *current viewer* first, not the actual creator. Every member saw their own card labeled Creador regardless of role.
- Fix: \`MemberStatusGrid\` now receives \`creatorId\` and compares \`memberId == creatorId\` directly. \`in_circle_view.dart\` passes \`circle.creatorId\` through.

## Test plan
- [x] \`flutter analyze\` on both files — clean.
- [x] Device test (SM A145M): with 2 real members (TestCreator, TestJoiner), confirmed only the actual creator's card shows "• Creador" regardless of which account is the active viewer — before the fix, whoever was logged in saw their own card mislabeled.