### PR TITLE
fix: Firestore Rules blocked rejoining a circle after leaving it

### DIFF
--- a/firestore-rules-tests/rules.test.js
+++ b/firestore-rules-tests/rules.test.js
@@ -252,6 +252,31 @@ test('joinRequests: el propio solicitante NO puede aprobarse a si mismo', async 
   await assertFails(updateDoc(doc(mallory, 'circles/c1/joinRequests/mallory'), { status: 'approved' }));
 });
 
+test('joinRequests: un NO-miembro puede RE-solicitar tras salir del circulo (doc previo approved)', async () => {
+  // Reproduce el caso real: mallory ya fue miembro, salio, y su doc
+  // joinRequests de aquel ciclo quedo en 'approved' — el set() de una nueva
+  // solicitud es un update (el doc ya existe), no un create.
+  await seed(async (db) => {
+    await setDoc(doc(db, 'circles/c1'), { creatorId: 'alice', members: ['alice'] });
+    await setDoc(doc(db, 'circles/c1/joinRequests/mallory'), { status: 'approved' });
+  });
+  const mallory = testEnv.authenticatedContext('mallory').firestore();
+  await assertSucceeds(
+    setDoc(doc(mallory, 'circles/c1/joinRequests/mallory'), { status: 'pending' })
+  );
+});
+
+test('joinRequests: NO puede re-solicitar poniendose approved directamente (bypass de aprobacion)', async () => {
+  await seed(async (db) => {
+    await setDoc(doc(db, 'circles/c1'), { creatorId: 'alice', members: ['alice'] });
+    await setDoc(doc(db, 'circles/c1/joinRequests/mallory'), { status: 'approved' });
+  });
+  const mallory = testEnv.authenticatedContext('mallory').firestore();
+  await assertFails(
+    setDoc(doc(mallory, 'circles/c1/joinRequests/mallory'), { status: 'approved' })
+  );
+});
+
 // ─── subcolecciones (zones, customEmojis, statusEvents, members) ───────
 
 for (const sub of ['zones', 'zone_events', 'customEmojis', 'members', 'statusEvents']) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -45,7 +45,15 @@ service cloud.firestore {
     }
 
     match /circles/{circleId}/joinRequests/{requestUserId} {
-      allow create: if request.auth != null && request.auth.uid == requestUserId;
+      // create + update (no solo create): un usuario que salió del círculo y
+      // vuelve a solicitar ingreso reusa el mismo doc (circle_service.dart
+      // requestToJoinCircle "set sobreescribe") — para Firestore Rules ese
+      // set() es un update si el doc ya existe de un ciclo anterior, no un
+      // create. Se exige status == 'pending' para que el propio solicitante
+      // nunca pueda auto-aprobarse; la aprobación real (status: 'approved')
+      // sigue restringida a miembros en la regla de abajo.
+      allow create, update: if request.auth != null && request.auth.uid == requestUserId &&
+        request.resource.data.status == 'pending';
       allow read: if request.auth != null && (
         request.auth.uid == requestUserId ||
         request.auth.uid in get(/databases/$(database)/documents/circles/$(circleId)).data.members

--- a/firestore.rules.proposed
+++ b/firestore.rules.proposed
@@ -49,7 +49,15 @@ service cloud.firestore {
     }
 
     match /circles/{circleId}/joinRequests/{requestUserId} {
-      allow create: if request.auth != null && request.auth.uid == requestUserId;
+      // create + update (no solo create): un usuario que salió del círculo y
+      // vuelve a solicitar ingreso reusa el mismo doc (circle_service.dart
+      // requestToJoinCircle "set sobreescribe") — para Firestore Rules ese
+      // set() es un update si el doc ya existe de un ciclo anterior, no un
+      // create. Se exige status == 'pending' para que el propio solicitante
+      // nunca pueda auto-aprobarse; la aprobación real (status: 'approved')
+      // sigue restringida a miembros en la regla de abajo.
+      allow create, update: if request.auth != null && request.auth.uid == requestUserId &&
+        request.resource.data.status == 'pending';
       allow read: if request.auth != null && (
         request.auth.uid == requestUserId ||
         request.auth.uid in get(/databases/$(database)/documents/circles/$(circleId)).data.members


### PR DESCRIPTION
## Summary
- \`circle_service.dart requestToJoinCircle()\` reuses the same \`joinRequests/{uid}\` doc across join cycles (comment: "set sobreescribe"). For a doc that already exists from a prior approved+left cycle, that \`set()\` is a Firestore Rules **update**, not a **create**.
- \`firestore.rules\` only granted \`create\` to the requester on that path — \`update\` was restricted to circle members. Any user who left a circle and tried to rejoin the same one got \`permission-denied\`.
- Fix: the requester can now also \`update\` their own doc, but only when the new value keeps \`status == 'pending'\` — real approval (\`status: approved\`) stays restricted to members, so a requester can never self-approve.
- \`firestore.rules.proposed\` (the file the emulator test suite actually reads, separate from the deployed \`firestore.rules\` — pre-existing drift from the earlier DT-RULES-CIRCLES-OPEN work) updated in parallel so tests reflect what's deployed.

## Test plan
- [x] 2 new rules-emulator tests added: rejoin-after-leaving succeeds; self-approve-via-rejoin still fails.
- [x] Full suite: 38/38 passing against Firebase Emulator.
- [x] Deployed to production (\`zync-app-a2712\`) — done ahead of this PR with explicit developer sign-off, since it was blocking live device testing (Grupo B, Sem 9 batch).
- [x] Device test (SM A145M): TestJoiner left TestSOS, then successfully re-requested and was re-approved by TestCreator — confirmed via direct Firestore read (\`members\` array updated correctly).