### PR TITLE
fix: stale approved joinRequest could silently restore a departed member's circleId

### DIFF
--- a/lib/services/circle_service.dart
+++ b/lib/services/circle_service.dart
@@ -321,6 +321,14 @@ class CircleService {
       final status = snapshot.data()?['status'] as String?;
 
       if (status == 'approved') {
+        // Guard contra reproceso: leaveCircle() no resetea este doc
+        // joinRequests, que queda en 'approved' para siempre. Sin este check,
+        // cualquier re-disparo del listener (p. ej. una escritura optimista
+        // local revertida por el servidor) reescribe circleId aunque el
+        // usuario ya haya salido del círculo. pendingCircleId solo está
+        // presente mientras la aprobación no fue procesada todavía.
+        final userDoc = await _firestore.collection('users').doc(user.uid).get();
+        if (userDoc.data()?['pendingCircleId'] != circleId) return;
         await _firestore.collection('users').doc(user.uid).update({
           'circleId': circleId,
           'pendingCircleId': FieldValue.delete(),

--- a/scripts/read_circle_status.js
+++ b/scripts/read_circle_status.js
@@ -1,0 +1,37 @@
+// Script temporal — Grupos B y C (device-test Sem 9)
+// Lee un círculo completo (creatorId, members, memberStatus) para verificar
+// resultados de tests de SOS y de salida/sucesión de círculo.
+// Solo lectura. No es parte del código fuente de la app — uso único, borrar al cerrar el batch.
+//
+// Uso: node scripts/read_circle_status.js <circleId>
+
+const admin = require('firebase-admin');
+const serviceAccount = require('./serviceAccountKey.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  projectId: 'zync-app-a2712',
+});
+
+const [, , circleId] = process.argv;
+
+if (!circleId) {
+  console.error('Uso: node scripts/read_circle_status.js <circleId>');
+  process.exit(1);
+}
+
+(async () => {
+  const doc = await admin.firestore().collection('circles').doc(circleId).get();
+  if (!doc.exists) {
+    console.error(`Círculo ${circleId} no existe.`);
+    process.exit(1);
+  }
+  const data = doc.data();
+  console.log('creatorId:', data.creatorId);
+  console.log('members:', JSON.stringify(data.members));
+  console.log('memberStatus:', JSON.stringify(data.memberStatus, null, 2));
+  process.exit(0);
+})().catch((e) => {
+  console.error('ERROR:', e);
+  process.exit(1);
+});

--- a/scripts/reset_test_user_circle.js
+++ b/scripts/reset_test_user_circle.js
@@ -1,0 +1,37 @@
+// Script temporal — Grupo B (device-test Sem 9)
+// Limpia circleId/pendingCircleId de UNA cuenta de prueba puntual, sin tocar
+// el circulo (a diferencia de create_test_accounts.js, que borra el circulo
+// completo si el uid es su creatorId). Uso solo para corregir estado de test
+// quedado inconsistente por reintentos de escritura en cola durante debugging.
+// No es parte del codigo fuente de la app — uso unico, borrar al cerrar el grupo.
+//
+// Uso: node scripts/reset_test_user_circle.js <uid>
+
+const admin = require('firebase-admin');
+const serviceAccount = require('./serviceAccountKey.json');
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+  projectId: 'zync-app-a2712',
+});
+
+const [, , uid] = process.argv;
+
+if (!uid) {
+  console.error('Uso: node scripts/reset_test_user_circle.js <uid>');
+  process.exit(1);
+}
+
+(async () => {
+  const userRef = admin.firestore().collection('users').doc(uid);
+  await userRef.update({
+    circleId: admin.firestore.FieldValue.delete(),
+    pendingCircleId: admin.firestore.FieldValue.delete(),
+  });
+  const updated = await userRef.get();
+  console.log(`users/${uid} tras reset:`, JSON.stringify(updated.data()));
+  process.exit(0);
+})().catch((e) => {
+  console.error('ERROR:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- \`listenToOwnJoinRequest()\` writes \`circleId\` to the user's own doc whenever it observes \`status == 'approved'\` on their \`joinRequests/{uid}\` doc.
- \`leaveCircle()\` clears \`circleId\` on leaving, but never touches the \`joinRequests\` doc — it stays \`status: 'approved'\` forever from the original join.
- Any later re-fire of this listener against that unchanged doc (e.g. a local optimistic write from a blocked rejoin attempt that the server then rejects and rolls back) makes it re-apply \`circleId\`, silently putting a departed user back "in" a circle they aren't a member of.
- Fix: guard the write with \`pendingCircleId == circleId\` — only present while an approval is genuinely in flight (\`requestToJoinCircle\` sets it, both the approved/rejected branches already clear it). A stale replay finds it cleared and no-ops.

## Also included
- \`scripts/read_circle_status.js\`, \`scripts/reset_test_user_circle.js\` — read-only/surgical admin-SDK helpers used to diagnose this and correct test-account state, same throwaway pattern as \`scripts/toggle_email_verified.js\`.

## Test plan
- [x] \`flutter analyze lib/services/circle_service.dart\` — clean.
- [x] Device test (SM A145M): confirmed via direct Firestore reads (not client cache) that \`users/{uid}.circleId\` was restored for an account that had already left a circle, before this fix. After the fix, rebuilt+reinstalled, repeated the leave → rejoin → approve → creator-leaves(succession) cycle for Grupo B (Sem 9 batch) cleanly, with no stale circleId reappearing at any step.
- [ ] Not separately unit-tested (no existing test harness mocks \`FirebaseAuth\`/\`Firestore\` streams for \`CircleService\`) — verified via the device reproduction above only.